### PR TITLE
Extract common value/option parsing logic, and trim whitespace. 

### DIFF
--- a/src/Exceptions/Resource/Annotations/BadOptionsListException.php
+++ b/src/Exceptions/Resource/Annotations/BadOptionsListException.php
@@ -7,16 +7,18 @@ class BadOptionsListException extends \Exception
 
     /**
      * @param string $annotation
+     * @param string $docblock
      * @param array $values
      * @param string $class
      * @param string $method
      * @return BadOptionsListException
      */
-    public static function create($annotation, array $values, $class, $method)
+    public static function create($annotation, $docblock, array $values, $class, $method)
     {
         $message = sprintf(
-            'The options list on `@api-param %s`in %s::%s should written as `[%s]`, not `[%s]`.',
+            'The options list on `@api-%s %s`in %s::%s should written as `[%s]`, not `[%s]`.',
             $annotation,
+            $docblock,
             $class,
             $method,
             preg_replace("/,( )?/uim", "|", implode(',', $values)),
@@ -25,6 +27,7 @@ class BadOptionsListException extends \Exception
 
         $exception = new self($message);
         $exception->annotation = $annotation;
+        $exception->docblock = $docblock;
         $exception->values = $values;
         $exception->class = $class;
         $exception->method = $method;

--- a/src/Parser/Annotation.php
+++ b/src/Parser/Annotation.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mill\Parser;
 
+use Mill\Exceptions\Resource\Annotations\BadOptionsListException;
 use Mill\Exceptions\Resource\Annotations\MissingRequiredFieldException;
 
 /**
@@ -222,6 +223,41 @@ abstract class Annotation
     public function supportsDeprecation()
     {
         return static::SUPPORTS_DEPRECATION;
+    }
+
+    /**
+     * Given our common format for describing enumerated values, parse it out and run validation.
+     *
+     * @param string $annotation
+     * @param string $values
+     * @return array
+     * @throws BadOptionsListException If the enum values were not written in the proper format.
+     */
+    public function parseEnumValues($annotation, $values)
+    {
+        $values = explode('|', $values);
+        if (!empty($values)) {
+            foreach ($values as $k => $value) {
+                if (strpos($value, ',') !== false) {
+                    throw BadOptionsListException::create(
+                        $annotation,
+                        $this->docblock,
+                        $values,
+                        $this->controller,
+                        $this->method
+                    );
+                }
+
+                // Values might be on multiple lines, or be surrounded with whitespace to make them easier to read,
+                // so let's clean them up a bit.
+                $values[$k] = trim($value);
+            }
+
+            // Keep the array of values alphabetical so it's cleaner when generated into documentation.
+            sort($values);
+        }
+
+        return $values;
     }
 
     /**

--- a/src/Parser/Annotations/FieldAnnotation.php
+++ b/src/Parser/Annotations/FieldAnnotation.php
@@ -142,10 +142,7 @@ class FieldAnnotation extends Annotation
                 // `@api-options`
                 case 'options':
                     if (preg_match(self::OPTIONS_PATTERN, $data, $options_matches)) {
-                        $parsed['options'] = array_filter(explode('|', $options_matches[1]));
-
-                        // Keep the array of options alphabetical so it's cleaner when generated into documentation.
-                        sort($parsed['options']);
+                        $parsed['options'] = $this->parseEnumValues('field', $options_matches[1]);
                     }
                     break;
 

--- a/src/Parser/Annotations/ParamAnnotation.php
+++ b/src/Parser/Annotations/ParamAnnotation.php
@@ -138,23 +138,7 @@ class ParamAnnotation extends Annotation
 
         // Parameter values are provided `[in|braces]`.
         if (preg_match(self::REGEX_VALUES, $doc, $matches)) {
-            $parsed['values'] = explode('|', substr($matches[1], 1, -1));
-            if (!empty($parsed['values'])) {
-                foreach ($parsed['values'] as $value) {
-                    if (strpos($value, ',') !== false) {
-                        throw BadOptionsListException::create(
-                            $this->docblock,
-                            $parsed['values'],
-                            $this->controller,
-                            $this->method
-                        );
-                    }
-                }
-            }
-
-            // Keep the array of values alphabetical so it's cleaner when generated into documentation.
-            sort($parsed['values']);
-
+            $parsed['values'] = $this->parseEnumValues('param', substr($matches[1], 1, -1));
             $doc = trim(preg_replace(self::REGEX_VALUES, '', $doc));
         }
 

--- a/src/Parser/Annotations/UriSegmentAnnotation.php
+++ b/src/Parser/Annotations/UriSegmentAnnotation.php
@@ -61,20 +61,7 @@ class UriSegmentAnnotation extends ParamAnnotation
 
         // Parameter values are provided `[in|braces]`.
         if (preg_match(self::REGEX_VALUES, $doc, $matches)) {
-            $parsed['values'] = explode('|', substr($matches[1], 1, -1));
-            if (!empty($parsed['values'])) {
-                foreach ($parsed['values'] as $value) {
-                    if (strpos($value, ',') !== false) {
-                        throw BadOptionsListException::create(
-                            $this->docblock,
-                            $parsed['values'],
-                            $this->controller,
-                            $this->method
-                        );
-                    }
-                }
-            }
-
+            $parsed['values'] = $this->parseEnumValues('options', substr($matches[1], 1, -1));
             $doc = trim(preg_replace(self::REGEX_VALUES, '', $doc));
         }
 

--- a/tests/Parser/Annotations/FieldAnnotationTest.php
+++ b/tests/Parser/Annotations/FieldAnnotationTest.php
@@ -148,6 +148,13 @@ class FieldAnnotationTest extends AnnotationTest
      */
     public function providerAnnotationFailsOnInvalidAnnotations()
     {
+        $bad_values_docblock = '/**
+         * @api-label MPAA rating
+         * @api-field content_rating
+         * @api-type enum
+         * @api-options [G,PG-13]
+         */';
+
         return [
             'invalid-type-is-detected' => [
                 'annotation' => '\Mill\Parser\Annotations\FieldAnnotation',
@@ -170,6 +177,19 @@ class FieldAnnotationTest extends AnnotationTest
                     */',
                 'expected.exception' => '\Mill\Exceptions\Representation\RestrictedFieldNameException',
                 'expected.exception.asserts' => []
+            ],
+            'values-are-in-the-wrong-format' => [
+                'annotation' => '\Mill\Parser\Annotations\FieldAnnotation',
+                'docblock' => $bad_values_docblock,
+                'expected.exception' => '\Mill\Exceptions\Resource\Annotations\BadOptionsListException',
+                'expected.exception.asserts' => [
+                    'getRequiredField' => null,
+                    'getAnnotation' => 'field',
+                    'getDocblock' => $bad_values_docblock,
+                    'getValues' => [
+                        'G,PG-13'
+                    ]
+                ]
             ]
         ];
     }

--- a/tests/Parser/Annotations/ParamAnnotationTest.php
+++ b/tests/Parser/Annotations/ParamAnnotationTest.php
@@ -202,8 +202,8 @@ class ParamAnnotationTest extends AnnotationTest
                 'expected.exception' => '\Mill\Exceptions\Resource\Annotations\BadOptionsListException',
                 'expected.exception.asserts' => [
                     'getRequiredField' => null,
-                    'getAnnotation' => '{string} __testing [true,false] Because reasons',
-                    'getDocblock' => null,
+                    'getAnnotation' => 'param',
+                    'getDocblock' => '{string} __testing [true,false] Because reasons',
                     'getValues' => [
                         'true,false'
                     ]

--- a/tests/Parser/Annotations/UriSegmentAnnotationTest.php
+++ b/tests/Parser/Annotations/UriSegmentAnnotationTest.php
@@ -107,9 +107,9 @@ class UriSegmentAnnotationTest extends AnnotationTest
                 'expected.exception' => '\Mill\Exceptions\Resource\Annotations\BadOptionsListException',
                 'expected.exception.asserts' => [
                     'getRequiredField' => null,
-                    'getAnnotation' => '{/movies/+id/showtimes/*date} {string} date [today,tomorrow] Date to look ' .
+                    'getAnnotation' => 'options',
+                    'getDocblock' => '{/movies/+id/showtimes/*date} {string} date [today,tomorrow] Date to look ' .
                         'for movie showtimes.',
-                    'getDocblock' => null,
                     'getValues' => [
                         'today,tomorrow'
                     ]


### PR DESCRIPTION
* [x] Extracts common enum value/option parsing logic, so we don't have variations of  the same code in three places.
* [x] Adds enum format validation to the `@api-options` annotation parsing.
* [x] Trims away any unnecessary whitespace that may be present on enum values.

Fixes #51