### PR TITLE
Restricting the parameter annotation enum values regex. #53

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -35,5 +35,12 @@
                 <directory name="tests/" />
             </errorLevel>
         </MissingReturnType>
+
+        <PossiblyInvalidArgument>
+            <errorLevel type="suppress">
+                <!-- Masking errors where we're passing methods that return object|bool into test assertions. -->
+                <directory name="tests/" />
+            </errorLevel>
+        </PossiblyInvalidArgument>
     </issueHandlers>
 </psalm>

--- a/src/Parser/Annotations/ParamAnnotation.php
+++ b/src/Parser/Annotations/ParamAnnotation.php
@@ -19,7 +19,7 @@ class ParamAnnotation extends Annotation
 
     const REGEX_TYPE = '/^({[^}]*})/';
     const REGEX_OPTIONAL = '/(\(optional\))/';
-    const REGEX_VALUES = '/(\[[^\]]*\])/';
+    const REGEX_VALUES = '/(\[[^\]]*\])(\ |$)/';
 
     /**
      * Name of this parameter's field.

--- a/tests/Parser/Annotations/ParamAnnotationTest.php
+++ b/tests/Parser/Annotations/ParamAnnotationTest.php
@@ -155,6 +155,60 @@ class ParamAnnotationTest extends AnnotationTest
                     'version' => '1.1 - 1.2',
                     'visible' => true
                 ]
+            ],
+            '_complete' => [
+                'param' => '{string} content_rating [G|PG|PG-13|R|NC-17|X|NR|UR] (optional) +MOVIE_RATINGS+ ' .
+                    'MPAA rating',
+                'version' => null,
+                'visible' => true,
+                'deprecated' => false,
+                'expected' => [
+                    'capability' => 'MOVIE_RATINGS',
+                    'deprecated' => false,
+                    'description' => 'MPAA rating',
+                    'field' => 'content_rating',
+                    'required' => false,
+                    'type' => 'string',
+                    'values' => [
+                        'G',
+                        'NC-17',
+                        'NR',
+                        'PG',
+                        'PG-13',
+                        'R',
+                        'UR',
+                        'X'
+                    ],
+                    'version' => false,
+                    'visible' => true
+                ]
+            ],
+            '_complete.with-markdown-description' => [
+                'param' => '{string} content_rating [G|PG|PG-13|R|NC-17|X|NR|UR] (optional) +MOVIE_RATINGS+ ' .
+                    '[MPAA rating](http://www.mpaa.org/film-ratings/)',
+                'version' => null,
+                'visible' => true,
+                'deprecated' => false,
+                'expected' => [
+                    'capability' => 'MOVIE_RATINGS',
+                    'deprecated' => false,
+                    'description' => '[MPAA rating](http://www.mpaa.org/film-ratings/)',
+                    'field' => 'content_rating',
+                    'required' => false,
+                    'type' => 'string',
+                    'values' => [
+                        'G',
+                        'NC-17',
+                        'NR',
+                        'PG',
+                        'PG-13',
+                        'R',
+                        'UR',
+                        'X'
+                    ],
+                    'version' => false,
+                    'visible' => true
+                ]
             ]
         ];
     }


### PR DESCRIPTION
This restricts the `@api-param` annotation enum values regex so it no longer attempts to match any Markdown content present in descriptions.

Resolves. #53 

![screen shot 2017-04-12 at 5 17 27 pm](https://cloud.githubusercontent.com/assets/33762/24981260/f4500e5a-1fa9-11e7-8065-475a1995ea05.png)