### PR TITLE
Versions attached to @api-see now follow through

### DIFF
--- a/resources/examples/Showtimes/Representations/Movie.php
+++ b/resources/examples/Showtimes/Representations/Movie.php
@@ -64,6 +64,10 @@ class Movie extends Representation
             'genres' => $this->movie->getGenres(),
 
             /**
+             * @api-label Urls
+             * @api-field urls
+             * @api-type object
+             * @api-version 1.1
              * @api-see \Mill\Examples\Showtimes\Representations\Movie::getUrls urls
              */
             'urls' => $this->getUrls(),

--- a/resources/examples/Showtimes/blueprints/1.0/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.0/Movies.apib
@@ -29,10 +29,6 @@ Information on a specific movie.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object)
-            - `imdb` (string) - IMDB URL
-            - `tickets` (string) - Tickets URL
-            - `trailer` (string) - Trailer URL
 + Response 304 (application/json)
 + Response 404 (application/json)
 
@@ -73,10 +69,6 @@ Information on a specific movie.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object)
-            - `imdb` (string) - IMDB URL
-            - `tickets` (string) - Tickets URL
-            - `trailer` (string) - Trailer URL
 + Response 400 (application/json)
 
 ### Create a movie. [POST]
@@ -122,10 +114,6 @@ This action requires a bearer token with `create` scope.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object)
-            - `imdb` (string) - IMDB URL
-            - `tickets` (string) - Tickets URL
-            - `trailer` (string) - Trailer URL
 + Response 400 (application/json)
     There are 2 ways that this status code can be encountered.
          * If there is a problem with the request.

--- a/resources/examples/Showtimes/blueprints/1.1/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.1/Movies.apib
@@ -29,7 +29,7 @@ Information on a specific movie.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object)
+        - `urls` (object) - Urls
             - `imdb` (string) - IMDB URL
             - `tickets` (string) - Tickets URL
             - `trailer` (string) - Trailer URL
@@ -83,7 +83,7 @@ This action requires a bearer token with `edit` scope.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object)
+        - `urls` (object) - Urls
             - `imdb` (string) - IMDB URL
             - `tickets` (string) - Tickets URL
             - `trailer` (string) - Trailer URL
@@ -130,7 +130,7 @@ Information on a specific movie.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object)
+        - `urls` (object) - Urls
             - `imdb` (string) - IMDB URL
             - `tickets` (string) - Tickets URL
             - `trailer` (string) - Trailer URL
@@ -181,7 +181,7 @@ This action requires a bearer token with `create` scope.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object)
+        - `urls` (object) - Urls
             - `imdb` (string) - IMDB URL
             - `tickets` (string) - Tickets URL
             - `trailer` (string) - Trailer URL

--- a/src/Parser/Annotation.php
+++ b/src/Parser/Annotation.php
@@ -364,4 +364,17 @@ abstract class Annotation
     {
         return $this->version;
     }
+
+    /**
+     * Set a version that this annotation is available on. This is specifically used in tandem with `@api-see`
+     * annotations.
+     *
+     * @param Version $version
+     * @return Annotation
+     */
+    public function setVersion(Version $version)
+    {
+        $this->version = $version;
+        return $this;
+    }
 }

--- a/src/Parser/Representation/RepresentationParser.php
+++ b/src/Parser/Representation/RepresentationParser.php
@@ -7,6 +7,7 @@ use Mill\Exceptions\MethodNotSuppliedException;
 use Mill\Exceptions\Representation\DuplicateFieldException;
 use Mill\Parser;
 use Mill\Parser\Annotations\FieldAnnotation;
+use Mill\Parser\Version;
 
 /**
  * Class for parsing the docblock on a representation.
@@ -76,30 +77,52 @@ class RepresentationParser extends Parser
         $annotations = [];
 
         // Does this have any `@api-see` pointers?
+        $has_version = false;
+        $has_see = false;
         foreach ($matches as $k => $match) {
             list($_, $annotation, $decorator, $_last_decorator, $data) = $match;
-            if ($annotation !== 'see') {
-                continue;
-            }
+            switch ($annotation) {
+                case 'see':
+                    $has_see = explode(' ', trim($data));
+                    unset($matches[$k]);
+                    break;
 
-            $parts = explode(' ', trim($data));
-            list($see_class, $see_method) = explode('::', array_shift($parts));
-            $prefix = array_shift($parts);
+                // Do not remove the version from the array of matches, because we'll re-apply the version to the
+                // field annotation that we, maybe, picked up here.
+                case 'version':
+                    $data = trim($data);
+                    $has_version = new Version($data, $this->class, $this->method);
+                    break;
+
+                default:
+                    continue;
+            }
+        }
+
+        // If we matched an `@api-see` annotation, then let's parse it out into viable annotations.
+        if ($has_see) {
+            list($see_class, $see_method) = explode('::', array_shift($has_see));
+            $prefix = array_shift($has_see);
 
             $parser = new self($see_class);
             $see_annotations = $parser->getAnnotations($see_method);
 
-            // If this `@api-see` has a prefix to attach to found annotations, do so.
-            if (!empty($prefix)) {
-                /** @var FieldAnnotation $annotation */
-                foreach ($see_annotations as $name => $annotation) {
+            /** @var FieldAnnotation $annotation */
+            foreach ($see_annotations as $name => $annotation) {
+                if ($has_version) {
+                    // If this `@api-see` is being used with a `@api-version`, then the version here should always
+                    // take precedence over any versioning set up within the see.
+                    $annotation->setVersion($has_version);
+                }
+
+                // If this `@api-see` has a prefix to attach to found annotations, do so.
+                if (!empty($prefix)) {
                     $see_annotations[$prefix . '.' . $name] = $annotation->setFieldNamePrefix($prefix);
                     unset($see_annotations[$name]);
                 }
             }
 
             $annotations += $see_annotations;
-            unset($matches[$k]);
         }
 
         // If $matches is empty, then we only parsed `@api-see` annotations, so let's drop out.

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -54,6 +54,8 @@ class Reader
 
         /** @var \ReflectionMethod $method */
         $method = $reflection->getMethod($method);
+
+        /** @var string $filename */
         $filename = $method->getFileName();
 
         // The start line is actually `- 1`, otherwise you wont get the function() block.

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -12,7 +12,10 @@ class GeneratorTest extends TestCase
         $generator = new Generator($this->getConfig());
         $generator->generate();
 
-        $this->assertCount(2, $generator->getResources());
+        $this->assertSame([
+            '1.0',
+            '1.1'
+        ], array_keys($generator->getResources()));
     }
 
     public function testGeneratorButExcludeARepresentation()
@@ -122,8 +125,8 @@ class GeneratorTest extends TestCase
 
             $this->assertSame($data['label'], $actual['label']);
             $this->assertSame($data['description.length'], strlen($actual['description']));
-            $this->assertCount($data['content.size'], $actual['content']);
-            $this->assertCount($data['content.size'], $representation->getContent());
+            $this->assertSame($data['content.keys'], array_keys($actual['content']));
+            $this->assertSame($data['content.keys'], array_keys($representation->getContent()));
         }
     }
 
@@ -139,12 +142,33 @@ class GeneratorTest extends TestCase
                     '\Mill\Examples\Showtimes\Representations\Movie' => [
                         'label' => 'Movie',
                         'description.length' => 41,
-                        'content.size' => 14
+                        'content.keys' => [
+                            'cast',
+                            'content_rating',
+                            'description',
+                            'director',
+                            'genres',
+                            'id',
+                            'name',
+                            'runtime',
+                            'showtimes',
+                            'theaters',
+                            'uri'
+                        ]
                     ],
                     '\Mill\Examples\Showtimes\Representations\Theater' => [
                         'label' => 'Theater',
                         'description.length' => 49,
-                        'content.size' => 8
+                        'content.keys' => [
+                            'address',
+                            'id',
+                            'movies',
+                            'name',
+                            'phone_number',
+                            'showtimes',
+                            'uri',
+                            'website'
+                        ]
                     ]
                 ],
                 'expected.resources' => [
@@ -270,12 +294,36 @@ class GeneratorTest extends TestCase
                     '\Mill\Examples\Showtimes\Representations\Movie' => [
                         'label' => 'Movie',
                         'description.length' => 41,
-                        'content.size' => 14
+                        'content.keys' => [
+                            'cast',
+                            'content_rating',
+                            'description',
+                            'director',
+                            'genres',
+                            'id',
+                            'name',
+                            'runtime',
+                            'showtimes',
+                            'theaters',
+                            'uri',
+                            'urls',
+                            'urls.imdb',
+                            'urls.tickets',
+                            'urls.trailer'
+                        ]
                     ],
                     '\Mill\Examples\Showtimes\Representations\Theater' => [
                         'label' => 'Theater',
                         'description.length' => 49,
-                        'content.size' => 7
+                        'content.keys' => [
+                            'address',
+                            'id',
+                            'movies',
+                            'name',
+                            'phone_number',
+                            'showtimes',
+                            'uri'
+                        ]
                     ]
                 ],
                 'expected.resources' => [

--- a/tests/Parser/Representation/DocumentationTest.php
+++ b/tests/Parser/Representation/DocumentationTest.php
@@ -158,13 +158,21 @@ class DocumentationTest extends TestCase
                             'type' => 'uri',
                             'version' => false
                         ],
+                        'urls' => [
+                            'capability' => false,
+                            'field' => 'urls',
+                            'label' => 'Urls',
+                            'options' => false,
+                            'type' => 'object',
+                            'version' => '1.1'
+                        ],
                         'urls.imdb' => [
                             'capability' => false,
                             'field' => 'urls.imdb',
                             'label' => 'IMDB URL',
                             'options' => false,
                             'type' => 'string',
-                            'version' => false
+                            'version' => '1.1'
                         ],
                         'urls.tickets' => [
                             'capability' => 'BUY_TICKETS',
@@ -172,7 +180,7 @@ class DocumentationTest extends TestCase
                             'label' => 'Tickets URL',
                             'options' => false,
                             'type' => 'string',
-                            'version' => false
+                            'version' => '1.1'
                         ],
                         'urls.trailer' => [
                             'capability' => false,
@@ -180,7 +188,7 @@ class DocumentationTest extends TestCase
                             'label' => 'Trailer URL',
                             'options' => false,
                             'type' => 'string',
-                            'version' => false
+                            'version' => '1.1'
                         ]
                     ],
                     'content.exploded' => [
@@ -308,6 +316,14 @@ class DocumentationTest extends TestCase
                             ]
                         ],
                         'urls' => [
+                            '__FIELD_DATA__' => [
+                                'capability' => false,
+                                'field' => 'urls',
+                                'label' => 'Urls',
+                                'options' => false,
+                                'type' => 'object',
+                                'version' => '1.1'
+                            ],
                             'imdb' => [
                                 '__FIELD_DATA__' => [
                                     'capability' => false,
@@ -315,7 +331,7 @@ class DocumentationTest extends TestCase
                                     'label' => 'IMDB URL',
                                     'options' => false,
                                     'type' => 'string',
-                                    'version' => false
+                                    'version' => '1.1'
                                 ]
                             ],
                             'tickets' => [
@@ -325,7 +341,7 @@ class DocumentationTest extends TestCase
                                     'label' => 'Tickets URL',
                                     'options' => false,
                                     'type' => 'string',
-                                    'version' => false
+                                    'version' => '1.1'
                                 ]
                             ],
                             'trailer' => [
@@ -335,7 +351,7 @@ class DocumentationTest extends TestCase
                                     'label' => 'Trailer URL',
                                     'options' => false,
                                     'type' => 'string',
-                                    'version' => false
+                                    'version' => '1.1'
                                 ]
                             ]
                         ]

--- a/tests/Parser/Representation/RepresentationParserTest.php
+++ b/tests/Parser/Representation/RepresentationParserTest.php
@@ -60,7 +60,23 @@ class RepresentationParserTest extends TestCase
 
         // We're already asserting that the parser actually parses annotations, we just want to make sure that we
         // picked up the full Movie representation here by way of an `@api-see` pointer.
-        $this->assertCount(14, $annotations);
+        $this->assertSame([
+            'cast',
+            'content_rating',
+            'description',
+            'director',
+            'genres',
+            'id',
+            'name',
+            'runtime',
+            'showtimes',
+            'theaters',
+            'uri',
+            'urls',
+            'urls.imdb',
+            'urls.tickets',
+            'urls.trailer'
+        ], array_keys($annotations));
     }
 
     /**
@@ -214,13 +230,21 @@ class RepresentationParserTest extends TestCase
                             'type' => 'uri',
                             'version' => false
                         ],
+                        'urls' => [
+                            'capability' => false,
+                            'field' => 'urls',
+                            'label' => 'Urls',
+                            'options' => false,
+                            'type' => 'object',
+                            'version' => '1.1'
+                        ],
                         'urls.imdb' => [
                             'capability' => false,
                             'field' => 'urls.imdb',
                             'label' => 'IMDB URL',
                             'options' => false,
                             'type' => 'string',
-                            'version' => false
+                            'version' => '1.1'
                         ],
                         'urls.tickets' => [
                             'capability' => 'BUY_TICKETS',
@@ -228,7 +252,7 @@ class RepresentationParserTest extends TestCase
                             'label' => 'Tickets URL',
                             'options' => false,
                             'type' => 'string',
-                            'version' => false
+                            'version' => '1.1'
                         ],
                         'urls.trailer' => [
                             'capability' => false,
@@ -236,7 +260,7 @@ class RepresentationParserTest extends TestCase
                             'label' => 'Trailer URL',
                             'options' => false,
                             'type' => 'string',
-                            'version' => false
+                            'version' => '1.1'
                         ]
                     ]
                 ]


### PR DESCRIPTION
This fixes an issue with `@api-version` usage when used on `@api-see` annotations, where the following would not add the supplied version to the also supplied see:

```
/**
 * @api-label Play representation
 * @api-field play
 * @api-type representation
 * @api-version >=3.3
 * @api-see \PlayResponse::_json play
 */
```

Now, with this, `play` is under `>=3.3`, as well as everything within ` \PlayResponse::_json`.

I also added some improved assertions in a few tests, moving them away from count assertions and onto direct array key comparisons, making it loads easier to debug failures.

Fixes #30.