### PR TITLE
Adding full versioning support to representations in the generator.

### DIFF
--- a/resources/examples/Showtimes/Representations/Theater.php
+++ b/resources/examples/Showtimes/Representations/Theater.php
@@ -40,6 +40,14 @@ class Theater extends Representation
             'phone_number' => $this->theater->phone_number,
 
             /**
+             * @api-label Website
+             * @api-field website
+             * @api-type string
+             * @api-version <1.1
+             */
+            'website' => $this->theater->website,
+
+            /**
              * @api-label Movies currently playing
              * @api-field movies
              * @api-type array

--- a/resources/examples/Showtimes/blueprints/1.0/Theaters.apib
+++ b/resources/examples/Showtimes/blueprints/1.0/Theaters.apib
@@ -16,6 +16,7 @@ This action requires a bearer token with `public` scope.
         - `name` (string) - Name
         - `phone_number` (string) - Phone number
         - `showtimes` (array) - Non-movie specific showtimes
+        - `website` (string) - Website
 + Response 404 (application/json)
 
 ### Update a movie theater [PATCH]
@@ -36,6 +37,7 @@ This action requires a bearer token with `create` scope.
         - `name` (string) - Name
         - `phone_number` (string) - Phone number
         - `showtimes` (array) - Non-movie specific showtimes
+        - `website` (string) - Website
 + Response 400 (application/json)
 + Response 404 (application/json)
 
@@ -63,6 +65,7 @@ This action requires a bearer token with `public` scope.
         - `name` (string) - Name
         - `phone_number` (string) - Phone number
         - `showtimes` (array) - Non-movie specific showtimes
+        - `website` (string) - Website
 + Response 400 (application/json)
 
 ### Create a movie theater. [POST]
@@ -81,4 +84,5 @@ This action requires a bearer token with `create` scope.
         - `name` (string) - Name
         - `phone_number` (string) - Phone number
         - `showtimes` (array) - Non-movie specific showtimes
+        - `website` (string) - Website
 + Response 400 (application/json)

--- a/src/Generator/Blueprint.php
+++ b/src/Generator/Blueprint.php
@@ -301,10 +301,10 @@ class Blueprint extends Generator
         /** @var ReturnAnnotation|ThrowsAnnotation $response */
         $response = array_shift($responses);
         $representation = $response->getRepresentation();
-        $representations = $this->getRepresentations();
+        $representations = $this->getRepresentations($this->version);
 
-        // There's rare, and highly discouraged, instances where you might be using a representation that hasn't been
-        // configured, and is devoid of any documentation; like "string".
+        // There's rare, and highly discouraged, instances where you might be using a representation that is being
+        // ignored, and is devoid of any documentation; like `@api-return:public {200} string`
         if (!isset($representations[$representation])) {
             return $blueprint;
         }

--- a/src/Parser/Representation/Documentation.php
+++ b/src/Parser/Representation/Documentation.php
@@ -101,6 +101,29 @@ class Documentation
     }
 
     /**
+     * Filter down, and return, all annotations on this representation to a specific version.
+     *
+     * @param string $version
+     * @return array
+     */
+    public function filterRepresentationForVersion($version)
+    {
+        /** @var Parser\Annotation $annotation */
+        foreach ($this->representation as $name => $annotation) {
+            // If this annotation has a set version, but that version doesn't match what we're looking for, filter it
+            // out.
+            $annotation_version = $annotation->getVersion();
+            if ($annotation_version) {
+                if (!$annotation_version->matches($version)) {
+                    unset($this->representation[$name]);
+                }
+            }
+        }
+
+        return $this->representation;
+    }
+
+    /**
      * Get the representation class that we're parsing.
      *
      * @return string

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -90,6 +90,9 @@ class GeneratorTest extends TestCase
          * Verify representations
          */
         $representations = $generator->getRepresentations();
+        $this->assertArrayHasKey($version, $representations);
+
+        $representations = $representations[$version];
         $this->assertCount(count($expected_representations), $representations);
 
         foreach ($expected_representations as $name => $data) {
@@ -133,7 +136,7 @@ class GeneratorTest extends TestCase
                     '\Mill\Examples\Showtimes\Representations\Theater' => [
                         'label' => 'Theater',
                         'description.length' => 0,
-                        'content.size' => 6
+                        'content.size' => 7
                     ]
                 ],
                 'expected.resources' => [


### PR DESCRIPTION
This adds full versioning support to representations in the generator system.

Previously, it would compile them properly, but when generating documentation for a specific version of your API, representations in that action weren't being versioned.

#22