### PR TITLE
Representations with enum subtypes now have their enums in Blueprints.

### DIFF
--- a/src/Generator/Blueprint.php
+++ b/src/Generator/Blueprint.php
@@ -419,7 +419,9 @@ class Blueprint extends Generator
                 $blueprint .= $this->line();
 
                 // Only enum's support options/members.
-                if ($data['type'] === 'enum' && !empty($data['values'])) {
+                if (($data['type'] === 'enum' || (isset($data['subtype']) && $data['subtype'] === 'enum')) &&
+                    !empty($data['values'])
+                ) {
                     $blueprint .= $this->tab($indent + 1);
                     $blueprint .= '+ Members';
                     $blueprint .= $this->line();


### PR DESCRIPTION
This fixes a bug in generated API Blueprint files where representations that had `enum` subtypes weren't having their documented enums in the generated file.

Resolves #85 