### PR TITLE
Make `@api-return` representations an optional argument

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -65,8 +65,7 @@
                         <xs:element name="class" minOccurs="0" maxOccurs="unbounded">
                             <xs:complexType>
                                 <xs:attribute name="name" type="xs:string" use="required" />
-                                <xs:attribute name="method" type="xs:string" use="optional" />
-                                <xs:attribute name="noMethod" type="xs:boolean" use="optional" />
+                                <xs:attribute name="method" type="xs:string" use="required" />
                             </xs:complexType>
                         </xs:element>
                         <xs:element name="excludes" type="common.excludes" minOccurs="0" maxOccurs="unbounded" />

--- a/resources/examples/Showtimes/Controllers/Movie.php
+++ b/resources/examples/Showtimes/Controllers/Movie.php
@@ -70,7 +70,7 @@ class Movie
      * @api-contentType application/json
      * @api-scope delete
      *
-     * @api-return:private {deleted} \Mill\Examples\Showtimes\Representations\Representation
+     * @api-return:private {deleted}
      *
      * @api-throws:private {404} \Mill\Examples\Showtimes\Representations\Error If the movie could not be found.
      */

--- a/resources/examples/Showtimes/Controllers/Theater.php
+++ b/resources/examples/Showtimes/Controllers/Theater.php
@@ -65,7 +65,7 @@ class Theater
      * @api-contentType application/json
      * @api-scope delete
      *
-     * @api-return:private {deleted} \Mill\Examples\Showtimes\Representations\Representation
+     * @api-return:private {deleted}
      *
      * @api-throws:private {404} \Mill\Examples\Showtimes\Representations\Error If the movie theater could not be
      *      found.

--- a/resources/examples/mill.xml
+++ b/resources/examples/mill.xml
@@ -20,7 +20,6 @@
                 <exclude name="\Mill\Examples\Showtimes\Representations\Error" />
                 <exclude name="\Mill\Examples\Showtimes\Representations\CodedError" />
                 <exclude name="\Mill\Examples\Showtimes\Representations\Representation" />
-                <exclude name="string" />
             </exclude>
         </filter>
 

--- a/resources/examples/mill.xml
+++ b/resources/examples/mill.xml
@@ -16,11 +16,10 @@
         <filter>
             <directory name="Showtimes/Representations/" method="create" suffix=".php"  />
 
-            <class name="\Mill\Examples\Showtimes\Representations\Representation" noMethod="true" />
-
             <exclude>
                 <exclude name="\Mill\Examples\Showtimes\Representations\Error" />
                 <exclude name="\Mill\Examples\Showtimes\Representations\CodedError" />
+                <exclude name="\Mill\Examples\Showtimes\Representations\Representation" />
                 <exclude name="string" />
             </exclude>
         </filter>

--- a/src/Config.php
+++ b/src/Config.php
@@ -363,6 +363,7 @@ class Config
 
         // Keep things tidy.
         $this->controllers = array_unique($this->controllers);
+        sort($this->controllers);
 
         if (empty($this->controllers)) {
             throw new InvalidArgumentException('Mill requires a set of controllers to parse for documentation.');
@@ -464,6 +465,9 @@ class Config
                 $this->addRepresentation($class, $method);
             }
         }
+
+        // Keep things tidy
+        ksort($this->representations);
 
         if (empty($this->representations)) {
             throw new InvalidArgumentException('Mill requires a set of representations to parse for documentation.');

--- a/src/Config.php
+++ b/src/Config.php
@@ -396,7 +396,7 @@ class Config
      * @param SimpleXMLElement $representations
      * @return void
      * @throws UncallableRepresentationException If a configured representation does not exist.
-     * @throws InvalidArgumentException If a representation is configured without a `method` or `noMethod` attribute.
+     * @throws InvalidArgumentException If a representation is configured without a `method` attribute.
      * @throws InvalidArgumentException If a directory configured does not exist.
      * @throws InvalidArgumentException If no representations were detected.
      */
@@ -426,9 +426,8 @@ class Config
          */
         foreach ($filters->class as $class) {
             $class_name = (string) $class['name'];
-            $no_method = isset($class['noMethod']) ? true : false;
             $method = (string) $class['method'] ?: null;
-            if (empty($method) && !$no_method) {
+            if (empty($method)) {
                 throw new InvalidArgumentException(
                     sprintf(
                         'The `%s` representation class declaration is missing a `method` attribute.',
@@ -437,7 +436,7 @@ class Config
                 );
             }
 
-            $this->addRepresentation($class_name, $method, $no_method);
+            $this->addRepresentation($class_name, $method);
         }
 
         /**
@@ -476,25 +475,19 @@ class Config
      *
      * @param string $class
      * @param string|null $method
-     * @param bool $no_method
      * @return void
      * @throws UncallableRepresentationException If the representation is uncallable.
      */
-    public function addRepresentation($class, $method = null, $no_method = false)
+    public function addRepresentation($class, $method = null)
     {
         if (!class_exists($class)) {
             throw UncallableRepresentationException::create($class);
         }
 
         $this->representations[$class] = [
-            'class' => $class
+            'class' => $class,
+            'method' => $method
         ];
-
-        if ($no_method) {
-            $this->representations[$class]['no_method'] = true;
-        } else {
-            $this->representations[$class]['method'] = $method;
-        }
     }
 
     /**

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -190,22 +190,12 @@ class Generator
                 continue;
             }
 
-            $docs = null;
-            if (!isset($representation['no_method'])) {
-                $docs = (new Representation\Documentation($class, $representation['method']))->parse();
-            }
+            $docs = (new Representation\Documentation($class, $representation['method']))->parse();
 
             foreach ($this->supported_versions as $version) {
                 // If we're generating documentation for a specific version range, and this doesn't fall in
                 // that, then skip it.
                 if ($this->version && !$this->version->matches($version)) {
-                    continue;
-                }
-
-                // If this method has been configured as having no method, then it doesn't have any annotations to
-                // parse.
-                if (isset($representation['no_method'])) {
-                    $representations[$version][$class] = $docs;
                     continue;
                 }
 

--- a/src/Generator/Blueprint.php
+++ b/src/Generator/Blueprint.php
@@ -303,8 +303,6 @@ class Blueprint extends Generator
         $representation = $response->getRepresentation();
         $representations = $this->getRepresentations($this->version);
 
-        // There's rare, and highly discouraged, instances where you might be using a representation that is being
-        // excluded, and is devoid of any documentation; like `@api-return:public {200} string`
         if (!isset($representations[$representation])) {
             return $blueprint;
         }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -34,10 +34,6 @@ class ConfigTest extends TestCase
         ], $config->getControllers());
 
         $this->assertSame([
-            '\Mill\Examples\Showtimes\Representations\Representation' => [
-                'class' => '\Mill\Examples\Showtimes\Representations\Representation',
-                'no_method' => true
-            ],
             '\Mill\Examples\Showtimes\Representations\Movie' => [
                 'class' => '\Mill\Examples\Showtimes\Representations\Movie',
                 'method' => 'create'
@@ -62,6 +58,7 @@ class ConfigTest extends TestCase
         $this->assertSame([
             '\Mill\Examples\Showtimes\Representations\Error',
             '\Mill\Examples\Showtimes\Representations\CodedError',
+            '\Mill\Examples\Showtimes\Representations\Representation',
             'string'
         ], $config->getExcludedRepresentations());
 
@@ -252,7 +249,7 @@ XML
                 'xml' => <<<XML
 <representations>
     <filter>
-        <class name="\Mill\Tests\Stubs\Representations\RepresentationStub" />
+        <class name="\Mill\Tests\Stubs\Representations\RepresentationStub" method="" />
     </filter>
 </representations>
 XML

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -58,8 +58,7 @@ class ConfigTest extends TestCase
         $this->assertSame([
             '\Mill\Examples\Showtimes\Representations\Error',
             '\Mill\Examples\Showtimes\Representations\CodedError',
-            '\Mill\Examples\Showtimes\Representations\Representation',
-            'string'
+            '\Mill\Examples\Showtimes\Representations\Representation'
         ], $config->getExcludedRepresentations());
 
         $this->assertEmpty($config->getUriSegmentTranslations());

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -123,11 +123,6 @@ class GeneratorTest extends TestCase
             'version-1.0' => [
                 'version' => '1.0',
                 'expected.representations' => [
-                    '\Mill\Examples\Showtimes\Representations\Representation' => [
-                        'label' => 'Representation',
-                        'description.length' => 0,
-                        'content.size' => 0
-                    ],
                     '\Mill\Examples\Showtimes\Representations\Movie' => [
                         'label' => 'Movie',
                         'description.length' => 12,
@@ -259,11 +254,6 @@ class GeneratorTest extends TestCase
             'version-1.1' => [
                 'version' => '1.1',
                 'expected.representations' => [
-                    '\Mill\Examples\Showtimes\Representations\Representation' => [
-                        'label' => 'Representation',
-                        'description.length' => 0,
-                        'content.size' => 0
-                    ],
                     '\Mill\Examples\Showtimes\Representations\Movie' => [
                         'label' => 'Movie',
                         'description.length' => 12,

--- a/tests/Parser/Annotations/ReturnAnnotationTest.php
+++ b/tests/Parser/Annotations/ReturnAnnotationTest.php
@@ -36,11 +36,47 @@ class ReturnAnnotationTest extends AnnotationTest
     public function annotationProvider()
     {
         return [
+            'with-no-representation' => [
+                'param' => '{deleted}',
+                'version' => null,
+                'expected' => [
+                    'description' => false,
+                    'http_code' => '204 No Content',
+                    'representation' => false,
+                    'type' => 'deleted',
+                    'version' => false
+                ]
+            ],
+            'with-no-representation-and-a-description' => [
+                'param' => '{notmodified} If no data has been changed.',
+                'version' => null,
+                'expected' => [
+                    'description' => 'If no data has been changed.',
+                    'http_code' => '304 Not Modified',
+                    'representation' => false,
+                    'type' => 'notmodified',
+                    'version' => false
+                ]
+            ],
             'versioned' => [
                 'param' => '{collection} \Mill\Examples\Showtimes\Representations\Movie',
                 'version' => new Version('3.2', __CLASS__, __METHOD__),
                 'expected' => [
                     'description' => false,
+                    'http_code' => '200 OK',
+                    'representation' => '\Mill\Examples\Showtimes\Representations\Movie',
+                    'type' => 'collection',
+                    'version' => [
+                        'start' => '3.2',
+                        'end' => '3.2'
+                    ]
+                ]
+            ],
+            '_complete' => [
+                'param' => '{collection} \Mill\Examples\Showtimes\Representations\Movie A collection of movies.',
+                'version' => new Version('3.2', __CLASS__, __METHOD__),
+                'expected' => [
+                    'description' => 'A collection of movies.',
                     'http_code' => '200 OK',
                     'representation' => '\Mill\Examples\Showtimes\Representations\Movie',
                     'type' => 'collection',
@@ -92,17 +128,6 @@ class ReturnAnnotationTest extends AnnotationTest
                     'description' => false,
                     'http_code' => '200 OK',
                     'representation' => '\Mill\Examples\Showtimes\Representations\Movie',
-                    'type' => 'ok',
-                    'version' => false
-                ]
-            ],
-            'string' => [
-                'param' => '{ok} string',
-                'version' => null,
-                'expected' => [
-                    'description' => false,
-                    'http_code' => '200 OK',
-                    'representation' => 'string',
                     'type' => 'ok',
                     'version' => false
                 ]

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -349,7 +349,7 @@ class DocumentationTest extends TestCase
                             [
                                 'description' => false,
                                 'http_code' => '204 No Content',
-                                'representation' => '\Mill\Examples\Showtimes\Representations\Representation',
+                                'representation' => false,
                                 'type' => 'deleted',
                                 'version' => false
                             ]

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -16,11 +16,10 @@
         <filter>
             <directory name="resources/examples/Showtimes/Representations/" method="create" suffix=".php"  />
 
-            <class name="\Mill\Examples\Showtimes\Representations\Representation" noMethod="true" />
-
             <excludes>
                 <exclude name="\Mill\Examples\Showtimes\Representations\Error" />
                 <exclude name="\Mill\Examples\Showtimes\Representations\CodedError" />
+                <exclude name="\Mill\Examples\Showtimes\Representations\Representation" />
                 <exclude name="string" />
             </excludes>
         </filter>

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -20,7 +20,6 @@
                 <exclude name="\Mill\Examples\Showtimes\Representations\Error" />
                 <exclude name="\Mill\Examples\Showtimes\Representations\CodedError" />
                 <exclude name="\Mill\Examples\Showtimes\Representations\Representation" />
-                <exclude name="string" />
             </excludes>
         </filter>
 


### PR DESCRIPTION
This cleans up some `@api-return` requirements where we were originally requiring a representation to be supplied to all `@api-return` annotations. This resulted in a lot of hacky shit, where we needed to add a `noMethod` representation config to specify that the given representation didn't have any actual content (like in the case of normal `@api-return {delete}` calls).

Overall result of this is that the return annotation is easier to understand and work with now, without having to jump through hoops in your Mill config.

https://github.com/vimeo/mill/issues/12