### PR TITLE
Upgrading the library requirement to PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - '5.6'
-  - '7.0'
   - '7.1'
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -15,20 +15,20 @@
     "minimum-stability": "stable",
     "bin": ["bin/mill"],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.1.0",
         "ext-xml": "*",
         "dflydev/dot-access-data": "^1.0",
-        "symfony/console": "^2.8",
         "pimple/pimple": "^3.0",
         "league/flysystem": "^1.0",
         "composer/semver": "^1.4",
-        "gossi/docblock": "^1.5"
+        "gossi/docblock": "^1.5",
+        "symfony/console": "^3.2"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^2.7",
-        "phpunit/phpunit": "^5.5",
-        "vimeo/psalm": "^0.2",
-        "league/flysystem-memory": "^1.0"
+        "league/flysystem-memory": "^1.0",
+        "vimeo/psalm": "^0.3",
+        "squizlabs/php_codesniffer": "^3.0",
+        "phpunit/phpunit": "^6.1"
     },
     "suggest": {
         "ext-xml": "Required for config file processing."

--- a/tests/Command/GenerateTest.php
+++ b/tests/Command/GenerateTest.php
@@ -5,7 +5,7 @@ use Mill\Command\Generate;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class GenerateTest extends \PHPUnit_Framework_TestCase
+class GenerateTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Symfony\Component\Console\Command\Command

--- a/tests/Parser/AnnotationTest.php
+++ b/tests/Parser/AnnotationTest.php
@@ -4,7 +4,7 @@ namespace Mill\Parser;
 use Mill\Exceptions\Annotations\MissingRequiredFieldException;
 use Mill\Tests\Fixtures\AnnotationStub;
 
-class AnnotationTest extends \PHPUnit_Framework_TestCase
+class AnnotationTest extends \PHPUnit\Framework\TestCase
 {
     public function testAnnotationFailsIfARequiredFieldWasNotSuppliedToRequired()
     {

--- a/tests/Parser/VersionTest.php
+++ b/tests/Parser/VersionTest.php
@@ -10,7 +10,7 @@ use Mill\Parser\Version;
  *
  * @link https://github.com/composer/semver
  */
-class VersionTest extends \PHPUnit_Framework_TestCase
+class VersionTest extends \PHPUnit\Framework\TestCase
 {
     public function testParse()
     {

--- a/tests/Provider/ConfigTest.php
+++ b/tests/Provider/ConfigTest.php
@@ -6,7 +6,7 @@ use Mill\Provider\Config;
 use Mill\Provider\Filesystem;
 use Pimple\Container;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends \PHPUnit\Framework\TestCase
 {
     public function testRegister()
     {

--- a/tests/Provider/FilesystemTest.php
+++ b/tests/Provider/FilesystemTest.php
@@ -4,7 +4,7 @@ namespace Mill\Tests\Provider;
 use Mill\Provider\Filesystem;
 use Pimple\Container;
 
-class FilesystemTest extends \PHPUnit_Framework_TestCase
+class FilesystemTest extends \PHPUnit\Framework\TestCase
 {
     public function testRegister()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,7 +9,7 @@ use Mill\Parser;
 use Mill\Parser\Annotations\DataAnnotation;
 use Mill\Parser\Representation\RepresentationParser;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Container


### PR DESCRIPTION
This upgrades the PHP requirement for Mill to PHP 7.1, as well as upgrading the libraries we use of [Console](https://packagist.org/packages/symfony/console), [Psalm](https://packagist.org/packages/vimeo/psalm), [PHPCS](https://packagist.org/packages/squizlabs/php_codesniffer), and [PHPUnit](https://packagist.org/packages/phpunit/phpunit) to 7.1-compatible releases.

Resolves https://github.com/vimeo/mill/issues/13