### PR TITLE
Blueprint and @api-param type fixes.

### DIFF
--- a/resources/examples/Showtimes/Controllers/Movie.php
+++ b/resources/examples/Showtimes/Controllers/Movie.php
@@ -48,6 +48,8 @@ class Movie
      * @api-param:public {string} trailer (optional) Trailer URL
      * @api-param:public {string} director (optional) Name of the director.
      * @api-param:public {array} cast (optional) Array of names of the cast.
+     * @api-param:public {boolean} is_kid_friendly (optional) Is this movie kid friendly?
+     * @api-param:public {integer} rotten_tomatoes_score (optional) Rotten Tomatoes score
      *
      * @api-return:public {object} \Mill\Examples\Showtimes\Representations\Movie
      *

--- a/resources/examples/Showtimes/Controllers/Movies.php
+++ b/resources/examples/Showtimes/Controllers/Movies.php
@@ -43,6 +43,8 @@ class Movies
      * @api-param:public {array} genres (optional) Array of movie genres.
      * @api-param:public {string} director (optional) Name of the director.
      * @api-param:public {array} cast (optional) Array of names of the cast.
+     * @api-param:public {boolean} is_kid_friendly (optional) Is this movie kid friendly?
+     * @api-param:public {integer} rotten_tomatoes_score (optional) Rotten Tomatoes score
      *
      * @api-return:public {object} \Mill\Examples\Showtimes\Representations\Movie
      *

--- a/resources/examples/Showtimes/Representations/Movie.php
+++ b/resources/examples/Showtimes/Representations/Movie.php
@@ -78,6 +78,13 @@ class Movie extends Representation
             'cast' => $this->movie->getCast(),
 
             /**
+             * @api-label Kid friendly?
+             * @api-field kid_friendly
+             * @api-type boolean
+             */
+            'kid_friendly' => $this->movie->is_kid_friendly,
+
+            /**
              * @api-label Theaters the movie is currently showing in
              * @api-field theaters
              * @api-type array
@@ -99,7 +106,14 @@ class Movie extends Representation
              * @api-version >=1.1
              * @api-see \Mill\Examples\Showtimes\Representations\Movie::getExternalUrls external_urls
              */
-            'external_urls' => $this->getExternalUrls()
+            'external_urls' => $this->getExternalUrls(),
+
+            /**
+             * @api-label Rotten Tomatoes score
+             * @api-field rotten_tomatoes_score
+             * @api-type number
+             */
+            'rotten_tomatoes_score' => $this->rotten_tomatoes_score
         ];
     }
 

--- a/resources/examples/Showtimes/blueprints/1.0/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.0/Movies.apib
@@ -24,7 +24,9 @@ Information on a specific movie.
         - `director` (string) - Director
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
+        - `kid_friendly` (boolean) - Kid friendly?
         - `name` (string) - Name
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Runtime
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
@@ -64,7 +66,9 @@ Information on a specific movie.
         - `director` (string) - Director
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
+        - `kid_friendly` (boolean) - Kid friendly?
         - `name` (string) - Name
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Runtime
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
@@ -76,7 +80,7 @@ This action requires a bearer token with `create` scope.
 
 + Request
     + Attributes
-        - `cast` (string) - Array of names of the cast.
+        - `cast` (array) - Array of names of the cast.
         - `content_rating` (enum[string]) - MPAA rating
             + Members
                 + `G`
@@ -89,8 +93,10 @@ This action requires a bearer token with `create` scope.
                 + `UR`
         - `description` (string, required) - Description, or tagline, for the movie.
         - `director` (string) - Name of the director.
-        - `genres` (string) - Array of movie genres.
+        - `genres` (array) - Array of movie genres.
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
         - `name` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
 + Response 200 (application/json)
     + Attributes
@@ -109,7 +115,9 @@ This action requires a bearer token with `create` scope.
         - `director` (string) - Director
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
+        - `kid_friendly` (boolean) - Kid friendly?
         - `name` (string) - Name
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Runtime
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in

--- a/resources/examples/Showtimes/blueprints/1.1.1/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.1/Movies.apib
@@ -28,7 +28,9 @@ Information on a specific movie.
             - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
+        - `kid_friendly` (boolean) - Kid friendly?
         - `name` (string) - Name
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Runtime
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
@@ -43,7 +45,7 @@ This action requires a bearer token with `edit` scope.
     + `id` (integer, required) - Movie ID
 + Request
     + Attributes
-        - `cast` (string) - Array of names of the cast.
+        - `cast` (array) - Array of names of the cast.
         - `content_rating` (enum[string]) - MPAA rating
             + Members
                 + `G`
@@ -56,9 +58,11 @@ This action requires a bearer token with `edit` scope.
                 + `UR`
         - `description` (string, required) - Description, or tagline, for the movie.
         - `director` (string) - Name of the director.
-        - `genres` (string) - Array of movie genres.
+        - `genres` (array) - Array of movie genres.
         - `imdb` (string) - IMDB URL
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
         - `name` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
         - `trailer` (string) - Trailer URL
 + Response 200 (application/json)
@@ -82,7 +86,9 @@ This action requires a bearer token with `edit` scope.
             - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
+        - `kid_friendly` (boolean) - Kid friendly?
         - `name` (string) - Name
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Runtime
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
@@ -129,7 +135,9 @@ Information on a specific movie.
             - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
+        - `kid_friendly` (boolean) - Kid friendly?
         - `name` (string) - Name
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Runtime
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
@@ -141,7 +149,7 @@ This action requires a bearer token with `create` scope.
 
 + Request
     + Attributes
-        - `cast` (string) - Array of names of the cast.
+        - `cast` (array) - Array of names of the cast.
         - `content_rating` (enum[string]) - MPAA rating
             + Members
                 + `G`
@@ -154,9 +162,11 @@ This action requires a bearer token with `create` scope.
                 + `UR`
         - `description` (string, required) - Description, or tagline, for the movie.
         - `director` (string) - Name of the director.
-        - `genres` (string) - Array of movie genres.
+        - `genres` (array) - Array of movie genres.
         - `imdb` (string) - IMDB URL
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
         - `name` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
         - `trailer` (string) - Trailer URL
 + Response 200 (application/json)
@@ -180,7 +190,9 @@ This action requires a bearer token with `create` scope.
             - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
+        - `kid_friendly` (boolean) - Kid friendly?
         - `name` (string) - Name
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Runtime
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in

--- a/resources/examples/Showtimes/blueprints/1.1/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.1/Movies.apib
@@ -28,7 +28,9 @@ Information on a specific movie.
             - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
+        - `kid_friendly` (boolean) - Kid friendly?
         - `name` (string) - Name
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Runtime
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
@@ -43,7 +45,7 @@ This action requires a bearer token with `edit` scope.
     + `id` (integer, required) - Movie ID
 + Request
     + Attributes
-        - `cast` (string) - Array of names of the cast.
+        - `cast` (array) - Array of names of the cast.
         - `content_rating` (enum[string]) - MPAA rating
             + Members
                 + `G`
@@ -56,8 +58,10 @@ This action requires a bearer token with `edit` scope.
                 + `UR`
         - `description` (string, required) - Description, or tagline, for the movie.
         - `director` (string) - Name of the director.
-        - `genres` (string) - Array of movie genres.
+        - `genres` (array) - Array of movie genres.
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
         - `name` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
         - `trailer` (string) - Trailer URL
 + Response 200 (application/json)
@@ -81,7 +85,9 @@ This action requires a bearer token with `edit` scope.
             - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
+        - `kid_friendly` (boolean) - Kid friendly?
         - `name` (string) - Name
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Runtime
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
@@ -128,7 +134,9 @@ Information on a specific movie.
             - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
+        - `kid_friendly` (boolean) - Kid friendly?
         - `name` (string) - Name
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Runtime
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in
@@ -140,7 +148,7 @@ This action requires a bearer token with `create` scope.
 
 + Request
     + Attributes
-        - `cast` (string) - Array of names of the cast.
+        - `cast` (array) - Array of names of the cast.
         - `content_rating` (enum[string]) - MPAA rating
             + Members
                 + `G`
@@ -153,9 +161,11 @@ This action requires a bearer token with `create` scope.
                 + `UR`
         - `description` (string, required) - Description, or tagline, for the movie.
         - `director` (string) - Name of the director.
-        - `genres` (string) - Array of movie genres.
+        - `genres` (array) - Array of movie genres.
         - `imdb` (string) - IMDB URL
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
         - `name` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Movie runtime, in `HHhr MMmin` format.
         - `trailer` (string) - Trailer URL
 + Response 200 (application/json)
@@ -179,7 +189,9 @@ This action requires a bearer token with `create` scope.
             - `trailer` (string) - Trailer URL
         - `genres` (array) - Genres
         - `id` (number) - Unique ID
+        - `kid_friendly` (boolean) - Kid friendly?
         - `name` (string) - Name
+        - `rotten_tomatoes_score` (number) - Rotten Tomatoes score
         - `runtime` (string) - Runtime
         - `showtimes` (array) - Non-theater specific showtimes
         - `theaters` (array) - Theaters the movie is currently showing in

--- a/src/Exceptions/Resource/Annotations/UnsupportedTypeException.php
+++ b/src/Exceptions/Resource/Annotations/UnsupportedTypeException.php
@@ -1,0 +1,30 @@
+<?php
+namespace Mill\Exceptions\Resource\Annotations;
+
+class UnsupportedTypeException extends \Exception
+{
+    use AnnotationExceptionTrait;
+
+    /**
+     * @param string $annotation
+     * @param string $class
+     * @param string $method
+     * @return UnsupportedTypeException
+     */
+    public static function create($annotation, $class, $method)
+    {
+        $message = sprintf(
+            'The type on `@api-param %s`in %s::%s is unsupported. Please check the documentation for supported types.',
+            $annotation,
+            $class,
+            $method
+        );
+
+        $exception = new self($message);
+        $exception->annotation = $annotation;
+        $exception->class = $class;
+        $exception->method = $method;
+
+        return $exception;
+    }
+}

--- a/src/Generator/Blueprint.php
+++ b/src/Generator/Blueprint.php
@@ -206,12 +206,13 @@ class Blueprint extends Generator
         /** @var ParamAnnotation $param */
         foreach ($params as $param) {
             $values = $param->getValues();
+            $type = $this->convertTypeToCompatibleType($param->getType());
 
             $blueprint .= $this->tab(2);
             $blueprint .= sprintf(
                 '- `%s` (%s%s) - %s',
                 $param->getField(),
-                (!empty($values)) ? 'enum[' . $param->getType() . ']' : 'string',
+                (!empty($values)) ? 'enum[' . $type . ']' : $type,
                 ($param->isRequired()) ? ', required' : null,
                 $param->getDescription()
             );
@@ -317,31 +318,8 @@ class Blueprint extends Generator
             if (isset($field['__FIELD_DATA__'])) {
                 /** @var array $data */
                 $data = $field['__FIELD_DATA__'];
-                switch ($data['type']) {
-                    case 'enum':
-                        $type = 'enum[string]';
-                        break;
+                $type = $this->convertTypeToCompatibleType($data['type']);
 
-                    // @todo set this to the name of the response and embed the full docs for that response type
-                    case 'representation':
-                        // https://apiblueprint.org/documentation/mson/specification.html#22-named-types
-                        $type = 'object'; //'<<@todo REPRESENTATION>>';
-                        break;
-
-                    // API Blueprint doesn't have support for dates, timestamps, or URI's, but we still want to
-                    // keep that metadata in our comments, so just convert these on the fly to strings so they
-                    // pass blueprint validation.
-                    case 'datetime':
-                    case 'timestamp':
-                    case 'uri':
-                        $type = 'string';
-                        break;
-
-                    default:
-                        $type = $data['type'];
-                }
-
-                //$blueprint .= $this->tab($indent);
                 $blueprint .= sprintf('- `%s` (%s) - %s', $field_name, $type, $data['label']);
                 $blueprint .= $this->line();
 
@@ -403,5 +381,43 @@ class Blueprint extends Generator
     protected function tab($repeat = 1)
     {
         return str_repeat('    ', $repeat);
+    }
+
+    /**
+     * Convert a Mill-supported documentation into an API Blueprint-compatible type.
+     *
+     * @link https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#2-types
+     * @param string $type
+     * @return string
+     */
+    private function convertTypeToCompatibleType($type)
+    {
+        switch ($type) {
+            case 'enum':
+                return 'enum[string]';
+                break;
+
+            // @todo set this to the name of the response and embed the full docs for that response type
+            case 'representation':
+                // https://apiblueprint.org/documentation/mson/specification.html#22-named-types
+                return 'object'; //'<<@todo REPRESENTATION>>';
+                break;
+
+            case 'integer':
+            case 'float':
+                return 'number';
+                break;
+
+            // API Blueprint doesn't have support for dates, timestamps, or URI's, but we still want to
+            // keep that metadata in our comments, so just convert these on the fly to strings so they
+            // pass blueprint validation.
+            case 'datetime':
+            case 'timestamp':
+            case 'uri':
+                return 'string';
+                break;
+        }
+
+        return $type;
     }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -252,7 +252,9 @@ class GeneratorTest extends TestCase
                             'director',
                             'genres',
                             'id',
+                            'kid_friendly',
                             'name',
+                            'rotten_tomatoes_score',
                             'runtime',
                             'showtimes',
                             'theaters',
@@ -293,7 +295,9 @@ class GeneratorTest extends TestCase
                                             'description',
                                             'director',
                                             'genres',
+                                            'is_kid_friendly',
                                             'name',
+                                            'rotten_tomatoes_score',
                                             'runtime'
                                         ]
                                     ]),
@@ -361,7 +365,9 @@ class GeneratorTest extends TestCase
                             'external_urls.trailer',
                             'genres',
                             'id',
+                            'kid_friendly',
                             'name',
+                            'rotten_tomatoes_score',
                             'runtime',
                             'showtimes',
                             'theaters',
@@ -402,7 +408,9 @@ class GeneratorTest extends TestCase
                                             'director',
                                             'genres',
                                             'imdb',
+                                            'is_kid_friendly',
                                             'name',
+                                            'rotten_tomatoes_score',
                                             'runtime',
                                             'trailer'
                                         ]
@@ -417,7 +425,9 @@ class GeneratorTest extends TestCase
                                             'description',
                                             'director',
                                             'genres',
+                                            'is_kid_friendly',
                                             'name',
+                                            'rotten_tomatoes_score',
                                             'runtime',
                                             'trailer'
                                         ]
@@ -483,7 +493,9 @@ class GeneratorTest extends TestCase
                             'external_urls.trailer',
                             'genres',
                             'id',
+                            'kid_friendly',
                             'name',
+                            'rotten_tomatoes_score',
                             'runtime',
                             'showtimes',
                             'theaters',
@@ -524,7 +536,9 @@ class GeneratorTest extends TestCase
                                             'director',
                                             'genres',
                                             'imdb',
+                                            'is_kid_friendly',
                                             'name',
+                                            'rotten_tomatoes_score',
                                             'runtime',
                                             'trailer'
                                         ]
@@ -540,7 +554,9 @@ class GeneratorTest extends TestCase
                                             'director',
                                             'genres',
                                             'imdb',
+                                            'is_kid_friendly',
                                             'name',
+                                            'rotten_tomatoes_score',
                                             'runtime',
                                             'trailer'
                                         ]

--- a/tests/Parser/Annotations/ParamAnnotationTest.php
+++ b/tests/Parser/Annotations/ParamAnnotationTest.php
@@ -76,7 +76,7 @@ class ParamAnnotationTest extends AnnotationTest
                     'description' => 'The page number to show.',
                     'field' => 'page',
                     'required' => false,
-                    'type' => 'int',
+                    'type' => 'integer',
                     'values' => false,
                     'version' => false,
                     'visible' => false
@@ -113,7 +113,7 @@ class ParamAnnotationTest extends AnnotationTest
                     'description' => 'The page number to show.',
                     'field' => 'page',
                     'required' => false,
-                    'type' => 'int',
+                    'type' => 'integer',
                     'values' => false,
                     'version' => false,
                     'visible' => true
@@ -150,7 +150,7 @@ class ParamAnnotationTest extends AnnotationTest
                     'description' => 'The page number to show.',
                     'field' => 'page',
                     'required' => false,
-                    'type' => 'int',
+                    'type' => 'integer',
                     'values' => false,
                     'version' => '1.1 - 1.2',
                     'visible' => true
@@ -185,6 +185,15 @@ class ParamAnnotationTest extends AnnotationTest
                     'getAnnotation' => 'param',
                     'getDocblock' => '__testing',
                     'getValues' => []
+                ]
+            ],
+            'missing-field-name' => [
+                'annotation' => '\Mill\Parser\Annotations\ParamAnnotation',
+                'docblock' => '{int} __testing',
+                'expected.exception' => '\Mill\Exceptions\Resource\Annotations\UnsupportedTypeException',
+                'expected.exception.asserts' => [
+                    'getAnnotation' => '{int} __testing',
+                    'getDocblock' => null
                 ]
             ],
             'values-are-in-the-wrong-format' => [

--- a/tests/Parser/Representation/DocumentationTest.php
+++ b/tests/Parser/Representation/DocumentationTest.php
@@ -148,12 +148,28 @@ class DocumentationTest extends TestCase
                             'type' => 'number',
                             'version' => false
                         ],
+                        'kid_friendly' => [
+                            'capability' => false,
+                            'field' => 'kid_friendly',
+                            'label' => 'Kid friendly?',
+                            'options' => false,
+                            'type' => 'boolean',
+                            'version' => false
+                        ],
                         'name' => [
                             'capability' => false,
                             'field' => 'name',
                             'label' => 'Name',
                             'options' => false,
                             'type' => 'string',
+                            'version' => false
+                        ],
+                        'rotten_tomatoes_score' => [
+                            'capability' => false,
+                            'field' => 'rotten_tomatoes_score',
+                            'label' => 'Rotten Tomatoes score',
+                            'options' => false,
+                            'type' => 'number',
                             'version' => false
                         ],
                         'runtime' => [
@@ -303,6 +319,16 @@ class DocumentationTest extends TestCase
                                 'version' => false
                             ]
                         ],
+                        'kid_friendly' => [
+                            '__FIELD_DATA__' => [
+                                'capability' => false,
+                                'field' => 'kid_friendly',
+                                'label' => 'Kid friendly?',
+                                'options' => false,
+                                'type' => 'boolean',
+                                'version' => false
+                            ]
+                        ],
                         'name' => [
                             '__FIELD_DATA__' => [
                                 'capability' => false,
@@ -310,6 +336,16 @@ class DocumentationTest extends TestCase
                                 'label' => 'Name',
                                 'options' => false,
                                 'type' => 'string',
+                                'version' => false
+                            ]
+                        ],
+                        'rotten_tomatoes_score' => [
+                            '__FIELD_DATA__' => [
+                                'capability' => false,
+                                'field' => 'rotten_tomatoes_score',
+                                'label' => 'Rotten Tomatoes score',
+                                'options' => false,
+                                'type' => 'number',
                                 'version' => false
                             ]
                         ],

--- a/tests/Parser/Representation/RepresentationParserTest.php
+++ b/tests/Parser/Representation/RepresentationParserTest.php
@@ -71,7 +71,9 @@ class RepresentationParserTest extends TestCase
             'external_urls.trailer',
             'genres',
             'id',
+            'kid_friendly',
             'name',
+            'rotten_tomatoes_score',
             'runtime',
             'showtimes',
             'theaters',
@@ -220,12 +222,28 @@ class RepresentationParserTest extends TestCase
                             'type' => 'number',
                             'version' => false
                         ],
+                        'kid_friendly' => [
+                            'capability' => false,
+                            'field' => 'kid_friendly',
+                            'label' => 'Kid friendly?',
+                            'options' => false,
+                            'type' => 'boolean',
+                            'version' => false
+                        ],
                         'name' => [
                             'capability' => false,
                             'field' => 'name',
                             'label' => 'Name',
                             'options' => false,
                             'type' => 'string',
+                            'version' => false
+                        ],
+                        'rotten_tomatoes_score' => [
+                            'capability' => false,
+                            'field' => 'rotten_tomatoes_score',
+                            'label' => 'Rotten Tomatoes score',
+                            'options' => false,
+                            'type' => 'number',
                             'version' => false
                         ],
                         'runtime' => [

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -265,6 +265,17 @@ class DocumentationTest extends TestCase
                                 'version' => false,
                                 'visible' => true
                             ],
+                            'is_kid_friendly' => [
+                                'capability' => false,
+                                'deprecated' => false,
+                                'description' => 'Is this movie kid friendly?',
+                                'field' => 'is_kid_friendly',
+                                'required' => false,
+                                'type' => 'boolean',
+                                'values' => false,
+                                'version' => false,
+                                'visible' => true
+                            ],
                             'name' => [
                                 'capability' => false,
                                 'deprecated' => false,
@@ -296,6 +307,17 @@ class DocumentationTest extends TestCase
                                 'type' => 'string',
                                 'values' => false,
                                 'version' => '>=1.1.1',
+                                'visible' => true
+                            ],
+                            'rotten_tomatoes_score' => [
+                                'capability' => false,
+                                'deprecated' => false,
+                                'description' => 'Rotten Tomatoes score',
+                                'field' => 'rotten_tomatoes_score',
+                                'required' => false,
+                                'type' => 'integer',
+                                'values' => false,
+                                'version' => false,
                                 'visible' => true
                             ],
                             'runtime' => [

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -147,7 +147,7 @@ class ParserTest extends TestCase
                     ],
                     'param' => [
                         'class' => '\Mill\Parser\Annotations\ParamAnnotation',
-                        'count' => 9
+                        'count' => 11
                     ],
                     'return' => [
                         'class' => '\Mill\Parser\Annotations\ReturnAnnotation',

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -53,8 +53,8 @@
     </capabilities>
 
     <parameterTokens>
-        <token name="page">{int} page (optional) The page number to show.</token>
-        <token name="per_page">{int} per_page (optional) Number of items to show on each page. Max 100.</token>
+        <token name="page">{integer} page (optional) The page number to show.</token>
+        <token name="per_page">{integer} per_page (optional) Number of items to show on each page. Max 100.</token>
         <token name="filter">{string} filter (optional) Filter to apply to the results.</token>
     </parameterTokens>
 


### PR DESCRIPTION
This does a few things:

* [x] Be more strict with the types in `@api-param` annotations that we support. 
  * Updated wiki: https://github.com/vimeo/mill/wiki/@api%E2%80%90param#supported-types
* [x] #44: Represent parameters as their actual type in Blueprint files, and not just as "string".
