### PR TITLE
`@api-see` now has support for static/self targets. 

### DIFF
--- a/resources/examples/Showtimes/Representations/Movie.php
+++ b/resources/examples/Showtimes/Representations/Movie.php
@@ -86,7 +86,7 @@ class Movie extends Representation
             /**
              * @api-data external_urls (object) - External URLs
              * @api-version >=1.1
-             * @api-see \Mill\Examples\Showtimes\Representations\Movie::getExternalUrls external_urls
+             * @api-see self::getExternalUrls external_urls
              */
             'external_urls' => $this->getExternalUrls(),
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -923,6 +923,7 @@ class Config
      */
     private function getClassFQNFromFile($file)
     {
+        /** @var resource $fp */
         $fp = fopen($file, 'r');
         $class = $namespace = $buffer = '';
         $i = 0;

--- a/src/Parser/Representation/RepresentationParser.php
+++ b/src/Parser/Representation/RepresentationParser.php
@@ -110,6 +110,10 @@ class RepresentationParser extends Parser
         // If we matched an `@api-see` annotation, then let's parse it out into viable annotations.
         if (!empty($has_see)) {
             list($see_class, $see_method) = explode('::', array_shift($has_see));
+            if (in_array(strtolower($see_class), ['self', 'static'])) {
+                $see_class = $this->class;
+            }
+
             $prefix = array_shift($has_see);
 
             $parser = new self($see_class);

--- a/tests/_fixtures/Representations/RepresentationWithOnlyApiSee.php
+++ b/tests/_fixtures/Representations/RepresentationWithOnlyApiSee.php
@@ -1,6 +1,8 @@
 <?php
 namespace Mill\Tests\Fixtures\Representations;
 
+use Mill\Examples\Showtimes\Representations\Movie;
+
 /**
  * @api-label RepresentationWithOnlyApiSee
  */
@@ -11,5 +13,6 @@ class RepresentationWithOnlyApiSee
         /**
          * @api-see \Mill\Examples\Showtimes\Representations\Movie::create
          */
+        return (new Movie())->create();
     }
 }


### PR DESCRIPTION
This adds support to `@api-see` for `static` and `self` targets. 

```
/**
 * @api-data external_urls (object) - External URLs
 * @api-version >=1.1
 * @api-see self::getExternalUrls external_urls
 */
```

Versus having to pass the full FQN:

```
/**
 * @api-data external_urls (object) - External URLs
 * @api-version >=1.1
 * @api-see \Vimeo\Mill\Examples\Showtimes\Movie::getExternalUrls external_urls
 */
```

Resolves #66