### PR TITLE
Adding a `lint` command for quickly running validation on your app.

### DIFF
--- a/bin/mill
+++ b/bin/mill
@@ -18,5 +18,6 @@ $application->setName('Mill');
 $application->setVersion('1.0.0');
 
 $application->add(new Mill\Command\Generate);
+$application->add(new Mill\Command\Lint);
 
 $application->run();

--- a/src/Command/Lint.php
+++ b/src/Command/Lint.php
@@ -1,0 +1,55 @@
+<?php
+namespace Mill\Command;
+
+use Mill\Container;
+use Mill\Generator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Lint command for running validation checks against your Mill documentation.
+ *
+ */
+class Lint extends Command
+{
+    /**
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->setName('lint')
+            ->setDescription('Lint your documentation for any validation issues.')
+            ->addOption(
+                'config',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Path to your `mill.xml` config file.',
+                'mill.xml'
+            );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $style = new OutputFormatterStyle('green', null, ['bold']);
+        $output->getFormatter()->setStyle('success', $style);
+
+        // @todo This should be pulled from the core Application instead, so we can inject the dependency in tests.
+        $container = new Container([
+            'config.path' => realpath($input->getOption('config'))
+        ]);
+
+        $output->writeln('<comment>Linting your API documentation…</comment>');
+        $generator = new Generator($container['config']);
+        $generator->generate();
+
+        $output->writeln('<success>No errors found.</success>');
+    }
+}

--- a/tests/Command/GenerateTest.php
+++ b/tests/Command/GenerateTest.php
@@ -33,7 +33,7 @@ class GenerateTest extends \PHPUnit_Framework_TestCase
         $this->config_file = __DIR__ . '/../../resources/examples/mill.xml';
     }
 
-    public function testGenerate()
+    public function testCommand()
     {
         $output_dir = tempnam(sys_get_temp_dir(), 'mill-generate-test-');
         if (file_exists($output_dir)) {
@@ -97,7 +97,7 @@ class GenerateTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testGenerateWithDryRun()
+    public function testCommandWithDryRun()
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -128,7 +128,7 @@ class GenerateTest extends \PHPUnit_Framework_TestCase
         $this->assertContains('API version: 1.1', $output);
     }
 
-    public function testGenerateWithSpecificConstraint()
+    public function testCommandWithSpecificConstraint()
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -148,7 +148,7 @@ class GenerateTest extends \PHPUnit_Framework_TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The supplied Mill configuration file does not exist.
      */
-    public function testGenerateFailsOnInvalidConfigFile()
+    public function testCommandFailsOnInvalidConfigFile()
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -156,7 +156,7 @@ class GenerateTest extends \PHPUnit_Framework_TestCase
         ]);
     }
 
-    public function testGenerateFailsOnInvalidVersionConstraint()
+    public function testCommandFailsOnInvalidVersionConstraint()
     {
         $this->tester->execute([
             'command' => $this->command->getName(),

--- a/tests/Command/LintTest.php
+++ b/tests/Command/LintTest.php
@@ -1,0 +1,59 @@
+<?php
+namespace Mill\Tests\Command;
+
+use Mill\Command\Lint;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class LintTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Symfony\Component\Console\Command\Command
+     */
+    protected $command;
+
+    /**
+     * @var CommandTester
+     */
+    protected $tester;
+
+    /**
+     * @var string
+     */
+    protected $config_file;
+
+    public function setUp()
+    {
+        $application = new Application();
+        $application->add(new Lint);
+
+        $this->command = $application->find('lint');
+        $this->tester = new CommandTester($this->command);
+
+        $this->config_file = __DIR__ . '/../../resources/examples/mill.xml';
+    }
+
+    public function testCommand()
+    {
+        $this->tester->execute([
+            'command' => $this->command->getName(),
+            '--config' => $this->config_file
+        ]);
+
+        $output = $this->tester->getDisplay();
+
+        $this->assertNotContains('Exceptions', $output);
+        $this->assertContains('No errors found.', $output);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The supplied Mill configuration file does not exist.
+     */
+    public function testCommandFailsOnInvalidConfigFile()
+    {
+        $this->tester->execute([
+            'command' => $this->command->getName()
+        ]);
+    }
+}


### PR DESCRIPTION
This adds a new `lint` command for quickly running validation on your application's documentation.

If there are any exceptions, they will be spit out immediately:

```
$ ./bin/mill lint  --config=resources/examples/mill.xml
Linting your API documentation…

                                                                                                                  
  [Mill\Exceptions\Representation\DuplicateFieldException]                                                        
  `runtime` has been found twice in \Mill\Examples\Showtimes\Representations\Movie::create. This is not allowed.  
                                                                                                                  

lint [--config [CONFIG]]

```

Resolves #39 