### PR TITLE
Adding support for multiple `@api-data` annotations in a single docblock

### DIFF
--- a/resources/examples/Showtimes/Representations/Movie.php
+++ b/resources/examples/Showtimes/Representations/Movie.php
@@ -102,20 +102,14 @@ class Movie extends Representation
      */
     private function getExternalUrls()
     {
+        /**
+         * @api-data imdb (string) - IMDB URL
+         * @api-data trailer (string) - Trailer URL
+         * @api-data tickets (string, BUY_TICKETS) - Tickets URL
+         */
         return [
-            /**
-             * @api-data imdb (string) - IMDB URL
-             */
             'imdb' => $this->movie->imdb,
-
-            /**
-             * @api-data trailer (string) - Trailer URL
-             */
             'trailer' => $this->movie->trailer,
-
-            /**
-             * @api-data tickets (string, BUY_TICKETS) - Tickets URL
-             */
             'tickets' => $this->movie->tickets_url
         ];
     }

--- a/src/Parser/Representation/RepresentationParser.php
+++ b/src/Parser/Representation/RepresentationParser.php
@@ -77,9 +77,7 @@ class RepresentationParser extends Parser
     {
         $has_see = [];
         $annotations = [];
-
-        /** @var string|false $has_content */
-        $has_content = false;
+        $data = [];
 
         /** @var Version|null $has_version */
         $has_version = null;
@@ -90,11 +88,10 @@ class RepresentationParser extends Parser
             $annotation = $this->getAnnotationNameFromTag($tag);
             $content = $tag->getDescription();
             $content = trim($content);
-            //$decorators = null;
 
             switch ($annotation) {
                 case 'data':
-                    $has_content = $content;
+                    $data[] = $content;
                     break;
 
                 case 'see':
@@ -138,12 +135,14 @@ class RepresentationParser extends Parser
         }
 
         // If we don't have any `@api-data` content, then don't bother setting up a DataAnnotation.
-        if (empty($has_content)) {
+        if (empty($data)) {
             return $annotations;
         }
 
-        $annotation = new DataAnnotation($has_content, $this->class, $this->method, $has_version);
-        $annotations[$annotation->getIdentifier()] = $annotation;
+        foreach ($data as $content) {
+            $annotation = new DataAnnotation($content, $this->class, $this->method, $has_version);
+            $annotations[$annotation->getIdentifier()] = $annotation;
+        }
 
         return $annotations;
     }


### PR DESCRIPTION
This adds support for having multiple `@api-data` annotations within a single docblock. Previously if you wanted to document multiple datapoints, you had to do it as:

```
/**
 * @api-data imdb (string) - IMDB URL
 */
/**
 * @api-data trailer (string) - Trailer URL
 */
/**
 * @api-data tickets (string, BUY_TICKETS) - Tickets URL
 */
```

Now you can write:

```
/**
 * @api-data imdb (string) - IMDB URL
 * @api-data trailer (string) - Trailer URL
 * @api-data tickets (string, BUY_TICKETS) - Tickets URL
 */
```

As is standard with `@api-data` annotations, any `@api-version` annotation that exists within the same docblock is applied to all `@api-data` annotations alongside it:

```
// `imdb`, `trailer`, and `tickets` datapoints are now locked to version 3.0.
/**
 * @api-data imdb (string) - IMDB URL
 * @api-data trailer (string) - Trailer URL
 * @api-data tickets (string, BUY_TICKETS) - Tickets URL
 * @api-version 3.0
 */
```