### PR TITLE
Running a Composer clear-cache before install in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
     - ./vendor
 
 install:
+  - composer clear-cache
   - composer install
   - npm install
 


### PR DESCRIPTION
This apparently fixes a "Failed to decode response: zlib_decode(): data error" error that occurs from time to time on Traivs.