### PR TITLE
Verify that SemVer patch version generation works.

### DIFF
--- a/resources/examples/Showtimes/Controllers/Movie.php
+++ b/resources/examples/Showtimes/Controllers/Movie.php
@@ -45,7 +45,6 @@ class Movie
      * @api-param:public {string} runtime (optional) Movie runtime, in `HHhr MMmin` format.
      * @api-param:public {string} content_rating [G|PG|PG-13|R|NC-17|X|NR|UR] (optional) MPAA rating
      * @api-param:public {array} genres (optional) Array of movie genres.
-     * @api-param:public {string} imdb (optional) IMDB URL
      * @api-param:public {string} trailer (optional) Trailer URL
      * @api-param:public {string} director (optional) Name of the director.
      * @api-param:public {array} cast (optional) Array of names of the cast.
@@ -56,6 +55,9 @@ class Movie
      *      request.
      * @api-throws:public {400} \Mill\Examples\Showtimes\Representations\Error If the IMDB URL could not be validated.
      * @api-throws:public {404} \Mill\Examples\Showtimes\Representations\Error If the movie could not be found.
+     *
+     * @api-version >=1.1.1
+     * @api-param:public {string} imdb (optional) IMDB URL
      */
     public function PATCH()
     {

--- a/resources/examples/Showtimes/Controllers/Movies.php
+++ b/resources/examples/Showtimes/Controllers/Movies.php
@@ -50,7 +50,7 @@ class Movies
      *      request.
      * @api-throws:public {400} \Mill\Examples\Showtimes\Representations\Error If the IMDB URL could not be validated.
      *
-     * @api-version 1.1
+     * @api-version >=1.1
      * @api-param:public {string} imdb (optional) IMDB URL
      * @api-param:public {string} trailer (optional) Trailer URL
      */

--- a/resources/examples/Showtimes/Representations/Movie.php
+++ b/resources/examples/Showtimes/Representations/Movie.php
@@ -67,7 +67,7 @@ class Movie extends Representation
              * @api-label Urls
              * @api-field urls
              * @api-type object
-             * @api-version 1.1
+             * @api-version >=1.1
              * @api-see \Mill\Examples\Showtimes\Representations\Movie::getUrls urls
              */
             'urls' => $this->getUrls(),

--- a/resources/examples/Showtimes/blueprints/1.1.1/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.1/Movies.apib
@@ -60,6 +60,7 @@ This action requires a bearer token with `edit` scope.
         - `trailer` (string) - Trailer URL
         - `director` (string) - Name of the director.
         - `cast` (string) - Array of names of the cast.
+        - `imdb` (string) - IMDB URL
 + Response 200 (application/json)
     + Attributes
         - `cast` (array) - Cast

--- a/resources/examples/Showtimes/blueprints/1.1.1/Theaters.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.1/Theaters.apib
@@ -1,0 +1,87 @@
+FORMAT: 1A
+
+# Theaters
+## Movie Theaters [/theaters/{id}]
+Information on a specific movie theater.
+
+### Get a single movie theater [GET]
++ Parameters
+    + `id` (integer, required) - Theater ID
++ Response 200 (application/json)
+    + Attributes
+        - `address` (string) - Address
+        - `id` (number) - Unique ID
+        - `movies` (array) - Movies currently playing
+        - `name` (string) - Name
+        - `phone_number` (string) - Phone number
+        - `showtimes` (array) - Non-movie specific showtimes
+        - `uri` (string) - Theater URI
++ Response 304 (application/json)
++ Response 404 (application/json)
+
+### Update a movie theater [PATCH]
+This action requires a bearer token with `create` scope.
+
++ Parameters
+    + `id` (integer, required) - Theater ID
++ Request
+    + Attributes
+        - `name` (string, required) - Name of the theater.
+        - `address` (string, required) - Theater address
+        - `phone_number` (string, required) - Theater phone number
++ Response 200 (application/json)
+    + Attributes
+        - `address` (string) - Address
+        - `id` (number) - Unique ID
+        - `movies` (array) - Movies currently playing
+        - `name` (string) - Name
+        - `phone_number` (string) - Phone number
+        - `showtimes` (array) - Non-movie specific showtimes
+        - `uri` (string) - Theater URI
++ Response 400 (application/json)
++ Response 404 (application/json)
+
+### Delete a movie movie. [DELETE]
+This action requires a bearer token with `delete` scope.
+
++ Parameters
+    + `id` (integer, required) - Theater ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+
+## Movie Theaters [/theaters]
+Information on a specific movie theater.
+
+### Get movie theaters. [GET]
++ Request
+    + Attributes
+        - `location` (string, required) - Location you want theaters in.
++ Response 200 (application/json)
+    + Attributes
+        - `address` (string) - Address
+        - `id` (number) - Unique ID
+        - `movies` (array) - Movies currently playing
+        - `name` (string) - Name
+        - `phone_number` (string) - Phone number
+        - `showtimes` (array) - Non-movie specific showtimes
+        - `uri` (string) - Theater URI
++ Response 400 (application/json)
+
+### Create a movie theater. [POST]
+This action requires a bearer token with `create` scope.
+
++ Request
+    + Attributes
+        - `name` (string, required) - Name of the theater.
+        - `address` (string, required) - Theater address
+        - `phone_number` (string, required) - Theater phone number
++ Response 200 (application/json)
+    + Attributes
+        - `address` (string) - Address
+        - `id` (number) - Unique ID
+        - `movies` (array) - Movies currently playing
+        - `name` (string) - Name
+        - `phone_number` (string) - Phone number
+        - `showtimes` (array) - Non-movie specific showtimes
+        - `uri` (string) - Theater URI
++ Response 400 (application/json)

--- a/resources/examples/mill.xml
+++ b/resources/examples/mill.xml
@@ -5,7 +5,8 @@
 >
     <versions>
         <version name="1.0" />
-        <version name="1.1" default="true" />
+        <version name="1.1" />
+        <version name="1.1.1" default="true" />
     </versions>
 
     <controllers>

--- a/tests/Command/GenerateTest.php
+++ b/tests/Command/GenerateTest.php
@@ -57,7 +57,8 @@ class GenerateTest extends \PHPUnit_Framework_TestCase
             '.',
             '..',
             '1.0',
-            '1.1'
+            '1.1',
+            '1.1.1'
         ], scandir($output_dir));
 
         $blueprints_dir = __DIR__ . '/../../resources/examples/Showtimes/blueprints';

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -10,12 +10,13 @@ class ConfigTest extends TestCase
         $config = $this->getConfig();
 
         $this->assertSame('1.0', $config->getFirstApiVersion());
-        $this->assertSame('1.1', $config->getDefaultApiVersion());
-        $this->assertSame('1.1', $config->getLatestApiVersion());
+        $this->assertSame('1.1.1', $config->getDefaultApiVersion());
+        $this->assertSame('1.1.1', $config->getLatestApiVersion());
 
         $this->assertSame([
             '1.0',
-            '1.1'
+            '1.1',
+            '1.1.1'
         ], $config->getApiVersions());
 
         $this->assertSame([

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -14,7 +14,8 @@ class GeneratorTest extends TestCase
 
         $this->assertSame([
             '1.0',
-            '1.1'
+            '1.1',
+            '1.1.1'
         ], array_keys($generator->getResources()));
     }
 
@@ -135,6 +136,108 @@ class GeneratorTest extends TestCase
      */
     public function providerGeneratorWithVersion()
     {
+        // Save us the effort of copy and pasting the same base endpoints over and over.
+        $common_actions = [
+            '/movies::GET' => [
+                'uri' => '/movies',
+                'method' => 'GET',
+                'uriSegment' => false
+            ],
+            '/movies::POST' => [
+                'uri' => '/movies',
+                'method' => 'POST',
+                'uriSegment' => false
+            ],
+            '/movies/+id::GET' => [
+                'uri' => '/movies/+id',
+                'method' => 'GET',
+                'uriSegment' => [
+                    [
+                        'description' => 'Movie ID',
+                        'field' => 'id',
+                        'type' => 'integer',
+                        'uri' => '/movies/+id',
+                        'values' => false
+                    ]
+                ]
+            ],
+            '/movies/+id::PATCH' => [
+                'uri' => '/movies/+id',
+                'method' => 'PATCH',
+                'uriSegment' => [
+                    [
+                        'description' => 'Movie ID',
+                        'field' => 'id',
+                        'type' => 'integer',
+                        'uri' => '/movies/+id',
+                        'values' => false
+                    ]
+                ]
+            ],
+            '/movies/+id::DELETE' => [
+                'uri' => '/movies/+id',
+                'method' => 'DELETE',
+                'uriSegment' => [
+                    [
+                        'description' => 'Movie ID',
+                        'field' => 'id',
+                        'type' => 'integer',
+                        'uri' => '/movies/+id',
+                        'values' => false
+                    ]
+                ]
+            ],
+            '/theaters::GET' => [
+                'uri' => '/theaters',
+                'method' => 'GET',
+                'uriSegment' => false
+            ],
+            '/theaters::POST' => [
+                'uri' => '/theaters',
+                'method' => 'POST',
+                'uriSegment' => false
+            ],
+            '/theaters/+id::GET' => [
+                'uri' => '/theaters/+id',
+                'method' => 'GET',
+                'uriSegment' => [
+                    [
+                        'description' => 'Theater ID',
+                        'field' => 'id',
+                        'type' => 'integer',
+                        'uri' => '/theaters/+id',
+                        'values' => false
+                    ]
+                ]
+            ],
+            '/theaters/+id::PATCH' => [
+                'uri' => '/theaters/+id',
+                'method' => 'PATCH',
+                'uriSegment' => [
+                    [
+                        'description' => 'Theater ID',
+                        'field' => 'id',
+                        'type' => 'integer',
+                        'uri' => '/theaters/+id',
+                        'values' => false
+                    ]
+                ]
+            ],
+            '/theaters/+id::DELETE' => [
+                'uri' => '/theaters/+id',
+                'method' => 'DELETE',
+                'uriSegment' => [
+                    [
+                        'description' => 'Theater ID',
+                        'field' => 'id',
+                        'type' => 'integer',
+                        'uri' => '/theaters/+id',
+                        'values' => false
+                    ]
+                ]
+            ]
+        ];
+
         return [
             'version-1.0' => [
                 'version' => '1.0',
@@ -178,46 +281,18 @@ class GeneratorTest extends TestCase
                                 'resource.name' => 'Movies',
                                 'description.length' => 32,
                                 'actions.data' => [
-                                    '/movies::GET' => [
-                                        'uri' => '/movies',
-                                        'method' => 'GET',
-                                        'uriSegment' => false,
+                                    '/movies::GET' => array_merge($common_actions['/movies::GET'], [
                                         'params.size' => 1
-                                    ],
-                                    '/movies::POST' => [
-                                        'uri' => '/movies',
-                                        'method' => 'POST',
-                                        'uriSegment' => false,
+                                    ]),
+                                    '/movies::POST' => array_merge($common_actions['/movies::POST'], [
                                         'params.size' => 7
-                                    ],
-                                    '/movies/+id::GET' => [
-                                        'uri' => '/movies/+id',
-                                        'method' => 'GET',
-                                        'uriSegment' => [
-                                            [
-                                                'description' => 'Movie ID',
-                                                'field' => 'id',
-                                                'type' => 'integer',
-                                                'uri' => '/movies/+id',
-                                                'values' => false
-                                            ]
-                                        ],
+                                    ]),
+                                    '/movies/+id::GET' => array_merge($common_actions['/movies/+id::GET'], [
                                         'params.size' => 0
-                                    ],
-                                    '/movies/+id::DELETE' => [
-                                        'uri' => '/movies/+id',
-                                        'method' => 'DELETE',
-                                        'uriSegment' => [
-                                            [
-                                                'description' => 'Movie ID',
-                                                'field' => 'id',
-                                                'type' => 'integer',
-                                                'uri' => '/movies/+id',
-                                                'values' => false
-                                            ]
-                                        ],
+                                    ]),
+                                    '/movies/+id::DELETE' => array_merge($common_actions['/movies/+id::DELETE'], [
                                         'params.size' => 0
-                                    ]
+                                    ])
                                 ]
                             ]
                         ]
@@ -228,60 +303,21 @@ class GeneratorTest extends TestCase
                                 'resource.name' => 'Movie Theaters',
                                 'description.length' => 40,
                                 'actions.data' => [
-                                    '/theaters::GET' => [
-                                        'uri' => '/theaters',
-                                        'method' => 'GET',
-                                        'uriSegment' => false,
+                                    '/theaters::GET' => array_merge($common_actions['/theaters::GET'], [
                                         'params.size' => 1
-                                    ],
-                                    '/theaters::POST' => [
-                                        'uri' => '/theaters',
-                                        'method' => 'POST',
-                                        'uriSegment' => false,
+                                    ]),
+                                    '/theaters::POST' => array_merge($common_actions['/theaters::POST'], [
                                         'params.size' => 3
-                                    ],
-                                    '/theaters/+id::GET' => [
-                                        'uri' => '/theaters/+id',
-                                        'method' => 'GET',
-                                        'uriSegment' => [
-                                            [
-                                                'description' => 'Theater ID',
-                                                'field' => 'id',
-                                                'type' => 'integer',
-                                                'uri' => '/theaters/+id',
-                                                'values' => false
-                                            ]
-                                        ],
+                                    ]),
+                                    '/theaters/+id::GET' => array_merge($common_actions['/theaters/+id::GET'], [
                                         'params.size' => 0
-                                    ],
-                                    '/theaters/+id::PATCH' => [
-                                        'uri' => '/theaters/+id',
-                                        'method' => 'PATCH',
-                                        'uriSegment' => [
-                                            [
-                                                'description' => 'Theater ID',
-                                                'field' => 'id',
-                                                'type' => 'integer',
-                                                'uri' => '/theaters/+id',
-                                                'values' => false
-                                            ]
-                                        ],
+                                    ]),
+                                    '/theaters/+id::PATCH' => array_merge($common_actions['/theaters/+id::PATCH'], [
                                         'params.size' => 3
-                                    ],
-                                    '/theaters/+id::DELETE' => [
-                                        'uri' => '/theaters/+id',
-                                        'method' => 'DELETE',
-                                        'uriSegment' => [
-                                            [
-                                                'description' => 'Theater ID',
-                                                'field' => 'id',
-                                                'type' => 'integer',
-                                                'uri' => '/theaters/+id',
-                                                'values' => false
-                                            ]
-                                        ],
+                                    ]),
+                                    '/theaters/+id::DELETE' => array_merge($common_actions['/theaters/+id::DELETE'], [
                                         'params.size' => 0
-                                    ]
+                                    ])
                                 ]
                             ]
                         ]
@@ -333,60 +369,21 @@ class GeneratorTest extends TestCase
                                 'resource.name' => 'Movies',
                                 'description.length' => 32,
                                 'actions.data' => [
-                                    '/movies::GET' => [
-                                        'uri' => '/movies',
-                                        'method' => 'GET',
-                                        'uriSegment' => false,
+                                    '/movies::GET' => array_merge($common_actions['/movies::GET'], [
                                         'params.size' => 1
-                                    ],
-                                    '/movies::POST' => [
-                                        'uri' => '/movies',
-                                        'method' => 'POST',
-                                        'uriSegment' => false,
+                                    ]),
+                                    '/movies::POST' => array_merge($common_actions['/movies::POST'], [
                                         'params.size' => 9
-                                    ],
-                                    '/movies/+id::GET' => [
-                                        'uri' => '/movies/+id',
-                                        'method' => 'GET',
-                                        'uriSegment' => [
-                                            [
-                                                'description' => 'Movie ID',
-                                                'field' => 'id',
-                                                'type' => 'integer',
-                                                'uri' => '/movies/+id',
-                                                'values' => false
-                                            ]
-                                        ],
+                                    ]),
+                                    '/movies/+id::GET' => array_merge($common_actions['/movies/+id::GET'], [
                                         'params.size' => 0
-                                    ],
-                                    '/movies/+id::PATCH' => [
-                                        'uri' => '/movies/+id',
-                                        'method' => 'PATCH',
-                                        'uriSegment' => [
-                                            [
-                                                'description' => 'Movie ID',
-                                                'field' => 'id',
-                                                'type' => 'integer',
-                                                'uri' => '/movies/+id',
-                                                'values' => false
-                                                ]
-                                        ],
-                                        'params.size' => 9
-                                    ],
-                                    '/movies/+id::DELETE' => [
-                                        'uri' => '/movies/+id',
-                                        'method' => 'DELETE',
-                                        'uriSegment' => [
-                                            [
-                                                'description' => 'Movie ID',
-                                                'field' => 'id',
-                                                'type' => 'integer',
-                                                'uri' => '/movies/+id',
-                                                'values' => false
-                                            ]
-                                        ],
+                                    ]),
+                                    '/movies/+id::PATCH' => array_merge($common_actions['/movies/+id::PATCH'], [
+                                        'params.size' => 8
+                                    ]),
+                                    '/movies/+id::DELETE' => array_merge($common_actions['/movies/+id::DELETE'], [
                                         'params.size' => 0
-                                    ]
+                                    ])
                                 ]
                             ]
                         ]
@@ -397,60 +394,112 @@ class GeneratorTest extends TestCase
                                 'resource.name' => 'Movie Theaters',
                                 'description.length' => 40,
                                 'actions.data' => [
-                                    '/theaters::GET' => [
-                                        'uri' => '/theaters',
-                                        'method' => 'GET',
-                                        'uriSegment' => false,
+                                    '/theaters::GET' => array_merge($common_actions['/theaters::GET'], [
                                         'params.size' => 1
-                                    ],
-                                    '/theaters::POST' => [
-                                        'uri' => '/theaters',
-                                        'method' => 'POST',
-                                        'uriSegment' => false,
+                                    ]),
+                                    '/theaters::POST' => array_merge($common_actions['/theaters::POST'], [
                                         'params.size' => 3
-                                    ],
-                                    '/theaters/+id::GET' => [
-                                        'uri' => '/theaters/+id',
-                                        'method' => 'GET',
-                                        'uriSegment' => [
-                                            [
-                                                'description' => 'Theater ID',
-                                                'field' => 'id',
-                                                'type' => 'integer',
-                                                'uri' => '/theaters/+id',
-                                                'values' => false
-                                            ]
-                                        ],
+                                    ]),
+                                    '/theaters/+id::GET' => array_merge($common_actions['/theaters/+id::GET'], [
                                         'params.size' => 0
-                                    ],
-                                    '/theaters/+id::PATCH' => [
-                                        'uri' => '/theaters/+id',
-                                        'method' => 'PATCH',
-                                        'uriSegment' => [
-                                            [
-                                                'description' => 'Theater ID',
-                                                'field' => 'id',
-                                                'type' => 'integer',
-                                                'uri' => '/theaters/+id',
-                                                'values' => false
-                                            ]
-                                        ],
+                                    ]),
+                                    '/theaters/+id::PATCH' => array_merge($common_actions['/theaters/+id::PATCH'], [
                                         'params.size' => 3
-                                    ],
-                                    '/theaters/+id::DELETE' => [
-                                        'uri' => '/theaters/+id',
-                                        'method' => 'DELETE',
-                                        'uriSegment' => [
-                                            [
-                                                'description' => 'Theater ID',
-                                                'field' => 'id',
-                                                'type' => 'integer',
-                                                'uri' => '/theaters/+id',
-                                                'values' => false
-                                            ]
-                                        ],
+                                    ]),
+                                    '/theaters/+id::DELETE' => array_merge($common_actions['/theaters/+id::DELETE'], [
                                         'params.size' => 0
-                                    ]
+                                    ])
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'version-1.1.1' => [
+                'version' => '1.1.1',
+                'expected.representations' => [
+                    '\Mill\Examples\Showtimes\Representations\Movie' => [
+                        'label' => 'Movie',
+                        'description.length' => 41,
+                        'content.keys' => [
+                            'cast',
+                            'content_rating',
+                            'description',
+                            'director',
+                            'genres',
+                            'id',
+                            'name',
+                            'runtime',
+                            'showtimes',
+                            'theaters',
+                            'uri',
+                            'urls',
+                            'urls.imdb',
+                            'urls.tickets',
+                            'urls.trailer'
+                        ]
+                    ],
+                    '\Mill\Examples\Showtimes\Representations\Theater' => [
+                        'label' => 'Theater',
+                        'description.length' => 49,
+                        'content.keys' => [
+                            'address',
+                            'id',
+                            'movies',
+                            'name',
+                            'phone_number',
+                            'showtimes',
+                            'uri'
+                        ]
+                    ]
+                ],
+                'expected.resources' => [
+                    'Movies' => [
+                        'resources' => [
+                            [
+                                'resource.name' => 'Movies',
+                                'description.length' => 32,
+                                'actions.data' => [
+                                    '/movies::GET' => array_merge($common_actions['/movies::GET'], [
+                                        'params.size' => 1
+                                    ]),
+                                    '/movies::POST' => array_merge($common_actions['/movies::POST'], [
+                                        'params.size' => 9
+                                    ]),
+                                    '/movies/+id::GET' => array_merge($common_actions['/movies/+id::GET'], [
+                                        'params.size' => 0
+                                    ]),
+                                    '/movies/+id::PATCH' => array_merge($common_actions['/movies/+id::PATCH'], [
+                                        'params.size' => 9
+                                    ]),
+                                    '/movies/+id::DELETE' => array_merge($common_actions['/movies/+id::DELETE'], [
+                                        'params.size' => 0
+                                    ])
+                                ]
+                            ]
+                        ]
+                    ],
+                    'Theaters' => [
+                        'resources' => [
+                            [
+                                'resource.name' => 'Movie Theaters',
+                                'description.length' => 40,
+                                'actions.data' => [
+                                    '/theaters::GET' => array_merge($common_actions['/theaters::GET'], [
+                                        'params.size' => 1
+                                    ]),
+                                    '/theaters::POST' => array_merge($common_actions['/theaters::POST'], [
+                                        'params.size' => 3
+                                    ]),
+                                    '/theaters/+id::GET' => array_merge($common_actions['/theaters/+id::GET'], [
+                                        'params.size' => 0
+                                    ]),
+                                    '/theaters/+id::PATCH' => array_merge($common_actions['/theaters/+id::PATCH'], [
+                                        'params.size' => 3
+                                    ]),
+                                    '/theaters/+id::DELETE' => array_merge($common_actions['/theaters/+id::DELETE'], [
+                                        'params.size' => 0
+                                    ])
                                 ]
                             ]
                         ]

--- a/tests/Parser/Representation/DocumentationTest.php
+++ b/tests/Parser/Representation/DocumentationTest.php
@@ -164,7 +164,7 @@ class DocumentationTest extends TestCase
                             'label' => 'Urls',
                             'options' => false,
                             'type' => 'object',
-                            'version' => '1.1'
+                            'version' => '>=1.1'
                         ],
                         'urls.imdb' => [
                             'capability' => false,
@@ -172,7 +172,7 @@ class DocumentationTest extends TestCase
                             'label' => 'IMDB URL',
                             'options' => false,
                             'type' => 'string',
-                            'version' => '1.1'
+                            'version' => '>=1.1'
                         ],
                         'urls.tickets' => [
                             'capability' => 'BUY_TICKETS',
@@ -180,7 +180,7 @@ class DocumentationTest extends TestCase
                             'label' => 'Tickets URL',
                             'options' => false,
                             'type' => 'string',
-                            'version' => '1.1'
+                            'version' => '>=1.1'
                         ],
                         'urls.trailer' => [
                             'capability' => false,
@@ -188,7 +188,7 @@ class DocumentationTest extends TestCase
                             'label' => 'Trailer URL',
                             'options' => false,
                             'type' => 'string',
-                            'version' => '1.1'
+                            'version' => '>=1.1'
                         ]
                     ],
                     'content.exploded' => [
@@ -322,7 +322,7 @@ class DocumentationTest extends TestCase
                                 'label' => 'Urls',
                                 'options' => false,
                                 'type' => 'object',
-                                'version' => '1.1'
+                                'version' => '>=1.1'
                             ],
                             'imdb' => [
                                 '__FIELD_DATA__' => [
@@ -331,7 +331,7 @@ class DocumentationTest extends TestCase
                                     'label' => 'IMDB URL',
                                     'options' => false,
                                     'type' => 'string',
-                                    'version' => '1.1'
+                                    'version' => '>=1.1'
                                 ]
                             ],
                             'tickets' => [
@@ -341,7 +341,7 @@ class DocumentationTest extends TestCase
                                     'label' => 'Tickets URL',
                                     'options' => false,
                                     'type' => 'string',
-                                    'version' => '1.1'
+                                    'version' => '>=1.1'
                                 ]
                             ],
                             'trailer' => [
@@ -351,7 +351,7 @@ class DocumentationTest extends TestCase
                                     'label' => 'Trailer URL',
                                     'options' => false,
                                     'type' => 'string',
-                                    'version' => '1.1'
+                                    'version' => '>=1.1'
                                 ]
                             ]
                         ]

--- a/tests/Parser/Representation/RepresentationParserTest.php
+++ b/tests/Parser/Representation/RepresentationParserTest.php
@@ -236,7 +236,7 @@ class RepresentationParserTest extends TestCase
                             'label' => 'Urls',
                             'options' => false,
                             'type' => 'object',
-                            'version' => '1.1'
+                            'version' => '>=1.1'
                         ],
                         'urls.imdb' => [
                             'capability' => false,
@@ -244,7 +244,7 @@ class RepresentationParserTest extends TestCase
                             'label' => 'IMDB URL',
                             'options' => false,
                             'type' => 'string',
-                            'version' => '1.1'
+                            'version' => '>=1.1'
                         ],
                         'urls.tickets' => [
                             'capability' => 'BUY_TICKETS',
@@ -252,7 +252,7 @@ class RepresentationParserTest extends TestCase
                             'label' => 'Tickets URL',
                             'options' => false,
                             'type' => 'string',
-                            'version' => '1.1'
+                            'version' => '>=1.1'
                         ],
                         'urls.trailer' => [
                             'capability' => false,
@@ -260,7 +260,7 @@ class RepresentationParserTest extends TestCase
                             'label' => 'Trailer URL',
                             'options' => false,
                             'type' => 'string',
-                            'version' => '1.1'
+                            'version' => '>=1.1'
                         ]
                     ]
                 ]

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -269,17 +269,6 @@ class DocumentationTest extends TestCase
                             [
                                 'capability' => false,
                                 'deprecated' => false,
-                                'description' => 'IMDB URL',
-                                'field' => 'imdb',
-                                'required' => false,
-                                'type' => 'string',
-                                'values' => false,
-                                'version' => false,
-                                'visible' => true
-                            ],
-                            [
-                                'capability' => false,
-                                'deprecated' => false,
                                 'description' => 'Trailer URL',
                                 'field' => 'trailer',
                                 'required' => false,
@@ -309,7 +298,18 @@ class DocumentationTest extends TestCase
                                 'values' => false,
                                 'version' => false,
                                 'visible' => true
-                            ]
+                            ],
+                            [
+                                'capability' => false,
+                                'deprecated' => false,
+                                'description' => 'IMDB URL',
+                                'field' => 'imdb',
+                                'required' => false,
+                                'type' => 'string',
+                                'values' => false,
+                                'version' => '>=1.1.1',
+                                'visible' => true
+                            ],
                         ],
                         'return' => [
                             [

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -5,7 +5,8 @@
 >
     <versions>
         <version name="1.0" />
-        <version name="1.1" default="true" />
+        <version name="1.1" />
+        <version name="1.1.1" default="true" />
     </versions>
 
     <controllers>


### PR DESCRIPTION
This adds some tests, and updates our examples, to show support for SemVer patches like:

```
@api-version 1.1.1
```