### PR TITLE
Alphabetizing resource parameters

### DIFF
--- a/resources/examples/Showtimes/Representations/Movie.php
+++ b/resources/examples/Showtimes/Representations/Movie.php
@@ -64,15 +64,6 @@ class Movie extends Representation
             'genres' => $this->movie->getGenres(),
 
             /**
-             * @api-label Urls
-             * @api-field urls
-             * @api-type object
-             * @api-version >=1.1
-             * @api-see \Mill\Examples\Showtimes\Representations\Movie::getUrls urls
-             */
-            'urls' => $this->getUrls(),
-
-            /**
              * @api-label Director
              * @api-field director
              * @api-type string
@@ -99,14 +90,23 @@ class Movie extends Representation
              * @api-field showtimes
              * @api-type array
              */
-            'showtimes' => $this->getShowtimes()
+            'showtimes' => $this->getShowtimes(),
+
+            /**
+             * @api-label External URLs
+             * @api-field external_urls
+             * @api-type object
+             * @api-version >=1.1
+             * @api-see \Mill\Examples\Showtimes\Representations\Movie::getExternalUrls external_urls
+             */
+            'external_urls' => $this->getExternalUrls()
         ];
     }
 
     /**
      * @return array
      */
-    private function getUrls()
+    private function getExternalUrls()
     {
         return [
             /**

--- a/resources/examples/Showtimes/blueprints/1.0/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.0/Movies.apib
@@ -76,9 +76,7 @@ This action requires a bearer token with `create` scope.
 
 + Request
     + Attributes
-        - `name` (string, required) - Name of the movie.
-        - `description` (string, required) - Description, or tagline, for the movie.
-        - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `cast` (string) - Array of names of the cast.
         - `content_rating` (enum[string]) - MPAA rating
             + Members
                 + `G`
@@ -89,9 +87,11 @@ This action requires a bearer token with `create` scope.
                 + `X`
                 + `NR`
                 + `UR`
-        - `genres` (string) - Array of movie genres.
+        - `description` (string, required) - Description, or tagline, for the movie.
         - `director` (string) - Name of the director.
-        - `cast` (string) - Array of names of the cast.
+        - `genres` (string) - Array of movie genres.
+        - `name` (string, required) - Name of the movie.
+        - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
 + Response 200 (application/json)
     + Attributes
         - `cast` (array) - Cast

--- a/resources/examples/Showtimes/blueprints/1.0/Theaters.apib
+++ b/resources/examples/Showtimes/blueprints/1.0/Theaters.apib
@@ -27,8 +27,8 @@ This action requires a bearer token with `create` scope.
     + `id` (integer, required) - Theater ID
 + Request
     + Attributes
-        - `name` (string, required) - Name of the theater.
         - `address` (string, required) - Theater address
+        - `name` (string, required) - Name of the theater.
         - `phone_number` (string, required) - Theater phone number
 + Response 200 (application/json)
     + Attributes
@@ -75,8 +75,8 @@ This action requires a bearer token with `create` scope.
 
 + Request
     + Attributes
-        - `name` (string, required) - Name of the theater.
         - `address` (string, required) - Theater address
+        - `name` (string, required) - Name of the theater.
         - `phone_number` (string, required) - Theater phone number
 + Response 200 (application/json)
     + Attributes

--- a/resources/examples/Showtimes/blueprints/1.1.1/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.1/Movies.apib
@@ -22,6 +22,10 @@ Information on a specific movie.
                 + `UR`
         - `description` (string) - Description
         - `director` (string) - Director
+        - `external_urls` (object) - External URLs
+            - `imdb` (string) - IMDB URL
+            - `tickets` (string) - Tickets URL
+            - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
         - `name` (string) - Name
@@ -29,10 +33,6 @@ Information on a specific movie.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object) - Urls
-            - `imdb` (string) - IMDB URL
-            - `tickets` (string) - Tickets URL
-            - `trailer` (string) - Trailer URL
 + Response 304 (application/json)
 + Response 404 (application/json)
 
@@ -43,9 +43,7 @@ This action requires a bearer token with `edit` scope.
     + `id` (integer, required) - Movie ID
 + Request
     + Attributes
-        - `name` (string, required) - Name of the movie.
-        - `description` (string, required) - Description, or tagline, for the movie.
-        - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `cast` (string) - Array of names of the cast.
         - `content_rating` (enum[string]) - MPAA rating
             + Members
                 + `G`
@@ -56,11 +54,13 @@ This action requires a bearer token with `edit` scope.
                 + `X`
                 + `NR`
                 + `UR`
-        - `genres` (string) - Array of movie genres.
-        - `trailer` (string) - Trailer URL
+        - `description` (string, required) - Description, or tagline, for the movie.
         - `director` (string) - Name of the director.
-        - `cast` (string) - Array of names of the cast.
+        - `genres` (string) - Array of movie genres.
         - `imdb` (string) - IMDB URL
+        - `name` (string, required) - Name of the movie.
+        - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `trailer` (string) - Trailer URL
 + Response 200 (application/json)
     + Attributes
         - `cast` (array) - Cast
@@ -76,6 +76,10 @@ This action requires a bearer token with `edit` scope.
                 + `UR`
         - `description` (string) - Description
         - `director` (string) - Director
+        - `external_urls` (object) - External URLs
+            - `imdb` (string) - IMDB URL
+            - `tickets` (string) - Tickets URL
+            - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
         - `name` (string) - Name
@@ -83,10 +87,6 @@ This action requires a bearer token with `edit` scope.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object) - Urls
-            - `imdb` (string) - IMDB URL
-            - `tickets` (string) - Tickets URL
-            - `trailer` (string) - Trailer URL
 + Response 400 (application/json)
     There are 2 ways that this status code can be encountered.
          * If there is a problem with the request.
@@ -123,6 +123,10 @@ Information on a specific movie.
                 + `UR`
         - `description` (string) - Description
         - `director` (string) - Director
+        - `external_urls` (object) - External URLs
+            - `imdb` (string) - IMDB URL
+            - `tickets` (string) - Tickets URL
+            - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
         - `name` (string) - Name
@@ -130,10 +134,6 @@ Information on a specific movie.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object) - Urls
-            - `imdb` (string) - IMDB URL
-            - `tickets` (string) - Tickets URL
-            - `trailer` (string) - Trailer URL
 + Response 400 (application/json)
 
 ### Create a movie. [POST]
@@ -141,9 +141,7 @@ This action requires a bearer token with `create` scope.
 
 + Request
     + Attributes
-        - `name` (string, required) - Name of the movie.
-        - `description` (string, required) - Description, or tagline, for the movie.
-        - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `cast` (string) - Array of names of the cast.
         - `content_rating` (enum[string]) - MPAA rating
             + Members
                 + `G`
@@ -154,10 +152,12 @@ This action requires a bearer token with `create` scope.
                 + `X`
                 + `NR`
                 + `UR`
-        - `genres` (string) - Array of movie genres.
+        - `description` (string, required) - Description, or tagline, for the movie.
         - `director` (string) - Name of the director.
-        - `cast` (string) - Array of names of the cast.
+        - `genres` (string) - Array of movie genres.
         - `imdb` (string) - IMDB URL
+        - `name` (string, required) - Name of the movie.
+        - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
         - `trailer` (string) - Trailer URL
 + Response 200 (application/json)
     + Attributes
@@ -174,6 +174,10 @@ This action requires a bearer token with `create` scope.
                 + `UR`
         - `description` (string) - Description
         - `director` (string) - Director
+        - `external_urls` (object) - External URLs
+            - `imdb` (string) - IMDB URL
+            - `tickets` (string) - Tickets URL
+            - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
         - `name` (string) - Name
@@ -181,10 +185,6 @@ This action requires a bearer token with `create` scope.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object) - Urls
-            - `imdb` (string) - IMDB URL
-            - `tickets` (string) - Tickets URL
-            - `trailer` (string) - Trailer URL
 + Response 400 (application/json)
     There are 2 ways that this status code can be encountered.
          * If there is a problem with the request.

--- a/resources/examples/Showtimes/blueprints/1.1.1/Theaters.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.1/Theaters.apib
@@ -26,8 +26,8 @@ This action requires a bearer token with `create` scope.
     + `id` (integer, required) - Theater ID
 + Request
     + Attributes
-        - `name` (string, required) - Name of the theater.
         - `address` (string, required) - Theater address
+        - `name` (string, required) - Name of the theater.
         - `phone_number` (string, required) - Theater phone number
 + Response 200 (application/json)
     + Attributes
@@ -72,8 +72,8 @@ This action requires a bearer token with `create` scope.
 
 + Request
     + Attributes
-        - `name` (string, required) - Name of the theater.
         - `address` (string, required) - Theater address
+        - `name` (string, required) - Name of the theater.
         - `phone_number` (string, required) - Theater phone number
 + Response 200 (application/json)
     + Attributes

--- a/resources/examples/Showtimes/blueprints/1.1/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.1/Movies.apib
@@ -22,6 +22,10 @@ Information on a specific movie.
                 + `UR`
         - `description` (string) - Description
         - `director` (string) - Director
+        - `external_urls` (object) - External URLs
+            - `imdb` (string) - IMDB URL
+            - `tickets` (string) - Tickets URL
+            - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
         - `name` (string) - Name
@@ -29,10 +33,6 @@ Information on a specific movie.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object) - Urls
-            - `imdb` (string) - IMDB URL
-            - `tickets` (string) - Tickets URL
-            - `trailer` (string) - Trailer URL
 + Response 304 (application/json)
 + Response 404 (application/json)
 
@@ -43,9 +43,7 @@ This action requires a bearer token with `edit` scope.
     + `id` (integer, required) - Movie ID
 + Request
     + Attributes
-        - `name` (string, required) - Name of the movie.
-        - `description` (string, required) - Description, or tagline, for the movie.
-        - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `cast` (string) - Array of names of the cast.
         - `content_rating` (enum[string]) - MPAA rating
             + Members
                 + `G`
@@ -56,10 +54,12 @@ This action requires a bearer token with `edit` scope.
                 + `X`
                 + `NR`
                 + `UR`
-        - `genres` (string) - Array of movie genres.
-        - `trailer` (string) - Trailer URL
+        - `description` (string, required) - Description, or tagline, for the movie.
         - `director` (string) - Name of the director.
-        - `cast` (string) - Array of names of the cast.
+        - `genres` (string) - Array of movie genres.
+        - `name` (string, required) - Name of the movie.
+        - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `trailer` (string) - Trailer URL
 + Response 200 (application/json)
     + Attributes
         - `cast` (array) - Cast
@@ -75,6 +75,10 @@ This action requires a bearer token with `edit` scope.
                 + `UR`
         - `description` (string) - Description
         - `director` (string) - Director
+        - `external_urls` (object) - External URLs
+            - `imdb` (string) - IMDB URL
+            - `tickets` (string) - Tickets URL
+            - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
         - `name` (string) - Name
@@ -82,10 +86,6 @@ This action requires a bearer token with `edit` scope.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object) - Urls
-            - `imdb` (string) - IMDB URL
-            - `tickets` (string) - Tickets URL
-            - `trailer` (string) - Trailer URL
 + Response 400 (application/json)
     There are 2 ways that this status code can be encountered.
          * If there is a problem with the request.
@@ -122,6 +122,10 @@ Information on a specific movie.
                 + `UR`
         - `description` (string) - Description
         - `director` (string) - Director
+        - `external_urls` (object) - External URLs
+            - `imdb` (string) - IMDB URL
+            - `tickets` (string) - Tickets URL
+            - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
         - `name` (string) - Name
@@ -129,10 +133,6 @@ Information on a specific movie.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object) - Urls
-            - `imdb` (string) - IMDB URL
-            - `tickets` (string) - Tickets URL
-            - `trailer` (string) - Trailer URL
 + Response 400 (application/json)
 
 ### Create a movie. [POST]
@@ -140,9 +140,7 @@ This action requires a bearer token with `create` scope.
 
 + Request
     + Attributes
-        - `name` (string, required) - Name of the movie.
-        - `description` (string, required) - Description, or tagline, for the movie.
-        - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `cast` (string) - Array of names of the cast.
         - `content_rating` (enum[string]) - MPAA rating
             + Members
                 + `G`
@@ -153,10 +151,12 @@ This action requires a bearer token with `create` scope.
                 + `X`
                 + `NR`
                 + `UR`
-        - `genres` (string) - Array of movie genres.
+        - `description` (string, required) - Description, or tagline, for the movie.
         - `director` (string) - Name of the director.
-        - `cast` (string) - Array of names of the cast.
+        - `genres` (string) - Array of movie genres.
         - `imdb` (string) - IMDB URL
+        - `name` (string, required) - Name of the movie.
+        - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
         - `trailer` (string) - Trailer URL
 + Response 200 (application/json)
     + Attributes
@@ -173,6 +173,10 @@ This action requires a bearer token with `create` scope.
                 + `UR`
         - `description` (string) - Description
         - `director` (string) - Director
+        - `external_urls` (object) - External URLs
+            - `imdb` (string) - IMDB URL
+            - `tickets` (string) - Tickets URL
+            - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
         - `name` (string) - Name
@@ -180,10 +184,6 @@ This action requires a bearer token with `create` scope.
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
         - `uri` (string) - Movie URI
-        - `urls` (object) - Urls
-            - `imdb` (string) - IMDB URL
-            - `tickets` (string) - Tickets URL
-            - `trailer` (string) - Trailer URL
 + Response 400 (application/json)
     There are 2 ways that this status code can be encountered.
          * If there is a problem with the request.

--- a/resources/examples/Showtimes/blueprints/1.1/Theaters.apib
+++ b/resources/examples/Showtimes/blueprints/1.1/Theaters.apib
@@ -26,8 +26,8 @@ This action requires a bearer token with `create` scope.
     + `id` (integer, required) - Theater ID
 + Request
     + Attributes
-        - `name` (string, required) - Name of the theater.
         - `address` (string, required) - Theater address
+        - `name` (string, required) - Name of the theater.
         - `phone_number` (string, required) - Theater phone number
 + Response 200 (application/json)
     + Attributes
@@ -72,8 +72,8 @@ This action requires a bearer token with `create` scope.
 
 + Request
     + Attributes
-        - `name` (string, required) - Name of the theater.
         - `address` (string, required) - Theater address
+        - `name` (string, required) - Name of the theater.
         - `phone_number` (string, required) - Theater phone number
 + Response 200 (application/json)
     + Attributes

--- a/src/Parser/Resource/Action/Documentation.php
+++ b/src/Parser/Resource/Action/Documentation.php
@@ -159,8 +159,20 @@ class Documentation
                     );
                 }
 
-                $this->annotations[$key][] = $annotation;
+                // If we're dealing with parameter annotations, let's set us up the ability to later sort them in
+                // alphabetical order by keying their annotation array off the parameter field name.
+                if ($key === 'param') {
+                    /** @var Parser\Annotations\ParamAnnotation $annotation */
+                    $this->annotations[$key][$annotation->getField()] = $annotation;
+                } else {
+                    $this->annotations[$key][] = $annotation;
+                }
             }
+        }
+
+        // Keep the parameter annotation array in alphabetical order, so they're easier to consume in the documentation.
+        if (isset($this->annotations['param'])) {
+            ksort($this->annotations['param']);
         }
 
         // Run through the parsed annotations and verify that we aren't missing any required annotations.

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -99,9 +99,9 @@ class GeneratorTest extends TestCase
                     }
 
                     $this->assertSame(
-                        $expected_action['params.size'],
-                        count($action->getParameters()),
-                        $i . ' does not have the right amount of parameters.'
+                        $expected_action['params.keys'],
+                        array_keys($action->getParameters()),
+                        $i . ' does not have the right parameters.'
                     );
                 }
             }
@@ -282,16 +282,26 @@ class GeneratorTest extends TestCase
                                 'description.length' => 32,
                                 'actions.data' => [
                                     '/movies::GET' => array_merge($common_actions['/movies::GET'], [
-                                        'params.size' => 1
+                                        'params.keys' => [
+                                            'location'
+                                        ]
                                     ]),
                                     '/movies::POST' => array_merge($common_actions['/movies::POST'], [
-                                        'params.size' => 7
+                                        'params.keys' => [
+                                            'cast',
+                                            'content_rating',
+                                            'description',
+                                            'director',
+                                            'genres',
+                                            'name',
+                                            'runtime'
+                                        ]
                                     ]),
                                     '/movies/+id::GET' => array_merge($common_actions['/movies/+id::GET'], [
-                                        'params.size' => 0
+                                        'params.keys' => []
                                     ]),
                                     '/movies/+id::DELETE' => array_merge($common_actions['/movies/+id::DELETE'], [
-                                        'params.size' => 0
+                                        'params.keys' => []
                                     ])
                                 ]
                             ]
@@ -304,19 +314,29 @@ class GeneratorTest extends TestCase
                                 'description.length' => 40,
                                 'actions.data' => [
                                     '/theaters::GET' => array_merge($common_actions['/theaters::GET'], [
-                                        'params.size' => 1
+                                        'params.keys' => [
+                                            'location'
+                                        ]
                                     ]),
                                     '/theaters::POST' => array_merge($common_actions['/theaters::POST'], [
-                                        'params.size' => 3
+                                        'params.keys' => [
+                                            'address',
+                                            'name',
+                                            'phone_number'
+                                        ]
                                     ]),
                                     '/theaters/+id::GET' => array_merge($common_actions['/theaters/+id::GET'], [
-                                        'params.size' => 0
+                                        'params.keys' => []
                                     ]),
                                     '/theaters/+id::PATCH' => array_merge($common_actions['/theaters/+id::PATCH'], [
-                                        'params.size' => 3
+                                        'params.keys' => [
+                                            'address',
+                                            'name',
+                                            'phone_number'
+                                        ]
                                     ]),
                                     '/theaters/+id::DELETE' => array_merge($common_actions['/theaters/+id::DELETE'], [
-                                        'params.size' => 0
+                                        'params.keys' => []
                                     ])
                                 ]
                             ]
@@ -335,17 +355,17 @@ class GeneratorTest extends TestCase
                             'content_rating',
                             'description',
                             'director',
+                            'external_urls',
+                            'external_urls.imdb',
+                            'external_urls.tickets',
+                            'external_urls.trailer',
                             'genres',
                             'id',
                             'name',
                             'runtime',
                             'showtimes',
                             'theaters',
-                            'uri',
-                            'urls',
-                            'urls.imdb',
-                            'urls.tickets',
-                            'urls.trailer'
+                            'uri'
                         ]
                     ],
                     '\Mill\Examples\Showtimes\Representations\Theater' => [
@@ -370,19 +390,40 @@ class GeneratorTest extends TestCase
                                 'description.length' => 32,
                                 'actions.data' => [
                                     '/movies::GET' => array_merge($common_actions['/movies::GET'], [
-                                        'params.size' => 1
+                                        'params.keys' => [
+                                            'location'
+                                        ]
                                     ]),
                                     '/movies::POST' => array_merge($common_actions['/movies::POST'], [
-                                        'params.size' => 9
+                                        'params.keys' => [
+                                            'cast',
+                                            'content_rating',
+                                            'description',
+                                            'director',
+                                            'genres',
+                                            'imdb',
+                                            'name',
+                                            'runtime',
+                                            'trailer'
+                                        ]
                                     ]),
                                     '/movies/+id::GET' => array_merge($common_actions['/movies/+id::GET'], [
-                                        'params.size' => 0
+                                        'params.keys' => []
                                     ]),
                                     '/movies/+id::PATCH' => array_merge($common_actions['/movies/+id::PATCH'], [
-                                        'params.size' => 8
+                                        'params.keys' => [
+                                            'cast',
+                                            'content_rating',
+                                            'description',
+                                            'director',
+                                            'genres',
+                                            'name',
+                                            'runtime',
+                                            'trailer'
+                                        ]
                                     ]),
                                     '/movies/+id::DELETE' => array_merge($common_actions['/movies/+id::DELETE'], [
-                                        'params.size' => 0
+                                        'params.keys' => []
                                     ])
                                 ]
                             ]
@@ -395,19 +436,29 @@ class GeneratorTest extends TestCase
                                 'description.length' => 40,
                                 'actions.data' => [
                                     '/theaters::GET' => array_merge($common_actions['/theaters::GET'], [
-                                        'params.size' => 1
+                                        'params.keys' => [
+                                            'location'
+                                        ]
                                     ]),
                                     '/theaters::POST' => array_merge($common_actions['/theaters::POST'], [
-                                        'params.size' => 3
+                                        'params.keys' => [
+                                            'address',
+                                            'name',
+                                            'phone_number'
+                                        ]
                                     ]),
                                     '/theaters/+id::GET' => array_merge($common_actions['/theaters/+id::GET'], [
-                                        'params.size' => 0
+                                        'params.keys' => []
                                     ]),
                                     '/theaters/+id::PATCH' => array_merge($common_actions['/theaters/+id::PATCH'], [
-                                        'params.size' => 3
+                                        'params.keys' => [
+                                            'address',
+                                            'name',
+                                            'phone_number'
+                                        ]
                                     ]),
                                     '/theaters/+id::DELETE' => array_merge($common_actions['/theaters/+id::DELETE'], [
-                                        'params.size' => 0
+                                        'params.keys' => []
                                     ])
                                 ]
                             ]
@@ -426,17 +477,17 @@ class GeneratorTest extends TestCase
                             'content_rating',
                             'description',
                             'director',
+                            'external_urls',
+                            'external_urls.imdb',
+                            'external_urls.tickets',
+                            'external_urls.trailer',
                             'genres',
                             'id',
                             'name',
                             'runtime',
                             'showtimes',
                             'theaters',
-                            'uri',
-                            'urls',
-                            'urls.imdb',
-                            'urls.tickets',
-                            'urls.trailer'
+                            'uri'
                         ]
                     ],
                     '\Mill\Examples\Showtimes\Representations\Theater' => [
@@ -461,19 +512,41 @@ class GeneratorTest extends TestCase
                                 'description.length' => 32,
                                 'actions.data' => [
                                     '/movies::GET' => array_merge($common_actions['/movies::GET'], [
-                                        'params.size' => 1
+                                        'params.keys' => [
+                                            'location'
+                                        ]
                                     ]),
                                     '/movies::POST' => array_merge($common_actions['/movies::POST'], [
-                                        'params.size' => 9
+                                        'params.keys' => [
+                                            'cast',
+                                            'content_rating',
+                                            'description',
+                                            'director',
+                                            'genres',
+                                            'imdb',
+                                            'name',
+                                            'runtime',
+                                            'trailer'
+                                        ]
                                     ]),
                                     '/movies/+id::GET' => array_merge($common_actions['/movies/+id::GET'], [
-                                        'params.size' => 0
+                                        'params.keys' => []
                                     ]),
                                     '/movies/+id::PATCH' => array_merge($common_actions['/movies/+id::PATCH'], [
-                                        'params.size' => 9
+                                        'params.keys' => [
+                                            'cast',
+                                            'content_rating',
+                                            'description',
+                                            'director',
+                                            'genres',
+                                            'imdb',
+                                            'name',
+                                            'runtime',
+                                            'trailer'
+                                        ]
                                     ]),
                                     '/movies/+id::DELETE' => array_merge($common_actions['/movies/+id::DELETE'], [
-                                        'params.size' => 0
+                                        'params.keys' => []
                                     ])
                                 ]
                             ]
@@ -486,19 +559,29 @@ class GeneratorTest extends TestCase
                                 'description.length' => 40,
                                 'actions.data' => [
                                     '/theaters::GET' => array_merge($common_actions['/theaters::GET'], [
-                                        'params.size' => 1
+                                        'params.keys' => [
+                                            'location'
+                                        ]
                                     ]),
                                     '/theaters::POST' => array_merge($common_actions['/theaters::POST'], [
-                                        'params.size' => 3
+                                        'params.keys' => [
+                                            'address',
+                                            'name',
+                                            'phone_number'
+                                        ]
                                     ]),
                                     '/theaters/+id::GET' => array_merge($common_actions['/theaters/+id::GET'], [
-                                        'params.size' => 0
+                                        'params.keys' => []
                                     ]),
                                     '/theaters/+id::PATCH' => array_merge($common_actions['/theaters/+id::PATCH'], [
-                                        'params.size' => 3
+                                        'params.keys' => [
+                                            'address',
+                                            'name',
+                                            'phone_number'
+                                        ]
                                     ]),
                                     '/theaters/+id::DELETE' => array_merge($common_actions['/theaters/+id::DELETE'], [
-                                        'params.size' => 0
+                                        'params.keys' => []
                                     ])
                                 ]
                             ]

--- a/tests/Parser/Representation/DocumentationTest.php
+++ b/tests/Parser/Representation/DocumentationTest.php
@@ -99,6 +99,38 @@ class DocumentationTest extends TestCase
                             'type' => 'string',
                             'version' => false
                         ],
+                        'external_urls' => [
+                            'capability' => false,
+                            'field' => 'external_urls',
+                            'label' => 'External URLs',
+                            'options' => false,
+                            'type' => 'object',
+                            'version' => '>=1.1'
+                        ],
+                        'external_urls.imdb' => [
+                            'capability' => false,
+                            'field' => 'external_urls.imdb',
+                            'label' => 'IMDB URL',
+                            'options' => false,
+                            'type' => 'string',
+                            'version' => '>=1.1'
+                        ],
+                        'external_urls.tickets' => [
+                            'capability' => 'BUY_TICKETS',
+                            'field' => 'external_urls.tickets',
+                            'label' => 'Tickets URL',
+                            'options' => false,
+                            'type' => 'string',
+                            'version' => '>=1.1'
+                        ],
+                        'external_urls.trailer' => [
+                            'capability' => false,
+                            'field' => 'external_urls.trailer',
+                            'label' => 'Trailer URL',
+                            'options' => false,
+                            'type' => 'string',
+                            'version' => '>=1.1'
+                        ],
                         'genres' => [
                             'capability' => false,
                             'field' => 'genres',
@@ -157,38 +189,6 @@ class DocumentationTest extends TestCase
                             'options' => false,
                             'type' => 'uri',
                             'version' => false
-                        ],
-                        'urls' => [
-                            'capability' => false,
-                            'field' => 'urls',
-                            'label' => 'Urls',
-                            'options' => false,
-                            'type' => 'object',
-                            'version' => '>=1.1'
-                        ],
-                        'urls.imdb' => [
-                            'capability' => false,
-                            'field' => 'urls.imdb',
-                            'label' => 'IMDB URL',
-                            'options' => false,
-                            'type' => 'string',
-                            'version' => '>=1.1'
-                        ],
-                        'urls.tickets' => [
-                            'capability' => 'BUY_TICKETS',
-                            'field' => 'urls.tickets',
-                            'label' => 'Tickets URL',
-                            'options' => false,
-                            'type' => 'string',
-                            'version' => '>=1.1'
-                        ],
-                        'urls.trailer' => [
-                            'capability' => false,
-                            'field' => 'urls.trailer',
-                            'label' => 'Trailer URL',
-                            'options' => false,
-                            'type' => 'string',
-                            'version' => '>=1.1'
                         ]
                     ],
                     'content.exploded' => [
@@ -200,6 +200,25 @@ class DocumentationTest extends TestCase
                                 'options' => false,
                                 'subtype' => false,
                                 'type' => 'array',
+                                'version' => false
+                            ]
+                        ],
+                        'content_rating' => [
+                            '__FIELD_DATA__' => [
+                                'capability' => false,
+                                'field' => 'content_rating',
+                                'label' => 'MPAA rating',
+                                'options' => [
+                                    'G',
+                                    'PG',
+                                    'PG-13',
+                                    'R',
+                                    'NC-17',
+                                    'X',
+                                    'NR',
+                                    'UR'
+                                ],
+                                'type' => 'enum',
                                 'version' => false
                             ]
                         ],
@@ -221,6 +240,46 @@ class DocumentationTest extends TestCase
                                 'options' => false,
                                 'type' => 'string',
                                 'version' => false
+                            ]
+                        ],
+                        'external_urls' => [
+                            '__FIELD_DATA__' => [
+                                'capability' => false,
+                                'field' => 'external_urls',
+                                'label' => 'External URLs',
+                                'options' => false,
+                                'type' => 'object',
+                                'version' => '>=1.1'
+                            ],
+                            'imdb' => [
+                                '__FIELD_DATA__' => [
+                                    'capability' => false,
+                                    'field' => 'external_urls.imdb',
+                                    'label' => 'IMDB URL',
+                                    'options' => false,
+                                    'type' => 'string',
+                                    'version' => '>=1.1'
+                                ]
+                            ],
+                            'tickets' => [
+                                '__FIELD_DATA__' => [
+                                    'capability' => 'BUY_TICKETS',
+                                    'field' => 'external_urls.tickets',
+                                    'label' => 'Tickets URL',
+                                    'options' => false,
+                                    'type' => 'string',
+                                    'version' => '>=1.1'
+                                ]
+                            ],
+                            'trailer' => [
+                                '__FIELD_DATA__' => [
+                                    'capability' => false,
+                                    'field' => 'external_urls.trailer',
+                                    'label' => 'Trailer URL',
+                                    'options' => false,
+                                    'type' => 'string',
+                                    'version' => '>=1.1'
+                                ]
                             ]
                         ],
                         'genres' => [
@@ -251,25 +310,6 @@ class DocumentationTest extends TestCase
                                 'label' => 'Name',
                                 'options' => false,
                                 'type' => 'string',
-                                'version' => false
-                            ]
-                        ],
-                        'content_rating' => [
-                            '__FIELD_DATA__' => [
-                                'capability' => false,
-                                'field' => 'content_rating',
-                                'label' => 'MPAA rating',
-                                'options' => [
-                                    'G',
-                                    'PG',
-                                    'PG-13',
-                                    'R',
-                                    'NC-17',
-                                    'X',
-                                    'NR',
-                                    'UR'
-                                ],
-                                'type' => 'enum',
                                 'version' => false
                             ]
                         ],
@@ -313,46 +353,6 @@ class DocumentationTest extends TestCase
                                 'options' => false,
                                 'type' => 'uri',
                                 'version' => false
-                            ]
-                        ],
-                        'urls' => [
-                            '__FIELD_DATA__' => [
-                                'capability' => false,
-                                'field' => 'urls',
-                                'label' => 'Urls',
-                                'options' => false,
-                                'type' => 'object',
-                                'version' => '>=1.1'
-                            ],
-                            'imdb' => [
-                                '__FIELD_DATA__' => [
-                                    'capability' => false,
-                                    'field' => 'urls.imdb',
-                                    'label' => 'IMDB URL',
-                                    'options' => false,
-                                    'type' => 'string',
-                                    'version' => '>=1.1'
-                                ]
-                            ],
-                            'tickets' => [
-                                '__FIELD_DATA__' => [
-                                    'capability' => 'BUY_TICKETS',
-                                    'field' => 'urls.tickets',
-                                    'label' => 'Tickets URL',
-                                    'options' => false,
-                                    'type' => 'string',
-                                    'version' => '>=1.1'
-                                ]
-                            ],
-                            'trailer' => [
-                                '__FIELD_DATA__' => [
-                                    'capability' => false,
-                                    'field' => 'urls.trailer',
-                                    'label' => 'Trailer URL',
-                                    'options' => false,
-                                    'type' => 'string',
-                                    'version' => '>=1.1'
-                                ]
                             ]
                         ]
                     ]

--- a/tests/Parser/Representation/RepresentationParserTest.php
+++ b/tests/Parser/Representation/RepresentationParserTest.php
@@ -65,17 +65,17 @@ class RepresentationParserTest extends TestCase
             'content_rating',
             'description',
             'director',
+            'external_urls',
+            'external_urls.imdb',
+            'external_urls.tickets',
+            'external_urls.trailer',
             'genres',
             'id',
             'name',
             'runtime',
             'showtimes',
             'theaters',
-            'uri',
-            'urls',
-            'urls.imdb',
-            'urls.tickets',
-            'urls.trailer'
+            'uri'
         ], array_keys($annotations));
     }
 
@@ -171,6 +171,38 @@ class RepresentationParserTest extends TestCase
                             'type' => 'string',
                             'version' => false
                         ],
+                        'external_urls' => [
+                            'capability' => false,
+                            'field' => 'external_urls',
+                            'label' => 'External URLs',
+                            'options' => false,
+                            'type' => 'object',
+                            'version' => '>=1.1'
+                        ],
+                        'external_urls.imdb' => [
+                            'capability' => false,
+                            'field' => 'external_urls.imdb',
+                            'label' => 'IMDB URL',
+                            'options' => false,
+                            'type' => 'string',
+                            'version' => '>=1.1'
+                        ],
+                        'external_urls.tickets' => [
+                            'capability' => 'BUY_TICKETS',
+                            'field' => 'external_urls.tickets',
+                            'label' => 'Tickets URL',
+                            'options' => false,
+                            'type' => 'string',
+                            'version' => '>=1.1'
+                        ],
+                        'external_urls.trailer' => [
+                            'capability' => false,
+                            'field' => 'external_urls.trailer',
+                            'label' => 'Trailer URL',
+                            'options' => false,
+                            'type' => 'string',
+                            'version' => '>=1.1'
+                        ],
                         'genres' => [
                             'capability' => false,
                             'field' => 'genres',
@@ -229,38 +261,6 @@ class RepresentationParserTest extends TestCase
                             'options' => false,
                             'type' => 'uri',
                             'version' => false
-                        ],
-                        'urls' => [
-                            'capability' => false,
-                            'field' => 'urls',
-                            'label' => 'Urls',
-                            'options' => false,
-                            'type' => 'object',
-                            'version' => '>=1.1'
-                        ],
-                        'urls.imdb' => [
-                            'capability' => false,
-                            'field' => 'urls.imdb',
-                            'label' => 'IMDB URL',
-                            'options' => false,
-                            'type' => 'string',
-                            'version' => '>=1.1'
-                        ],
-                        'urls.tickets' => [
-                            'capability' => 'BUY_TICKETS',
-                            'field' => 'urls.tickets',
-                            'label' => 'Tickets URL',
-                            'options' => false,
-                            'type' => 'string',
-                            'version' => '>=1.1'
-                        ],
-                        'urls.trailer' => [
-                            'capability' => false,
-                            'field' => 'urls.trailer',
-                            'label' => 'Trailer URL',
-                            'options' => false,
-                            'type' => 'string',
-                            'version' => '>=1.1'
                         ]
                     ]
                 ]

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -64,7 +64,17 @@ class DocumentationTest extends TestCase
             }
 
             foreach ($data as $k => $annotation) {
-                $this->assertSame($expected['annotations'][$name][$k], $annotation, '`' . $name . '` mismatch');
+                $annotation_key = $k;
+                if ($name === 'param') {
+                    // Param annotations are keyed off of the field name.
+                    $annotation_key = $annotation['field'];
+                }
+
+                $this->assertSame(
+                    $expected['annotations'][$name][$annotation_key],
+                    $annotation,
+                    '`' . $k . '` mismatch'
+                );
             }
         }
     }
@@ -202,40 +212,18 @@ class DocumentationTest extends TestCase
                             ]
                         ],
                         'param' => [
-                            [
+                            'cast' => [
                                 'capability' => false,
                                 'deprecated' => false,
-                                'description' => 'Name of the movie.',
-                                'field' => 'name',
-                                'required' => true,
-                                'type' => 'string',
-                                'values' => false,
-                                'version' => false,
-                                'visible' => true
-                            ],
-                            [
-                                'capability' => false,
-                                'deprecated' => false,
-                                'description' => 'Description, or tagline, for the movie.',
-                                'field' => 'description',
-                                'required' => true,
-                                'type' => 'string',
-                                'values' => false,
-                                'version' => false,
-                                'visible' => true
-                            ],
-                            [
-                                'capability' => false,
-                                'deprecated' => false,
-                                'description' => 'Movie runtime, in `HHhr MMmin` format.',
-                                'field' => 'runtime',
+                                'description' => 'Array of names of the cast.',
+                                'field' => 'cast',
                                 'required' => false,
-                                'type' => 'string',
+                                'type' => 'array',
                                 'values' => false,
                                 'version' => false,
                                 'visible' => true
                             ],
-                            [
+                            'content_rating' => [
                                 'capability' => false,
                                 'deprecated' => false,
                                 'description' => 'MPAA rating',
@@ -255,29 +243,18 @@ class DocumentationTest extends TestCase
                                 'version' => false,
                                 'visible' => true
                             ],
-                            [
+                            'description' => [
                                 'capability' => false,
                                 'deprecated' => false,
-                                'description' => 'Array of movie genres.',
-                                'field' => 'genres',
-                                'required' => false,
-                                'type' => 'array',
-                                'values' => false,
-                                'version' => false,
-                                'visible' => true
-                            ],
-                            [
-                                'capability' => false,
-                                'deprecated' => false,
-                                'description' => 'Trailer URL',
-                                'field' => 'trailer',
-                                'required' => false,
+                                'description' => 'Description, or tagline, for the movie.',
+                                'field' => 'description',
+                                'required' => true,
                                 'type' => 'string',
                                 'values' => false,
                                 'version' => false,
                                 'visible' => true
                             ],
-                            [
+                            'director' => [
                                 'capability' => false,
                                 'deprecated' => false,
                                 'description' => 'Name of the director.',
@@ -288,18 +265,29 @@ class DocumentationTest extends TestCase
                                 'version' => false,
                                 'visible' => true
                             ],
-                            [
+                            'name' => [
                                 'capability' => false,
                                 'deprecated' => false,
-                                'description' => 'Array of names of the cast.',
-                                'field' => 'cast',
+                                'description' => 'Name of the movie.',
+                                'field' => 'name',
+                                'required' => true,
+                                'type' => 'string',
+                                'values' => false,
+                                'version' => false,
+                                'visible' => true
+                            ],
+                            'genres' => [
+                                'capability' => false,
+                                'deprecated' => false,
+                                'description' => 'Array of movie genres.',
+                                'field' => 'genres',
                                 'required' => false,
                                 'type' => 'array',
                                 'values' => false,
                                 'version' => false,
                                 'visible' => true
                             ],
-                            [
+                            'imdb' => [
                                 'capability' => false,
                                 'deprecated' => false,
                                 'description' => 'IMDB URL',
@@ -310,6 +298,28 @@ class DocumentationTest extends TestCase
                                 'version' => '>=1.1.1',
                                 'visible' => true
                             ],
+                            'runtime' => [
+                                'capability' => false,
+                                'deprecated' => false,
+                                'description' => 'Movie runtime, in `HHhr MMmin` format.',
+                                'field' => 'runtime',
+                                'required' => false,
+                                'type' => 'string',
+                                'values' => false,
+                                'version' => false,
+                                'visible' => true
+                            ],
+                            'trailer' => [
+                                'capability' => false,
+                                'deprecated' => false,
+                                'description' => 'Trailer URL',
+                                'field' => 'trailer',
+                                'required' => false,
+                                'type' => 'string',
+                                'values' => false,
+                                'version' => false,
+                                'visible' => true
+                            ]
                         ],
                         'return' => [
                             [


### PR DESCRIPTION
Not having resource parameters in alphabetical when reading documentation is **super** frustrating. This fixes that.

Also added some tests to ensure that representations are already in alphabetical order.


Resolves #37 