### PR TITLE
Merge the exclude and ignore config system

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -43,7 +43,7 @@
                                 <xs:attribute name="name" type="xs:string" use="required" />
                             </xs:complexType>
                         </xs:element>
-                        <xs:element name="exclude" type="common.excludes" minOccurs="0" maxOccurs="unbounded" />
+                        <xs:element name="excludes" type="common.excludes" minOccurs="0" maxOccurs="unbounded" />
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -69,18 +69,7 @@
                                 <xs:attribute name="noMethod" type="xs:boolean" use="optional" />
                             </xs:complexType>
                         </xs:element>
-                        <xs:element name="exclude" type="common.excludes" minOccurs="0" maxOccurs="unbounded" />
-                        <xs:element name="ignores" minOccurs="0" maxOccurs="unbounded">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="ignore" minOccurs="1" maxOccurs="unbounded">
-                                        <xs:complexType>
-                                            <xs:attribute name="name" type="xs:string" use="required" />
-                                        </xs:complexType>
-                                    </xs:element>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
+                        <xs:element name="excludes" type="common.excludes" minOccurs="0" maxOccurs="unbounded" />
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -153,7 +142,7 @@
 
     <xs:complexType name="common.excludes">
         <xs:sequence>
-            <xs:element name="class" minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="exclude" minOccurs="1" maxOccurs="unbounded">
                 <xs:complexType>
                     <xs:attribute name="name" type="xs:string" use="required" />
                 </xs:complexType>

--- a/resources/examples/mill.xml
+++ b/resources/examples/mill.xml
@@ -19,13 +19,10 @@
             <class name="\Mill\Examples\Showtimes\Representations\Representation" noMethod="true" />
 
             <exclude>
-                <class name="\Mill\Examples\Showtimes\Representations\Error" />
-                <class name="\Mill\Examples\Showtimes\Representations\CodedError" />
+                <exclude name="\Mill\Examples\Showtimes\Representations\Error" />
+                <exclude name="\Mill\Examples\Showtimes\Representations\CodedError" />
+                <exclude name="string" />
             </exclude>
-
-            <ignores>
-                <ignore name="string" />
-            </ignores>
         </filter>
 
         <errors>

--- a/src/Config.php
+++ b/src/Config.php
@@ -324,12 +324,12 @@ class Config
         $controllers = $controllers->filter;
 
         $excludes = [];
-        if (isset($controllers->excludes) && isset($controllers->excludes->exclude)) {
+        if (isset($controllers->excludes)) {
             /** @var SimpleXMLElement $exclude_config */
             $exclude_config = $controllers->excludes;
 
-            /** @var SimpleXMLElement $class */
-            foreach ($exclude_config->name as $exclude) {
+            /** @var SimpleXMLElement $exclude */
+            foreach ($exclude_config->exclude as $exclude) {
                 $excludes[] = (string) $exclude['name'];
             }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -82,13 +82,13 @@ class Config
     protected $error_representations = [];
 
     /**
-     * Array of ignored application representations.
+     * Array of excluded application representations.
      *
      * These are representations that you have, but, for whatever reason, don't want to be parsed for documentation.
      *
      * @var array
      */
-    protected $ignored_representations = [];
+    protected $excluded_representations = [];
 
     /**
      * Array of URI segment translations. (Like translating `+clip_id` to `+video_id`.)
@@ -194,10 +194,9 @@ class Config
 
         $config->representations = [];
         $config->error_representations = [];
-        $config->ignored_representations = [];
+        $config->excluded_representations = [];
         $config->loadRepresentations($xml->representations);
         $config->loadErrorRepresentations($xml->representations);
-        $config->loadIgnoredRepresentations($xml->representations);
 
         return $config;
     }
@@ -325,13 +324,13 @@ class Config
         $controllers = $controllers->filter;
 
         $excludes = [];
-        if (isset($controllers->exclude) && isset($controllers->exclude->class)) {
+        if (isset($controllers->excludes) && isset($controllers->excludes->exclude)) {
             /** @var SimpleXMLElement $exclude_config */
-            $exclude_config = $controllers->exclude;
+            $exclude_config = $controllers->excludes;
 
             /** @var SimpleXMLElement $class */
-            foreach ($exclude_config->class as $class) {
-                $excludes[] = (string) $class['name'];
+            foreach ($exclude_config->name as $exclude) {
+                $excludes[] = (string) $exclude['name'];
             }
 
             // Keep things tidy.
@@ -403,28 +402,21 @@ class Config
      */
     protected function loadRepresentations(SimpleXMLElement $representations)
     {
-        $excludes = [];
-
         /** @var SimpleXMLElement $filters */
         $filters = $representations->filter;
 
         // Process excludes.
-        if (isset($filters->exclude) && isset($filters->exclude->class)) {
+        if (isset($filters->excludes)) {
             /** @var SimpleXMLElement $exclude_config */
-            $exclude_config = $filters->exclude;
+            $exclude_config = $filters->excludes;
 
-            /** @var SimpleXMLElement $class */
-            foreach ($exclude_config->class as $class) {
-                $class = (string) $class['name'];
-                if (!class_exists($class)) {
-                    throw UncallableRepresentationException::create($class);
-                }
-
-                $excludes[] = $class;
+            /** @var SimpleXMLElement $exclude */
+            foreach ($exclude_config->exclude as $exclude) {
+                $this->excluded_representations[] = (string) $exclude['name'];
             }
 
             // Keep things tidy.
-            $excludes = array_unique($excludes);
+            $this->excluded_representations = array_unique($this->excluded_representations);
         }
 
         /**
@@ -462,7 +454,7 @@ class Config
             $suffix = (string) $directory['suffix'] ?: '.php';
             $method = (string) $directory['method'] ?: null;
 
-            $classes = $this->scanDirectoryForClasses($directory_name, $suffix, $excludes);
+            $classes = $this->scanDirectoryForClasses($directory_name, $suffix, $this->excluded_representations);
             /** @var string $class */
             foreach ($classes as $class) {
                 // Class declarations should always take priority over directories.
@@ -534,37 +526,14 @@ class Config
     }
 
     /**
-     * Load in an ignored representations configuration definition.
-     *
-     * @param SimpleXMLElement $representations
-     * @return void
-     */
-    protected function loadIgnoredRepresentations(SimpleXMLElement $representations)
-    {
-        /** @var SimpleXMLElement $filters */
-        $filters = $representations->filter;
-
-        /** @var SimpleXMLElement $ignore_config */
-        $ignore_config = $filters->ignores;
-        if (!empty($ignore_config)) {
-            foreach ($ignore_config->ignore as $ignore) {
-                $this->ignored_representations[] = (string)$ignore['name'];
-            }
-
-            // Keep things tidy.
-            $this->ignored_representations = array_unique($this->ignored_representations);
-        }
-    }
-
-    /**
-     * Check if a given representation has been configured to be ignored.
+     * Check if a given representation has been configured to be excluded.
      *
      * @param string $class
      * @return bool
      */
-    public function isRepresentationIgnored($class)
+    public function isRepresentationExcluded($class)
     {
-        return in_array($class, $this->getIgnoredRepresentations());
+        return in_array($class, $this->getExcludedRepresentations());
     }
 
     /**
@@ -668,13 +637,13 @@ class Config
     }
 
     /**
-     * Get the array of configured ignored application representations.
+     * Get the array of configured excluded application representations.
      *
      * @return array
      */
-    public function getIgnoredRepresentations()
+    public function getExcludedRepresentations()
     {
-        return $this->ignored_representations;
+        return $this->excluded_representations;
     }
 
     /**
@@ -706,20 +675,20 @@ class Config
     }
 
     /**
-     * Check if a specific representation exists. If the representation has been configured as being ignored, then act
+     * Check if a specific representation exists. If the representation has been configured as being excluded, then act
      * as if it doesn't exist (but don't throw an exception).
      *
      * @param string $class
      * @return bool
-     * @throws UnconfiguredRepresentationException If the representation hasn't been configured, or ignored.
+     * @throws UnconfiguredRepresentationException If the representation hasn't been configured, or excluded.
      */
     public function doesRepresentationExist($class)
     {
         $representations = $this->getRepresentations();
-        $ignored = $this->getIgnoredRepresentations();
+        $excluded = $this->getExcludedRepresentations();
 
-        // If the representation is ignored, just act like it doesn't exist.
-        if (in_array($class, $ignored)) {
+        // If the representation is excluded, just act like it doesn't exist.
+        if (in_array($class, $excluded)) {
             return false;
         }
 

--- a/src/Exceptions/Config/UnconfiguredRepresentationException.php
+++ b/src/Exceptions/Config/UnconfiguredRepresentationException.php
@@ -15,7 +15,7 @@ class UnconfiguredRepresentationException extends \Exception
     public static function create($representation)
     {
         $message = sprintf(
-            'The `%s` representation is being used, but has not been configured for use (or ignored).',
+            'The `%s` representation is being used, but has not been configured for use (or excluded).',
             $representation
         );
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -185,8 +185,8 @@ class Generator
         foreach ($this->config->getRepresentations() as $representation) {
             $class = $representation['class'];
 
-            // If the representation is being ignored, then don't set it up for compilation.
-            if ($this->config->isRepresentationIgnored($class)) {
+            // If the representation is being excluded, then don't set it up for compilation.
+            if ($this->config->isRepresentationExcluded($class)) {
                 continue;
             }
 

--- a/src/Generator/Blueprint.php
+++ b/src/Generator/Blueprint.php
@@ -304,7 +304,7 @@ class Blueprint extends Generator
         $representations = $this->getRepresentations($this->version);
 
         // There's rare, and highly discouraged, instances where you might be using a representation that is being
-        // ignored, and is devoid of any documentation; like `@api-return:public {200} string`
+        // excluded, and is devoid of any documentation; like `@api-return:public {200} string`
         if (!isset($representations[$representation])) {
             return $blueprint;
         }

--- a/src/Parser/Annotations/ReturnAnnotation.php
+++ b/src/Parser/Annotations/ReturnAnnotation.php
@@ -74,7 +74,7 @@ class ReturnAnnotation extends Annotation
         $representation = array_shift($parts);
         $description = trim(implode(' ', $parts));
 
-        // Verify that the supplied representation class exists. If it's being ignored, we can just go ahead and set it
+        // Verify that the supplied representation class exists. If it's being excluded, we can just go ahead and set it
         // here anyways, as we'll be looking further up the stack to determine if we should actually parse it for
         // documentation.
         //

--- a/src/Parser/Annotations/ThrowsAnnotation.php
+++ b/src/Parser/Annotations/ThrowsAnnotation.php
@@ -97,7 +97,7 @@ class ThrowsAnnotation extends Annotation
         if (!empty($parsed['representation'])) {
             $representation = $parsed['representation'];
 
-            // Verify that the supplied representation class exists. If it's being ignored, we can just go ahead and
+            // Verify that the supplied representation class exists. If it's being excluded, we can just go ahead and
             // set it here anyways, as we'll be looking further up the stack to determine if we should actually parse it
             // for documentation.
             //

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -60,8 +60,10 @@ class ConfigTest extends TestCase
         ], $config->getErrorRepresentations());
 
         $this->assertSame([
+            '\Mill\Examples\Showtimes\Representations\Error',
+            '\Mill\Examples\Showtimes\Representations\CodedError',
             'string'
-        ], $config->getIgnoredRepresentations());
+        ], $config->getExcludedRepresentations());
 
         $this->assertEmpty($config->getUriSegmentTranslations());
     }
@@ -237,23 +239,6 @@ XML
 <representations>
     <filter>
         <directory name="resources/examples/Showtimes/Representations" suffix=".phps" method="create" />
-    </filter>
-</representations>
-XML
-            ],
-
-            'representations.exclude.uncallable' => [
-                'includes' => ['controllers'],
-                'exception' => [
-                    'exception' => '\Mill\Exceptions\Config\UncallableRepresentationException'
-                ],
-                'xml' => <<<XML
-<representations>
-    <filter>
-        <class name="\Mill\Examples\Showtimes\Representations\Movie" method="create" />
-        <exclude>
-            <class name="\UncallableClass" />
-        </exclude>
     </filter>
 </representations>
 XML

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -18,14 +18,11 @@
 
             <class name="\Mill\Examples\Showtimes\Representations\Representation" noMethod="true" />
 
-            <exclude>
-                <class name="\Mill\Examples\Showtimes\Representations\Error" />
-                <class name="\Mill\Examples\Showtimes\Representations\CodedError" />
-            </exclude>
-
-            <ignores>
-                <ignore name="string" />
-            </ignores>
+            <excludes>
+                <exclude name="\Mill\Examples\Showtimes\Representations\Error" />
+                <exclude name="\Mill\Examples\Showtimes\Representations\CodedError" />
+                <exclude name="string" />
+            </excludes>
         </filter>
 
         <errors>


### PR DESCRIPTION
This merges the `<exclude>` and `<ignores>` config systems into a single `<excludes>` declaration.

It was really confusing and completely pointless to have them split up like they were.

Fixes https://github.com/vimeo/mill/issues/9