### PR TITLE
Scopes attached to representation data now cascade down.

### DIFF
--- a/src/Parser/Representation/RepresentationParser.php
+++ b/src/Parser/Representation/RepresentationParser.php
@@ -68,7 +68,7 @@ class RepresentationParser extends Parser
             // Run through all created annotations and cascade any versioning down into any present child annotations.
             /** @var DataAnnotation $annotation */
             foreach ($annotations as $identifier => $annotation) {
-                if (!$annotation->getVersion() && !$annotation->getCapability()) {
+                if (!$annotation->getVersion() && !$annotation->getCapability() && !$annotation->getScopes()) {
                     continue;
                 }
 
@@ -210,6 +210,9 @@ class RepresentationParser extends Parser
         $parent_identifier = $parent->getIdentifier();
         $parent_version = $parent->getVersion();
 
+        /** @var array<ScopeAnnotation> $parent_scopes */
+        $parent_scopes = $parent->getScopes();
+
         /** @var string $parent_capability */
         $parent_capability = $parent->getCapability();
 
@@ -230,6 +233,10 @@ class RepresentationParser extends Parser
 
             if (!empty($parent_capability) && !$annotation->getCapability()) {
                 $annotation->setCapability($parent_capability);
+            }
+
+            if (!empty($parent_scopes) && !$annotation->getScopes()) {
+                $annotation->setScopes($parent_scopes);
             }
         }
     }

--- a/tests/Parser/Representation/RepresentationParserTest.php
+++ b/tests/Parser/Representation/RepresentationParserTest.php
@@ -149,17 +149,27 @@ class RepresentationParserTest extends TestCase
             'unrelated'
         ], array_keys($annotations));
 
-        $this->assertSame('>=3.3', $annotations['connections']->toArray()['version']);
-        $this->assertSame('>=3.3', $annotations['connections.things']->toArray()['version']);
-        $this->assertSame('>=3.3', $annotations['connections.things.name']->toArray()['version']);
-        $this->assertSame('3.4', $annotations['connections.things.uri']->toArray()['version']);
-        $this->assertEmpty($annotations['unrelated']->toArray()['version']);
+        $annotations = array_map(function ($annotation) {
+            return $annotation->toArray();
+        }, $annotations);
 
-        $this->assertEmpty($annotations['connections']->toArray()['capability']);
-        $this->assertSame('NONE', $annotations['connections.things']->toArray()['capability']);
-        $this->assertSame('MOVIE_RATINGS', $annotations['connections.things.name']->toArray()['capability']);
-        $this->assertSame('NONE', $annotations['connections.things.uri']->toArray()['capability']);
-        $this->assertEmpty($annotations['unrelated']->toArray()['version']);
+        $this->assertEmpty($annotations['connections']['capability']);
+        $this->assertSame('NONE', $annotations['connections.things']['capability']);
+        $this->assertSame('MOVIE_RATINGS', $annotations['connections.things.name']['capability']);
+        $this->assertSame('NONE', $annotations['connections.things.uri']['capability']);
+        $this->assertEmpty($annotations['unrelated']['capability']);
+
+        $this->assertSame('>=3.3', $annotations['connections']['version']);
+        $this->assertSame('>=3.3', $annotations['connections.things']['version']);
+        $this->assertSame('>=3.3', $annotations['connections.things.name']['version']);
+        $this->assertSame('3.4', $annotations['connections.things.uri']['version']);
+        $this->assertEmpty($annotations['unrelated']['version']);
+
+        $this->assertEmpty($annotations['connections']['scopes']);
+        $this->assertSame('public', $annotations['connections.things']['scopes'][0]['scope']);
+        $this->assertSame('public', $annotations['connections.things.name']['scopes'][0]['scope']);
+        $this->assertSame('public', $annotations['connections.things.uri']['scopes'][0]['scope']);
+        $this->assertEmpty($annotations['unrelated']['scopes']);
     }
 
     /**

--- a/tests/_fixtures/Representations/RepresentationWithVersioningAcrossMultipleAnnotations.php
+++ b/tests/_fixtures/Representations/RepresentationWithVersioningAcrossMultipleAnnotations.php
@@ -19,6 +19,7 @@ class RepresentationWithVersioningAcrossMultipleAnnotations
 
         /**
          * @api-data connections.things (object, NONE) - Information about this thing.
+         * @api-scope public
          * @api-see self::someMethod connections.things
          */
     }


### PR DESCRIPTION
This fixes a bug with `@api-scope` annotations on `@api-data` where they weren't cascading down into dot-notation children.