### PR TITLE
Support for groups to be excluded Blueprint generation.

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -15,6 +15,8 @@
     <xs:group name="group.config">
         <xs:all>
             <xs:element name="versions" type="component.versions" minOccurs="1" maxOccurs="1" />
+            <xs:element name="generators" type="component.generators" minOccurs="0" maxOccurs="1" />
+
             <xs:element name="controllers" type="component.controllers" minOccurs="1" maxOccurs="1" />
             <xs:element name="representations" type="component.representations" minOccurs="1" maxOccurs="1" />
 
@@ -34,6 +36,28 @@
                 </xs:complexType>
             </xs:element>
         </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="component.generators">
+        <xs:sequence>
+            <xs:element name="blueprint">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="excludes" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="exclude" minOccurs="1" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:attribute name="group" type="xs:string" use="required" />
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="component.controllers">

--- a/src/Generator/Blueprint.php
+++ b/src/Generator/Blueprint.php
@@ -27,6 +27,7 @@ class Blueprint extends Generator
     {
         parent::generate();
 
+        $group_excludes = $this->config->getBlueprintGroupExcludes();
         $resources = $this->getResources();
 
         $blueprints = [];
@@ -38,6 +39,11 @@ class Blueprint extends Generator
 
             // Process resource groups.
             foreach ($groups as $group_name => $data) {
+                // If this group has been designated in the config file to be excluded, then exclude it.
+                if (in_array($group_name, $group_excludes)) {
+                    continue;
+                }
+
                 $contents = sprintf('# Group %s', $group_name);
                 $contents .= $this->line();
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -22,6 +22,10 @@ class ConfigTest extends TestCase
         ], $config->getApiVersions());
 
         $this->assertSame([
+            'FakeExcludeGroup'
+        ], $config->getBlueprintGroupExcludes());
+
+        $this->assertSame([
             'BUY_TICKETS',
             'MOVIE_RATINGS',
             'NONE'
@@ -141,7 +145,7 @@ XML;
         if (isset($exception_details['exception'])) {
             $this->expectException($exception_details['exception']);
         } else {
-            $this->expectException('\InvalidArgumentException');
+            $this->expectException('\DomainException');
             $this->expectExceptionMessageRegExp($exception_details['regex']);
         }
 
@@ -230,6 +234,7 @@ XML
             'versions.multiple-defaults' => [
                 'includes' => ['controllers', 'representations'],
                 'exception' => [
+                    'exception' => '\InvalidArgumentException',
                     'regex' => '/Multiple default API versions/'
                 ],
                 'xml' => <<<XML
@@ -241,12 +246,33 @@ XML
             ],
 
             /**
+             * <generators>
+             *
+             */
+            'generators.blueprint.exclude.invalid' => [
+                'includes' => ['versions', 'controllers', 'representations'],
+                'exception' => [
+                    'regex' => '/invalid Blueprint generator group/'
+                ],
+                'xml' => <<<XML
+<generators>
+    <blueprint>
+        <excludes>
+            <exclude group="" />
+        </excludes>
+    </blueprint>
+</generators>
+XML
+            ],
+
+            /**
              * <controllers>
              *
              */
             'controllers.directory.invalid' => [
                 'includes' => ['versions', 'representations'],
                 'exception' => [
+                    'exception' => 'InvalidArgumentException',
                     'regex' => '/does not exist/'
                 ],
                 'xml' => <<<XML
@@ -261,6 +287,7 @@ XML
             'controllers.none-found' => [
                 'includes' => ['versions', 'representations'],
                 'exception' => [
+                    'exception' => '\InvalidArgumentException',
                     'regex' => '/requires a set of controllers/'
                 ],
                 'xml' => <<<XML
@@ -275,6 +302,7 @@ XML
             'controllers.class.uncallable' => [
                 'includes' => ['versions', 'representations'],
                 'exception' => [
+                    'exception' => '\InvalidArgumentException',
                     'regex' => '/could not be called/'
                 ],
                 'xml' => <<<XML
@@ -293,6 +321,7 @@ XML
             'representations.none-found' => [
                 'includes' => ['versions', 'controllers'],
                 'exception' => [
+                    'exception' => '\InvalidArgumentException',
                     'regex' => '/requires a set of representations/'
                 ],
                 'xml' => <<<XML
@@ -335,6 +364,7 @@ XML
             'representations.directory.invalid' => [
                 'includes' => ['versions', 'controllers'],
                 'exception' => [
+                    'exception' => '\InvalidArgumentException',
                     'regex' => '/does not exist/'
                 ],
                 'xml' => <<<XML

--- a/tests/Generator/BlueprintTest.php
+++ b/tests/Generator/BlueprintTest.php
@@ -47,4 +47,25 @@ class BlueprintTest extends TestCase
             }
         }
     }
+
+    public function testGenerationWithAnExcludedGroup()
+    {
+        $this->getConfig()->addBlueprintGroupExclude('Movies');
+
+        $blueprint = new Blueprint($this->getConfig());
+        $generated = $blueprint->generate();
+
+        $this->assertSame([
+            '1.0',
+            '1.1',
+            '1.1.1'
+        ], array_keys($generated));
+
+        foreach ($generated as $version => $section) {
+            $this->assertArrayNotHasKey('Movies', $section['groups']);
+            $this->assertArrayHasKey('Theaters', $section['groups']);
+        }
+
+        $this->getConfig()->removeBlueprintGroupExclude('Movies');
+    }
 }

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -9,6 +9,16 @@
         <version name="1.1.1" default="true" />
     </versions>
 
+    <generators>
+        <blueprint>
+            <excludes>
+                <!-- This is here just for code coverage purposes, and to verify that we're able to exclude resource
+                    groups when loading a config XML file. -->
+                <exclude group="FakeExcludeGroup" />
+            </excludes>
+        </blueprint>
+    </generators>
+
     <controllers>
         <filter>
             <directory name="resources/examples/Showtimes/Controllers/" suffix=".php" />


### PR DESCRIPTION
* [x] Add support for configuring specific groups to be excluded from API Blueprint generation (regardless of their visibility).
* [x] Restructured some exceptions being thrown in the Config system from `InvalidArgumentException` to the more syntactically correct, for their use cases, `DomainException`.

Resolves #31.