### PR TITLE
Implementing visibility support on the generator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,11 +48,23 @@
     },
     "scripts": {
         "analysis": "psalm",
-        "build-examples": [
+        "build-blueprints": [
             "rm -rf resources/examples/Showtimes/blueprints",
             "mkdir resources/examples/Showtimes/blueprints",
-            "./bin/mill generate --config=resources/examples/mill.xml resources/examples/Showtimes/blueprints/",
+            "./bin/mill generate --config=resources/examples/mill.xml resources/examples/Showtimes/blueprints/"
+        ],
+        "build-changelogs": [
+            "./bin/mill changelog --config=resources/examples/mill.xml --private=false resources/examples/Showtimes/blueprints/",
+            "mv resources/examples/Showtimes/blueprints/changelog.md resources/examples/Showtimes/blueprints/changelog-public-only-all-capabilities.md",
+            "./bin/mill changelog --config=resources/examples/mill.xml --private=false --capability=BUY_TICKETS --capability=FEATURE_FLAG resources/examples/Showtimes/blueprints/",
+            "mv resources/examples/Showtimes/blueprints/changelog.md resources/examples/Showtimes/blueprints/changelog-public-only-unmatched-capabilities.md",
+            "./bin/mill changelog --config=resources/examples/mill.xml --private=false --capability=DELETE_CONTENT resources/examples/Showtimes/blueprints/",
+            "mv resources/examples/Showtimes/blueprints/changelog.md resources/examples/Showtimes/blueprints/changelog-public-only-matched-capabilities.md",
             "./bin/mill changelog --config=resources/examples/mill.xml resources/examples/Showtimes/blueprints/"
+        ],
+        "build-resources": [
+            "composer build-blueprints",
+            "composer build-changelogs"
         ],
         "check-style": "phpcs --standard=PSR2 bin/ src/ tests/",
         "coverage": "phpunit --coverage-html reports/",

--- a/resources/examples/Showtimes/Controllers/Movie.php
+++ b/resources/examples/Showtimes/Controllers/Movie.php
@@ -118,6 +118,7 @@ class Movie
      * @api-uriSegment {/movies/+id} id (integer) - Movie ID
      *
      * @api-contentType application/json
+     * @api-capability DELETE_CONTENT
      * @api-scope delete
      * @api-minVersion 1.1
      *

--- a/resources/examples/Showtimes/blueprints/changelog-public-only-all-capabilities.md
+++ b/resources/examples/Showtimes/blueprints/changelog-public-only-all-capabilities.md
@@ -1,0 +1,56 @@
+# Changelog: Mill unit test API, Showtimes
+
+## 1.1.3
+### Added
+#### Resources
+- The GET on `/movies/{id}` can now throw the following errors:
+    - `404 Not Found` with a `Error` representation: For no reason.
+    - `404 Not Found` with a `Error` representation: For some other reason.
+- PATCH on `/movies/{id}` now returns a `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
+- PATCH on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
+- POST on `/movies` now returns a `201 Created`.
+
+### Removed
+#### Representations
+- `external_urls.tickets` has been removed from the `Movie` representation.
+
+## 1.1.2
+### Changed
+#### Resources
+- `/movies/{id}` now returns a `application/mill.example.movie` Content-Type header on the following HTTP methods:
+    - `GET`
+    - `PATCH`
+- `/movies` now returns a `application/mill.example.movie` Content-Type header on the following HTTP methods:
+    - `GET`
+    - `POST`
+- `/theaters/{id}` now returns a `application/mill.example.theater` Content-Type header on the following HTTP methods:
+    - `GET`
+    - `PATCH`
+- `/theaters` now returns a `application/mill.example.theater` Content-Type header on the following HTTP methods:
+    - `GET`
+    - `POST`
+
+## 1.1.1
+### Added
+#### Resources
+- A `imdb` request parameter was added to PATCH on `/movies/{id}`.
+
+## 1.1
+### Added
+#### Representations
+- The following fields have been added to the `Movie` representation:
+    - `external_urls`
+    - `external_urls.imdb`
+    - `external_urls.tickets`
+    - `external_urls.trailer`
+
+#### Resources
+- PATCH on `/movies/{id}` was added.
+- A `page` request parameter was added to GET on `/movies`.
+- The following parameters have been added to POST on `/movies`:
+    - `imdb`
+    - `trailer`
+
+### Removed
+#### Representations
+- `website` has been removed from the `Theater` representation.

--- a/resources/examples/Showtimes/blueprints/changelog-public-only-matched-capabilities.md
+++ b/resources/examples/Showtimes/blueprints/changelog-public-only-matched-capabilities.md
@@ -1,0 +1,58 @@
+# Changelog: Mill unit test API, Showtimes
+
+## 1.1.3
+### Added
+#### Resources
+- The GET on `/movies/{id}` can now throw the following errors:
+    - `404 Not Found` with a `Error` representation: For no reason.
+    - `404 Not Found` with a `Error` representation: For some other reason.
+- PATCH on `/movies/{id}` now returns a `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
+- PATCH on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
+- POST on `/movies` now returns a `201 Created`.
+
+### Removed
+#### Representations
+- `external_urls.tickets` has been removed from the `Movie` representation.
+
+## 1.1.2
+### Changed
+#### Resources
+- `/movies/{id}` now returns a `application/mill.example.movie` Content-Type header on the following HTTP methods:
+    - `GET`
+    - `PATCH`
+- `/movies` now returns a `application/mill.example.movie` Content-Type header on the following HTTP methods:
+    - `GET`
+    - `POST`
+- `/theaters/{id}` now returns a `application/mill.example.theater` Content-Type header on the following HTTP methods:
+    - `GET`
+    - `PATCH`
+- `/theaters` now returns a `application/mill.example.theater` Content-Type header on the following HTTP methods:
+    - `GET`
+    - `POST`
+
+## 1.1.1
+### Added
+#### Resources
+- A `imdb` request parameter was added to PATCH on `/movies/{id}`.
+
+## 1.1
+### Added
+#### Representations
+- The following fields have been added to the `Movie` representation:
+    - `external_urls`
+    - `external_urls.imdb`
+    - `external_urls.tickets`
+    - `external_urls.trailer`
+
+#### Resources
+- `/movies/{id}` has been added with support for the following HTTP methods:
+    - `PATCH`
+    - `DELETE`
+- A `page` request parameter was added to GET on `/movies`.
+- The following parameters have been added to POST on `/movies`:
+    - `imdb`
+    - `trailer`
+
+### Removed
+#### Representations
+- `website` has been removed from the `Theater` representation.

--- a/resources/examples/Showtimes/blueprints/changelog-public-only-unmatched-capabilities.md
+++ b/resources/examples/Showtimes/blueprints/changelog-public-only-unmatched-capabilities.md
@@ -1,0 +1,56 @@
+# Changelog: Mill unit test API, Showtimes
+
+## 1.1.3
+### Added
+#### Resources
+- The GET on `/movies/{id}` can now throw the following errors:
+    - `404 Not Found` with a `Error` representation: For no reason.
+    - `404 Not Found` with a `Error` representation: For some other reason.
+- PATCH on `/movies/{id}` now returns a `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
+- PATCH on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
+- POST on `/movies` now returns a `201 Created`.
+
+### Removed
+#### Representations
+- `external_urls.tickets` has been removed from the `Movie` representation.
+
+## 1.1.2
+### Changed
+#### Resources
+- `/movies/{id}` now returns a `application/mill.example.movie` Content-Type header on the following HTTP methods:
+    - `GET`
+    - `PATCH`
+- `/movies` now returns a `application/mill.example.movie` Content-Type header on the following HTTP methods:
+    - `GET`
+    - `POST`
+- `/theaters/{id}` now returns a `application/mill.example.theater` Content-Type header on the following HTTP methods:
+    - `GET`
+    - `PATCH`
+- `/theaters` now returns a `application/mill.example.theater` Content-Type header on the following HTTP methods:
+    - `GET`
+    - `POST`
+
+## 1.1.1
+### Added
+#### Resources
+- A `imdb` request parameter was added to PATCH on `/movies/{id}`.
+
+## 1.1
+### Added
+#### Representations
+- The following fields have been added to the `Movie` representation:
+    - `external_urls`
+    - `external_urls.imdb`
+    - `external_urls.tickets`
+    - `external_urls.trailer`
+
+#### Resources
+- PATCH on `/movies/{id}` was added.
+- A `page` request parameter was added to GET on `/movies`.
+- The following parameters have been added to POST on `/movies`:
+    - `imdb`
+    - `trailer`
+
+### Removed
+#### Representations
+- `website` has been removed from the `Theater` representation.

--- a/resources/examples/mill.xml
+++ b/resources/examples/mill.xml
@@ -44,7 +44,7 @@
     <capabilities>
         <capability name="BUY_TICKETS" />
         <capability name="DELETE_CONTENT" />
+        <capability name="FEATURE_FLAG" />
         <capability name="MOVIE_RATINGS" />
-        <capability name="NONE" />
     </capabilities>
 </mill>

--- a/resources/examples/mill.xml
+++ b/resources/examples/mill.xml
@@ -43,6 +43,7 @@
 
     <capabilities>
         <capability name="BUY_TICKETS" />
+        <capability name="DELETE_CONTENT" />
         <capability name="MOVIE_RATINGS" />
         <capability name="NONE" />
     </capabilities>

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,0 +1,49 @@
+<?php
+namespace Mill;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Application extends Command
+{
+    const DS = DIRECTORY_SEPARATOR;
+
+    /**
+     * @var \Pimple\Container
+     */
+    protected $container;
+
+    /**
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->addOption(
+            'config',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Path to your `mill.xml` config file.',
+            'mill.xml'
+        );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return void
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $style = new OutputFormatterStyle('green', null, ['bold']);
+        $output->getFormatter()->setStyle('success', $style);
+
+        $config_file = realpath($input->getOption('config'));
+
+        $this->container = new Container([
+            'config.path' => $config_file
+        ]);
+    }
+}

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -194,7 +194,7 @@ class Generator
                         // generating documentation for.
                         $cloned = clone $action;
                         $cloned->filterAnnotationsForVersion($version);
-                        $cloned->FilterAnnotationsForVisibility($this->load_private_docs, $this->load_capability_docs);
+                        $cloned->filterAnnotationsForVisibility($this->load_private_docs, $this->load_capability_docs);
 
                         if (!isset($resources[$version][$group]['resources'][$resource_label])) {
                             $resources[$version][$group]['resources'][$resource_label] = [

--- a/src/Parser/Resource/Action/Documentation.php
+++ b/src/Parser/Resource/Action/Documentation.php
@@ -461,6 +461,9 @@ class Documentation
     }
 
     /**
+     * Filter down, and return, all annotations on this action that match a specific visibility. This can either be
+     * public, public+private, or capability-locked.
+     *
      * @param boolean $allow_private
      * @param null|array $only_capabilities
      * @return array

--- a/src/Parser/Resource/Action/Documentation.php
+++ b/src/Parser/Resource/Action/Documentation.php
@@ -488,9 +488,11 @@ class Documentation
                 if ((!empty($capability) || !empty($method_capabilities)) && !empty($only_capabilities)) {
                     $all_found = true;
 
-                    /** @var CapabilityAnnotation $method_capability */
+                    /** @var Parser\Annotations\CapabilityAnnotation $method_capability */
                     foreach ($method_capabilities as $method_capability) {
-                        if (!in_array($method_capability->getCapability(), $only_capabilities)) {
+                        /** @var string $capability */
+                        $capability = $method_capability->getCapability();
+                        if (!in_array($capability, $only_capabilities)) {
                             $all_found = false;
                         }
                     }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -30,8 +30,8 @@ class ConfigTest extends TestCase
         $this->assertSame([
             'BUY_TICKETS',
             'DELETE_CONTENT',
-            'MOVIE_RATINGS',
-            'NONE'
+            'FEATURE_FLAG',
+            'MOVIE_RATINGS'
         ], $config->getCapabilities());
 
         $this->assertSame([

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -29,6 +29,7 @@ class ConfigTest extends TestCase
 
         $this->assertSame([
             'BUY_TICKETS',
+            'DELETE_CONTENT',
             'MOVIE_RATINGS',
             'NONE'
         ], $config->getCapabilities());

--- a/tests/Generator/ChangelogTest.php
+++ b/tests/Generator/ChangelogTest.php
@@ -6,41 +6,112 @@ use Mill\Tests\TestCase;
 
 class ChangelogTest extends TestCase
 {
-    public function testGeneration()
+    /**
+     * @dataProvider providerTestGeneration
+     * @param boolean $private_objects
+     * @param array $capabilities
+     * @param array $expected
+     * @return void
+     */
+    public function testGeneration($private_objects, $capabilities, $expected)
     {
         $generator = new Changelog($this->getConfig());
+        $generator->setLoadPrivateDocs($private_objects);
+        $generator->setLoadCapabilityDocs($capabilities);
         $changelog = $generator->generate();
 
+        $this->assertSame(array_keys($expected), array_keys($changelog));
+
+        foreach ($expected as $version => $expected_changes) {
+            $this->assertSame(
+                $expected_changes,
+                $changelog[$version],
+                'Change for v' . $version . ' don\'t match up.'
+            );
+        }
+    }
+
+    public function testJsonGeneration()
+    {
+        $generator = new Changelog($this->getConfig());
+        $changelog = $generator->generateJson();
+        $changelog = json_decode($changelog, true);
+
+        // We don't need to test the full functionality of the JSON extension to the Changelog generator, since that's
+        // being done in `Generator\Changelog\JsonTest`, we just want to make sure that we at least have the expected
+        // array keys.
         $this->assertSame([
             '1.1.3',
             '1.1.2',
             '1.1.1',
             '1.1'
         ], array_keys($changelog));
+    }
 
-        // v1.1.3
-        $this->assertSame([
-            'added' => [
-                'resources' => [
-                    '/movie/{id}' => [
-                        Changelog::CHANGE_ACTION_THROWS => [
+    /**
+     * @return array
+     */
+    public function providerTestGeneration()
+    {
+        // Save us the effort of copy and pasting the same base actions over and over.
+        $actions = [
+            '/movies' => [
+                '1.1.3' => [
+                    'added' => [
+                        Changelog::CHANGE_ACTION_RETURN => [
                             [
-                                'method' => 'GET',
-                                'uri' => '/movie/{id}',
-                                'http_code' => '404 Not Found',
-                                'representation' => 'Error',
-                                'description' => 'For no reason.'
-                            ],
-                            [
-                                'method' => 'GET',
-                                'uri' => '/movie/{id}',
-                                'http_code' => '404 Not Found',
-                                'representation' => 'Error',
-                                'description' => 'For some other reason.'
+                                'method' => 'POST',
+                                'uri' => '/movies',
+                                'http_code' => '201 Created',
+                                'representation' => false
                             ]
                         ]
-                    ],
-                    '/movies/{id}' => [
+                    ]
+                ],
+                '1.1.2' => [
+                    'changed' => [
+                        Changelog::CHANGE_CONTENT_TYPE => [
+                            [
+                                'method' => 'GET',
+                                'uri' => '/movies',
+                                'content_type' => 'application/mill.example.movie'
+                            ],
+                            [
+                                'method' => 'POST',
+                                'uri' => '/movies',
+                                'content_type' => 'application/mill.example.movie'
+                            ]
+                        ]
+                    ]
+                ],
+                '1.1' => [
+                    'added' => [
+                        Changelog::CHANGE_ACTION_PARAM => [
+                            [
+                                'method' => 'GET',
+                                'uri' => '/movies',
+                                'parameter' => 'page',
+                                'description' => 'Page of results to pull.'
+                            ],
+                            [
+                                'method' => 'POST',
+                                'uri' => '/movies',
+                                'parameter' => 'imdb',
+                                'description' => 'IMDB URL'
+                            ],
+                            [
+                                'method' => 'POST',
+                                'uri' => '/movies',
+                                'parameter' => 'trailer',
+                                'description' => 'Trailer URL'
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            '/movies/{id}' => [
+                '1.1.3' => [
+                    'added' => [
                         Changelog::CHANGE_ACTION_THROWS => [
                             [
                                 'method' => 'GET',
@@ -73,46 +144,9 @@ class ChangelogTest extends TestCase
                             ]
                         ]
                     ],
-                    '/movies' => [
-                        Changelog::CHANGE_ACTION_RETURN => [
-                            [
-                                'method' => 'POST',
-                                'uri' => '/movies',
-                                'http_code' => '201 Created',
-                                'representation' => false
-                            ]
-                        ]
-                    ]
-                ]
-            ],
-            'removed' => [
-                'representations' => [
-                    'Movie' => [
-                        Changelog::CHANGE_REPRESENTATION_DATA => [
-                            [
-                                'field' => 'external_urls.tickets',
-                                'representation' => 'Movie'
-                            ]
-                        ]
-                    ]
-                ]
-            ]
-        ], $changelog['1.1.3']);
-
-        // v1.1.2
-        $this->assertSame([
-            'changed' => [
-                'resources' => [
-                    '/movie/{id}' => [
-                        Changelog::CHANGE_CONTENT_TYPE => [
-                            [
-                                'method' => 'GET',
-                                'uri' => '/movie/{id}',
-                                'content_type' => 'application/mill.example.movie'
-                            ]
-                        ]
-                    ],
-                    '/movies/{id}' => [
+                ],
+                '1.1.2' => [
+                    'changed' => [
                         Changelog::CHANGE_CONTENT_TYPE => [
                             [
                                 'method' => 'GET',
@@ -125,58 +159,10 @@ class ChangelogTest extends TestCase
                                 'content_type' => 'application/mill.example.movie'
                             ]
                         ]
-                    ],
-                    '/movies' => [
-                        Changelog::CHANGE_CONTENT_TYPE => [
-                            [
-                                'method' => 'GET',
-                                'uri' => '/movies',
-                                'content_type' => 'application/mill.example.movie'
-                            ],
-                            [
-                                'method' => 'POST',
-                                'uri' => '/movies',
-                                'content_type' => 'application/mill.example.movie'
-                            ]
-                        ]
-                    ],
-                    '/theaters/{id}' => [
-                        Changelog::CHANGE_CONTENT_TYPE => [
-                            [
-                                'method' => 'GET',
-                                'uri' => '/theaters/{id}',
-                                'content_type' => 'application/mill.example.theater'
-                            ],
-                            [
-                                'method' => 'PATCH',
-                                'uri' => '/theaters/{id}',
-                                'content_type' => 'application/mill.example.theater'
-                            ]
-                        ]
-                    ],
-                    '/theaters' => [
-                        Changelog::CHANGE_CONTENT_TYPE => [
-                            [
-                                'method' => 'GET',
-                                'uri' => '/theaters',
-                                'content_type' => 'application/mill.example.theater'
-                            ],
-                            [
-                                'method' => 'POST',
-                                'uri' => '/theaters',
-                                'content_type' => 'application/mill.example.theater'
-                            ]
-                        ]
                     ]
-                ]
-            ]
-        ], $changelog['1.1.2']);
-
-        // v1.1.1
-        $this->assertSame([
-            'added' => [
-                'resources' => [
-                    '/movies/{id}' => [
+                ],
+                '1.1.1' => [
+                    'added' => [
                         Changelog::CHANGE_ACTION_PARAM => [
                             [
                                 'method' => 'PATCH',
@@ -186,15 +172,103 @@ class ChangelogTest extends TestCase
                             ]
                         ]
                     ]
+                ],
+                '1.1' => [
+                    'added' => [
+                        Changelog::CHANGE_ACTION => [
+                            [
+                                'method' => 'PATCH',
+                                'uri' => '/movies/{id}'
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            '/movie/{id}' => [
+                '1.1.3' => [
+                    'added' => [
+                        Changelog::CHANGE_ACTION_THROWS => [
+                            [
+                                'method' => 'GET',
+                                'uri' => '/movie/{id}',
+                                'http_code' => '404 Not Found',
+                                'representation' => 'Error',
+                                'description' => 'For no reason.'
+                            ],
+                            [
+                                'method' => 'GET',
+                                'uri' => '/movie/{id}',
+                                'http_code' => '404 Not Found',
+                                'representation' => 'Error',
+                                'description' => 'For some other reason.'
+                            ]
+                        ]
+                    ]
+                ],
+                '1.1.2' => [
+                    'changed' => [
+                        Changelog::CHANGE_CONTENT_TYPE => [
+                            [
+                                'method' => 'GET',
+                                'uri' => '/movie/{id}',
+                                'content_type' => 'application/mill.example.movie'
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            '/theaters' => [
+                '1.1.2' => [
+                    'changed' => [
+                        Changelog::CHANGE_CONTENT_TYPE => [
+                            [
+                                'method' => 'GET',
+                                'uri' => '/theaters',
+                                'content_type' => 'application/mill.example.theater'
+                            ],
+                            [
+                                'method' => 'POST',
+                                'uri' => '/theaters',
+                                'content_type' => 'application/mill.example.theater'
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            '/theaters/{id}' => [
+                '1.1.2' => [
+                    'changed' => [
+                        Changelog::CHANGE_CONTENT_TYPE => [
+                            [
+                                'method' => 'GET',
+                                'uri' => '/theaters/{id}',
+                                'content_type' => 'application/mill.example.theater'
+                            ],
+                            [
+                                'method' => 'PATCH',
+                                'uri' => '/theaters/{id}',
+                                'content_type' => 'application/mill.example.theater'
+                            ]
+                        ]
+                    ]
                 ]
             ]
-        ], $changelog['1.1.1']);
+        ];
 
-        // v1.1
-        $this->assertSame([
-            'added' => [
-                'representations' => [
-                    'Movie' => [
+        $representations = [
+            'Movie' => [
+                '1.1.3' => [
+                    'removed' => [
+                        Changelog::CHANGE_REPRESENTATION_DATA => [
+                            [
+                                'field' => 'external_urls.tickets',
+                                'representation' => 'Movie'
+                            ]
+                        ]
+                    ]
+                ],
+                '1.1' => [
+                    'added' => [
                         Changelog::CHANGE_REPRESENTATION_DATA => [
                             [
                                 'field' => 'external_urls',
@@ -214,48 +288,12 @@ class ChangelogTest extends TestCase
                             ]
                         ]
                     ]
-                ],
-                'resources' => [
-                    '/movies/{id}' => [
-                        Changelog::CHANGE_ACTION => [
-                            [
-                                'method' => 'PATCH',
-                                'uri' => '/movies/{id}'
-                            ],
-                            [
-                                'method' => 'DELETE',
-                                'uri' => '/movies/{id}'
-                            ]
-                        ]
-                    ],
-                    '/movies' => [
-                        Changelog::CHANGE_ACTION_PARAM => [
-                            [
-                                'method' => 'GET',
-                                'uri' => '/movies',
-                                'parameter' => 'page',
-                                'description' => 'Page of results to pull.'
-                            ],
-                            [
-                                'method' => 'POST',
-                                'uri' => '/movies',
-                                'parameter' => 'imdb',
-                                'description' => 'IMDB URL'
-                            ],
-                            [
-                                'method' => 'POST',
-                                'uri' => '/movies',
-                                'parameter' => 'trailer',
-                                'description' => 'Trailer URL'
-                            ]
-                        ]
-                    ]
                 ]
             ],
-            'removed' => [
-                'representations' => [
-                    'Theater' => [
-                        'representation_data' => [
+            'Theater' => [
+                '1.1' => [
+                    'removed' => [
+                        Changelog::CHANGE_REPRESENTATION_DATA => [
                             [
                                 'field' => 'website',
                                 'representation' => 'Theater'
@@ -264,23 +302,247 @@ class ChangelogTest extends TestCase
                     ]
                 ]
             ]
-        ], $changelog['1.1']);
-    }
+        ];
 
-    public function testJsonGeneration()
-    {
-        $generator = new Changelog($this->getConfig());
-        $changelog = $generator->generateJson();
-        $changelog = json_decode($changelog, true);
+        return [
+            // Complete changelog. All documentation parsed.
+            'complete-changelog' => [
+                'private_objects' => true,
+                'capabilities' => [],
+                'expected' => [
+                    '1.1.3' => [
+                        'added' => [
+                            'resources' => [
+                                '/movie/{id}' => $actions['/movie/{id}']['1.1.3']['added'],
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.3']['added'],
+                                '/movies' => $actions['/movies']['1.1.3']['added']
+                            ]
+                        ],
+                        'removed' => [
+                            'representations' => [
+                                'Movie' => $representations['Movie']['1.1.3']['removed']
+                            ]
+                        ]
+                    ],
+                    '1.1.2' => [
+                        'changed' => [
+                            'resources' => [
+                                '/movie/{id}' => $actions['/movie/{id}']['1.1.2']['changed'],
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.2']['changed'],
+                                '/movies' => $actions['/movies']['1.1.2']['changed'],
+                                '/theaters/{id}' => $actions['/theaters/{id}']['1.1.2']['changed'],
+                                '/theaters' => $actions['/theaters']['1.1.2']['changed']
+                            ]
+                        ]
+                    ],
+                    '1.1.1' => [
+                        'added' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.1']['added']
+                            ]
+                        ]
+                    ],
+                    '1.1' => [
+                        'added' => [
+                            'representations' => [
+                                'Movie' => $representations['Movie']['1.1']['added']
+                            ],
+                            'resources' => [
+                                '/movies/{id}' => call_user_func(function () use ($actions) {
+                                    $action = $actions['/movies/{id}']['1.1']['added'];
+                                    $action[Changelog::CHANGE_ACTION][] = [
+                                        'method' => 'DELETE',
+                                        'uri' => '/movies/{id}'
+                                    ];
 
-        // We don't need to test the full functionality of the JSON extension to the Changelog generator, since that's
-        // being done in `Generator\Changelog\JsonTest`, we just want to make sure that we at least have the expected
-        // array keys.
-        $this->assertSame([
-            '1.1.3',
-            '1.1.2',
-            '1.1.1',
-            '1.1'
-        ], array_keys($changelog));
+                                    return $action;
+                                }),
+                                '/movies' => $actions['/movies']['1.1']['added']
+                            ]
+                        ],
+                        'removed' => [
+                            'representations' => [
+                                'Theater' => $representations['Theater']['1.1']['removed']
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+
+            // Changelog with public-only parsed docs and all capabilities.
+            'changelog-public-docs-with-all-capabilities' => [
+                'private_objects' => false,
+                'capabilities' => [],
+                'expected' => [
+                    '1.1.3' => [
+                        'added' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.3']['added'],
+                                '/movies' => $actions['/movies']['1.1.3']['added']
+                            ]
+                        ],
+                        'removed' => [
+                            'representations' => [
+                                'Movie' => $representations['Movie']['1.1.3']['removed']
+                            ]
+                        ]
+                    ],
+                    '1.1.2' => [
+                        'changed' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.2']['changed'],
+                                '/movies' => $actions['/movies']['1.1.2']['changed'],
+                                '/theaters/{id}' => $actions['/theaters/{id}']['1.1.2']['changed'],
+                                '/theaters' => $actions['/theaters']['1.1.2']['changed']
+                            ]
+                        ]
+                    ],
+                    '1.1.1' => [
+                        'added' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.1']['added']
+                            ]
+                        ]
+                    ],
+                    '1.1' => [
+                        'added' => [
+                            'representations' => [
+                                'Movie' => $representations['Movie']['1.1']['added']
+                            ],
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1']['added'],
+                                '/movies' => $actions['/movies']['1.1']['added']
+                            ]
+                        ],
+                        'removed' => [
+                            'representations' => [
+                                'Theater' => $representations['Theater']['1.1']['removed']
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+
+            // Changelog with public-only parsed docs and unmatched capabilities
+            'changelog-public-docs-with-unmatched-capabilities' => [
+                'private_objects' => false,
+                'capabilities' => [
+                    'BUY_TICKETS',
+                    'FEATURE_FLAG'
+                ],
+                'expected' => [
+                    '1.1.3' => [
+                        'added' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.3']['added'],
+                                '/movies' => $actions['/movies']['1.1.3']['added']
+                            ]
+                        ],
+                        'removed' => [
+                            'representations' => [
+                                'Movie' => $representations['Movie']['1.1.3']['removed']
+                            ]
+                        ]
+                    ],
+                    '1.1.2' => [
+                        'changed' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.2']['changed'],
+                                '/movies' => $actions['/movies']['1.1.2']['changed'],
+                                '/theaters/{id}' => $actions['/theaters/{id}']['1.1.2']['changed'],
+                                '/theaters' => $actions['/theaters']['1.1.2']['changed']
+                            ]
+                        ]
+                    ],
+                    '1.1.1' => [
+                        'added' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.1']['added']
+                            ]
+                        ]
+                    ],
+                    '1.1' => [
+                        'added' => [
+                            'representations' => [
+                                'Movie' => $representations['Movie']['1.1']['added']
+                            ],
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1']['added'],
+                                '/movies' => $actions['/movies']['1.1']['added']
+                            ]
+                        ],
+                        'removed' => [
+                            'representations' => [
+                                'Theater' => $representations['Theater']['1.1']['removed']
+                            ]
+                        ]
+                    ]
+                ],
+            ],
+
+            // Changelog with public-only parsed docs and matched capabilities
+            'changelog-public-docs-with-matched-capabilities' => [
+                'private_objects' => false,
+                'capabilities' => [
+                    'DELETE_CONTENT'
+                ],
+                'expected' => [
+                    '1.1.3' => [
+                        'added' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.3']['added'],
+                                '/movies' => $actions['/movies']['1.1.3']['added']
+                            ]
+                        ],
+                        'removed' => [
+                            'representations' => [
+                                'Movie' => $representations['Movie']['1.1.3']['removed']
+                            ]
+                        ]
+                    ],
+                    '1.1.2' => [
+                        'changed' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.2']['changed'],
+                                '/movies' => $actions['/movies']['1.1.2']['changed'],
+                                '/theaters/{id}' => $actions['/theaters/{id}']['1.1.2']['changed'],
+                                '/theaters' => $actions['/theaters']['1.1.2']['changed']
+                            ]
+                        ]
+                    ],
+                    '1.1.1' => [
+                        'added' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.1']['added']
+                            ]
+                        ]
+                    ],
+                    '1.1' => [
+                        'added' => [
+                            'representations' => [
+                                'Movie' => $representations['Movie']['1.1']['added']
+                            ],
+                            'resources' => [
+                                '/movies/{id}' => call_user_func(function () use ($actions) {
+                                    $action = $actions['/movies/{id}']['1.1']['added'];
+                                    $action[Changelog::CHANGE_ACTION][] = [
+                                        'method' => 'DELETE',
+                                        'uri' => '/movies/{id}'
+                                    ];
+
+                                    return $action;
+                                }),
+                                '/movies' => $actions['/movies']['1.1']['added']
+                            ]
+                        ],
+                        'removed' => [
+                            'representations' => [
+                                'Theater' => $representations['Theater']['1.1']['removed']
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
     }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -49,7 +49,7 @@ class GeneratorTest extends TestCase
      * @dataProvider providerGeneratorWithVersion
      * @param string $version
      * @param boolean $private_objects
-     * @param array|null $capabilities
+     * @param array $capabilities
      * @param array $expected_representations
      * @param array $expected_resources
      * @return void
@@ -680,7 +680,7 @@ class GeneratorTest extends TestCase
                 'private_objects' => false,
                 'capabilities' => [
                     'BUY_TICKETS',
-                    'NONE'
+                    'FEATURE_FLAG'
                 ],
                 'expected.representations' => array_merge($error_representations, [
                     '\Mill\Examples\Showtimes\Representations\Movie' => call_user_func(

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -54,9 +54,7 @@ class GeneratorTest extends TestCase
         $generator = new Generator($this->getConfig(), $version_obj);
         $generator->generate();
 
-        /**
-         * Verify resources
-         */
+        // Verify resources
         $resources = $generator->getResources();
         $this->assertArrayHasKey($version, $resources);
 
@@ -99,6 +97,11 @@ class GeneratorTest extends TestCase
 
                     $this->assertSame($expected_action['method'], $action->getMethod());
                     $this->assertSame($annotations['uri'][0]['path'], $expected_action['uri']);
+                    $this->assertSame(
+                        $annotations['uri'][0]['visible'],
+                        $expected_action['uri.visible'],
+                        $expected_action['uri'] . '::' . $expected_action['method']
+                    );
 
                     if ($expected_action['uriSegment'] === false) {
                         $this->assertArrayNotHasKey(
@@ -119,9 +122,7 @@ class GeneratorTest extends TestCase
             }
         }
 
-        /**
-         * Verify representations
-         */
+        // Verify representations
         $representations = $generator->getRepresentations();
         $this->assertArrayHasKey($version, $representations);
 
@@ -148,8 +149,8 @@ class GeneratorTest extends TestCase
      */
     public function providerGeneratorWithVersion()
     {
-        // Save us the effort of copy and pasting the same base endpoints over and over.
-        $common_actions = [
+        // Save us the effort of copy and pasting the same base actions over and over.
+        $actions = [
             '/movie/+id::GET' => [
                 'uri' => '/movie/+id',
                 'method' => 'GET',
@@ -161,17 +162,35 @@ class GeneratorTest extends TestCase
                         'uri' => '/movie/+id',
                         'values' => false
                     ]
-                ]
+                ],
+                'uri.visible' => false,
+                'params.keys' => []
             ],
             '/movies::GET' => [
                 'uri' => '/movies',
                 'method' => 'GET',
-                'uriSegment' => false
+                'uriSegment' => false,
+                'uri.visible' => true,
+                'params.keys' => [
+                    'location'
+                ]
             ],
             '/movies::POST' => [
                 'uri' => '/movies',
                 'method' => 'POST',
-                'uriSegment' => false
+                'uriSegment' => false,
+                'uri.visible' => true,
+                'params.keys' => [
+                    'cast',
+                    'content_rating',
+                    'description',
+                    'director',
+                    'genres',
+                    'is_kid_friendly',
+                    'name',
+                    'rotten_tomatoes_score',
+                    'runtime'
+                ]
             ],
             '/movies/+id::GET' => [
                 'uri' => '/movies/+id',
@@ -184,7 +203,9 @@ class GeneratorTest extends TestCase
                         'uri' => '/movies/+id',
                         'values' => false
                     ]
-                ]
+                ],
+                'uri.visible' => true,
+                'params.keys' => []
             ],
             '/movies/+id::PATCH' => [
                 'uri' => '/movies/+id',
@@ -197,6 +218,19 @@ class GeneratorTest extends TestCase
                         'uri' => '/movies/+id',
                         'values' => false
                     ]
+                ],
+                'uri.visible' => true,
+                'params.keys' => [
+                    'cast',
+                    'content_rating',
+                    'description',
+                    'director',
+                    'genres',
+                    'is_kid_friendly',
+                    'name',
+                    'rotten_tomatoes_score',
+                    'runtime',
+                    'trailer'
                 ]
             ],
             '/movies/+id::DELETE' => [
@@ -210,17 +244,29 @@ class GeneratorTest extends TestCase
                         'uri' => '/movies/+id',
                         'values' => false
                     ]
-                ]
+                ],
+                'uri.visible' => false,
+                'params.keys' => []
             ],
             '/theaters::GET' => [
                 'uri' => '/theaters',
                 'method' => 'GET',
-                'uriSegment' => false
+                'uriSegment' => false,
+                'uri.visible' => true,
+                'params.keys' => [
+                    'location'
+                ]
             ],
             '/theaters::POST' => [
                 'uri' => '/theaters',
                 'method' => 'POST',
-                'uriSegment' => false
+                'uriSegment' => false,
+                'uri.visible' => true,
+                'params.keys' => [
+                    'address',
+                    'name',
+                    'phone_number'
+                ]
             ],
             '/theaters/+id::GET' => [
                 'uri' => '/theaters/+id',
@@ -233,7 +279,9 @@ class GeneratorTest extends TestCase
                         'uri' => '/theaters/+id',
                         'values' => false
                     ]
-                ]
+                ],
+                'uri.visible' => true,
+                'params.keys' => []
             ],
             '/theaters/+id::PATCH' => [
                 'uri' => '/theaters/+id',
@@ -246,6 +294,12 @@ class GeneratorTest extends TestCase
                         'uri' => '/theaters/+id',
                         'values' => false
                     ]
+                ],
+                'uri.visible' => true,
+                'params.keys' => [
+                    'address',
+                    'name',
+                    'phone_number'
                 ]
             ],
             '/theaters/+id::DELETE' => [
@@ -259,6 +313,54 @@ class GeneratorTest extends TestCase
                         'uri' => '/theaters/+id',
                         'values' => false
                     ]
+                ],
+                'uri.visible' => false,
+                'params.keys' => []
+            ]
+        ];
+
+        $representations = [
+            'Movie' => [
+                'label' => 'Movie',
+                'description.length' => 41,
+                'content.keys' => [
+                    'cast',
+                    'content_rating',
+                    'description',
+                    'director',
+                    'genres',
+                    'id',
+                    'kid_friendly',
+                    'name',
+                    'purchase.url',
+                    'rotten_tomatoes_score',
+                    'runtime',
+                    'showtimes',
+                    'theaters',
+                    'uri'
+                ]
+            ],
+            'Person' => [
+                'label' => 'Person',
+                'description.length' => 42,
+                'content.keys' => [
+                    'id',
+                    'imdb',
+                    'name',
+                    'uri'
+                ]
+            ],
+            'Theater' => [
+                'label' => 'Theater',
+                'description.length' => 49,
+                'content.keys' => [
+                    'address',
+                    'id',
+                    'movies',
+                    'name',
+                    'phone_number',
+                    'showtimes',
+                    'uri',
                 ]
             ]
         ];
@@ -285,50 +387,19 @@ class GeneratorTest extends TestCase
             'version-1.0' => [
                 'version' => '1.0',
                 'expected.representations' => array_merge($error_representations, [
-                    '\Mill\Examples\Showtimes\Representations\Movie' => [
-                        'label' => 'Movie',
-                        'description.length' => 41,
-                        'content.keys' => [
-                            'cast',
-                            'content_rating',
-                            'description',
-                            'director',
-                            'genres',
-                            'id',
-                            'kid_friendly',
-                            'name',
-                            'purchase.url',
-                            'rotten_tomatoes_score',
-                            'runtime',
-                            'showtimes',
-                            'theaters',
-                            'uri'
-                        ]
-                    ],
-                    '\Mill\Examples\Showtimes\Representations\Person' => [
-                        'label' => 'Person',
-                        'description.length' => 42,
-                        'content.keys' => [
-                            'id',
-                            'imdb',
-                            'name',
-                            'uri'
-                        ]
-                    ],
-                    '\Mill\Examples\Showtimes\Representations\Theater' => [
-                        'label' => 'Theater',
-                        'description.length' => 49,
-                        'content.keys' => [
-                            'address',
-                            'id',
-                            'movies',
-                            'name',
-                            'phone_number',
-                            'showtimes',
-                            'uri',
-                            'website'
-                        ]
-                    ]
+                    '\Mill\Examples\Showtimes\Representations\Movie' => $representations['Movie'],
+                    '\Mill\Examples\Showtimes\Representations\Person' => $representations['Person'],
+                    '\Mill\Examples\Showtimes\Representations\Theater' => call_user_func(
+                        function () use ($representations) {
+                            $representation = $representations['Theater'];
+                            $representation['content.keys'] = array_merge($representation['content.keys'], [
+                                'website'
+                            ]);
+
+                            sort($representation['content.keys']);
+                            return $representation;
+                        }
+                    )
                 ]),
                 'expected.resources' => [
                     'Movies' => [
@@ -337,30 +408,10 @@ class GeneratorTest extends TestCase
                                 'resource.name' => 'Movies',
                                 'description.length' => 103,
                                 'actions.data' => [
-                                    '/movie/+id::GET' => array_merge($common_actions['/movie/+id::GET'], [
-                                        'params.keys' => []
-                                    ]),
-                                    '/movies::GET' => array_merge($common_actions['/movies::GET'], [
-                                        'params.keys' => [
-                                            'location'
-                                        ]
-                                    ]),
-                                    '/movies::POST' => array_merge($common_actions['/movies::POST'], [
-                                        'params.keys' => [
-                                            'cast',
-                                            'content_rating',
-                                            'description',
-                                            'director',
-                                            'genres',
-                                            'is_kid_friendly',
-                                            'name',
-                                            'rotten_tomatoes_score',
-                                            'runtime'
-                                        ]
-                                    ]),
-                                    '/movies/+id::GET' => array_merge($common_actions['/movies/+id::GET'], [
-                                        'params.keys' => []
-                                    ])
+                                    '/movie/+id::GET' => $actions['/movie/+id::GET'],
+                                    '/movies::GET' => $actions['/movies::GET'],
+                                    '/movies::POST' => $actions['/movies::POST'],
+                                    '/movies/+id::GET' => $actions['/movies/+id::GET']
                                 ]
                             ]
                         ]
@@ -371,87 +422,36 @@ class GeneratorTest extends TestCase
                                 'resource.name' => 'Movie Theaters',
                                 'description.length' => 119,
                                 'actions.data' => [
-                                    '/theaters::GET' => array_merge($common_actions['/theaters::GET'], [
-                                        'params.keys' => [
-                                            'location'
-                                        ]
-                                    ]),
-                                    '/theaters::POST' => array_merge($common_actions['/theaters::POST'], [
-                                        'params.keys' => [
-                                            'address',
-                                            'name',
-                                            'phone_number'
-                                        ]
-                                    ]),
-                                    '/theaters/+id::GET' => array_merge($common_actions['/theaters/+id::GET'], [
-                                        'params.keys' => []
-                                    ]),
-                                    '/theaters/+id::PATCH' => array_merge($common_actions['/theaters/+id::PATCH'], [
-                                        'params.keys' => [
-                                            'address',
-                                            'name',
-                                            'phone_number'
-                                        ]
-                                    ]),
-                                    '/theaters/+id::DELETE' => array_merge($common_actions['/theaters/+id::DELETE'], [
-                                        'params.keys' => []
-                                    ])
+                                    '/theaters::GET' => $actions['/theaters::GET'],
+                                    '/theaters::POST' => $actions['/theaters::POST'],
+                                    '/theaters/+id::GET' => $actions['/theaters/+id::GET'],
+                                    '/theaters/+id::PATCH' => $actions['/theaters/+id::PATCH'],
+                                    '/theaters/+id::DELETE' => $actions['/theaters/+id::DELETE']
                                 ]
                             ]
                         ]
-                    ],
+                    ]
                 ]
             ],
             'version-1.1' => [
                 'version' => '1.1',
                 'expected.representations' => array_merge($error_representations, [
-                    '\Mill\Examples\Showtimes\Representations\Movie' => [
-                        'label' => 'Movie',
-                        'description.length' => 41,
-                        'content.keys' => [
-                            'cast',
-                            'content_rating',
-                            'description',
-                            'director',
-                            'external_urls',
-                            'external_urls.imdb',
-                            'external_urls.tickets',
-                            'external_urls.trailer',
-                            'genres',
-                            'id',
-                            'kid_friendly',
-                            'name',
-                            'purchase.url',
-                            'rotten_tomatoes_score',
-                            'runtime',
-                            'showtimes',
-                            'theaters',
-                            'uri'
-                        ]
-                    ],
-                    '\Mill\Examples\Showtimes\Representations\Person' => [
-                        'label' => 'Person',
-                        'description.length' => 42,
-                        'content.keys' => [
-                            'id',
-                            'imdb',
-                            'name',
-                            'uri'
-                        ]
-                    ],
-                    '\Mill\Examples\Showtimes\Representations\Theater' => [
-                        'label' => 'Theater',
-                        'description.length' => 49,
-                        'content.keys' => [
-                            'address',
-                            'id',
-                            'movies',
-                            'name',
-                            'phone_number',
-                            'showtimes',
-                            'uri'
-                        ]
-                    ]
+                    '\Mill\Examples\Showtimes\Representations\Movie' => call_user_func(
+                        function () use ($representations) {
+                            $representation = $representations['Movie'];
+                            $representation['content.keys'] = array_merge($representation['content.keys'], [
+                                'external_urls',
+                                'external_urls.imdb',
+                                'external_urls.tickets',
+                                'external_urls.trailer'
+                            ]);
+
+                            sort($representation['content.keys']);
+                            return $representation;
+                        }
+                    ),
+                    '\Mill\Examples\Showtimes\Representations\Person' => $representations['Person'],
+                    '\Mill\Examples\Showtimes\Representations\Theater' => $representations['Theater']
                 ]),
                 'expected.resources' => [
                     'Movies' => [
@@ -460,50 +460,25 @@ class GeneratorTest extends TestCase
                                 'resource.name' => 'Movies',
                                 'description.length' => 103,
                                 'actions.data' => [
-                                    '/movie/+id::GET' => array_merge($common_actions['/movie/+id::GET'], [
-                                        'params.keys' => []
-                                    ]),
-                                    '/movies::GET' => array_merge($common_actions['/movies::GET'], [
-                                        'params.keys' => [
-                                            'location',
-                                            'page'
-                                        ]
-                                    ]),
-                                    '/movies::POST' => array_merge($common_actions['/movies::POST'], [
-                                        'params.keys' => [
-                                            'cast',
-                                            'content_rating',
-                                            'description',
-                                            'director',
-                                            'genres',
-                                            'imdb',
-                                            'is_kid_friendly',
-                                            'name',
-                                            'rotten_tomatoes_score',
-                                            'runtime',
-                                            'trailer'
-                                        ]
-                                    ]),
-                                    '/movies/+id::GET' => array_merge($common_actions['/movies/+id::GET'], [
-                                        'params.keys' => []
-                                    ]),
-                                    '/movies/+id::PATCH' => array_merge($common_actions['/movies/+id::PATCH'], [
-                                        'params.keys' => [
-                                            'cast',
-                                            'content_rating',
-                                            'description',
-                                            'director',
-                                            'genres',
-                                            'is_kid_friendly',
-                                            'name',
-                                            'rotten_tomatoes_score',
-                                            'runtime',
-                                            'trailer'
-                                        ]
-                                    ]),
-                                    '/movies/+id::DELETE' => array_merge($common_actions['/movies/+id::DELETE'], [
-                                        'params.keys' => []
-                                    ])
+                                    '/movie/+id::GET' => $actions['/movie/+id::GET'],
+                                    '/movies::GET' => call_user_func(function () use ($actions) {
+                                        $action = $actions['/movies::GET'];
+                                        $action['params.keys'][] = 'page';
+
+                                        return $action;
+                                    }),
+                                    '/movies::POST' => call_user_func(function () use ($actions) {
+                                        $action = $actions['/movies::POST'];
+                                        $action['params.keys'][] = 'imdb';
+                                        $action['params.keys'][] = 'trailer';
+
+                                        sort($action['params.keys']);
+
+                                        return $action;
+                                    }),
+                                    '/movies/+id::GET' => $actions['/movies/+id::GET'],
+                                    '/movies/+id::PATCH' => $actions['/movies/+id::PATCH'],
+                                    '/movies/+id::DELETE' => $actions['/movies/+id::DELETE']
                                 ]
                             ]
                         ]
@@ -514,31 +489,11 @@ class GeneratorTest extends TestCase
                                 'resource.name' => 'Movie Theaters',
                                 'description.length' => 119,
                                 'actions.data' => [
-                                    '/theaters::GET' => array_merge($common_actions['/theaters::GET'], [
-                                        'params.keys' => [
-                                            'location'
-                                        ]
-                                    ]),
-                                    '/theaters::POST' => array_merge($common_actions['/theaters::POST'], [
-                                        'params.keys' => [
-                                            'address',
-                                            'name',
-                                            'phone_number'
-                                        ]
-                                    ]),
-                                    '/theaters/+id::GET' => array_merge($common_actions['/theaters/+id::GET'], [
-                                        'params.keys' => []
-                                    ]),
-                                    '/theaters/+id::PATCH' => array_merge($common_actions['/theaters/+id::PATCH'], [
-                                        'params.keys' => [
-                                            'address',
-                                            'name',
-                                            'phone_number'
-                                        ]
-                                    ]),
-                                    '/theaters/+id::DELETE' => array_merge($common_actions['/theaters/+id::DELETE'], [
-                                        'params.keys' => []
-                                    ])
+                                    '/theaters::GET' => $actions['/theaters::GET'],
+                                    '/theaters::POST' => $actions['/theaters::POST'],
+                                    '/theaters/+id::GET' => $actions['/theaters/+id::GET'],
+                                    '/theaters/+id::PATCH' => $actions['/theaters/+id::PATCH'],
+                                    '/theaters/+id::DELETE' => $actions['/theaters/+id::DELETE']
                                 ]
                             ]
                         ]
@@ -548,53 +503,22 @@ class GeneratorTest extends TestCase
             'version-1.1.1' => [
                 'version' => '1.1.1',
                 'expected.representations' => array_merge($error_representations, [
-                    '\Mill\Examples\Showtimes\Representations\Movie' => [
-                        'label' => 'Movie',
-                        'description.length' => 41,
-                        'content.keys' => [
-                            'cast',
-                            'content_rating',
-                            'description',
-                            'director',
-                            'external_urls',
-                            'external_urls.imdb',
-                            'external_urls.tickets',
-                            'external_urls.trailer',
-                            'genres',
-                            'id',
-                            'kid_friendly',
-                            'name',
-                            'purchase.url',
-                            'rotten_tomatoes_score',
-                            'runtime',
-                            'showtimes',
-                            'theaters',
-                            'uri'
-                        ]
-                    ],
-                    '\Mill\Examples\Showtimes\Representations\Person' => [
-                        'label' => 'Person',
-                        'description.length' => 42,
-                        'content.keys' => [
-                            'id',
-                            'imdb',
-                            'name',
-                            'uri'
-                        ]
-                    ],
-                    '\Mill\Examples\Showtimes\Representations\Theater' => [
-                        'label' => 'Theater',
-                        'description.length' => 49,
-                        'content.keys' => [
-                            'address',
-                            'id',
-                            'movies',
-                            'name',
-                            'phone_number',
-                            'showtimes',
-                            'uri'
-                        ]
-                    ]
+                    '\Mill\Examples\Showtimes\Representations\Movie' => call_user_func(
+                        function () use ($representations) {
+                            $representation = $representations['Movie'];
+                            $representation['content.keys'] = array_merge($representation['content.keys'], [
+                                'external_urls',
+                                'external_urls.imdb',
+                                'external_urls.tickets',
+                                'external_urls.trailer'
+                            ]);
+
+                            sort($representation['content.keys']);
+                            return $representation;
+                        }
+                    ),
+                    '\Mill\Examples\Showtimes\Representations\Person' => $representations['Person'],
+                    '\Mill\Examples\Showtimes\Representations\Theater' => $representations['Theater']
                 ]),
                 'expected.resources' => [
                     'Movies' => [
@@ -603,51 +527,32 @@ class GeneratorTest extends TestCase
                                 'resource.name' => 'Movies',
                                 'description.length' => 103,
                                 'actions.data' => [
-                                    '/movie/+id::GET' => array_merge($common_actions['/movie/+id::GET'], [
-                                        'params.keys' => []
-                                    ]),
-                                    '/movies::GET' => array_merge($common_actions['/movies::GET'], [
-                                        'params.keys' => [
-                                            'location',
-                                            'page'
-                                        ]
-                                    ]),
-                                    '/movies::POST' => array_merge($common_actions['/movies::POST'], [
-                                        'params.keys' => [
-                                            'cast',
-                                            'content_rating',
-                                            'description',
-                                            'director',
-                                            'genres',
-                                            'imdb',
-                                            'is_kid_friendly',
-                                            'name',
-                                            'rotten_tomatoes_score',
-                                            'runtime',
-                                            'trailer'
-                                        ]
-                                    ]),
-                                    '/movies/+id::GET' => array_merge($common_actions['/movies/+id::GET'], [
-                                        'params.keys' => []
-                                    ]),
-                                    '/movies/+id::PATCH' => array_merge($common_actions['/movies/+id::PATCH'], [
-                                        'params.keys' => [
-                                            'cast',
-                                            'content_rating',
-                                            'description',
-                                            'director',
-                                            'genres',
-                                            'imdb',
-                                            'is_kid_friendly',
-                                            'name',
-                                            'rotten_tomatoes_score',
-                                            'runtime',
-                                            'trailer'
-                                        ]
-                                    ]),
-                                    '/movies/+id::DELETE' => array_merge($common_actions['/movies/+id::DELETE'], [
-                                        'params.keys' => []
-                                    ])
+                                    '/movie/+id::GET' => $actions['/movie/+id::GET'],
+                                    '/movies::GET' => call_user_func(function () use ($actions) {
+                                        $action = $actions['/movies::GET'];
+                                        $action['params.keys'][] = 'page';
+
+                                        return $action;
+                                    }),
+                                    '/movies::POST' => call_user_func(function () use ($actions) {
+                                        $action = $actions['/movies::POST'];
+                                        $action['params.keys'][] = 'imdb';
+                                        $action['params.keys'][] = 'trailer';
+
+                                        sort($action['params.keys']);
+
+                                        return $action;
+                                    }),
+                                    '/movies/+id::GET' => $actions['/movies/+id::GET'],
+                                    '/movies/+id::PATCH' => call_user_func(function () use ($actions) {
+                                        $action = $actions['/movies/+id::PATCH'];
+                                        $action['params.keys'][] = 'imdb';
+
+                                        sort($action['params.keys']);
+
+                                        return $action;
+                                    }),
+                                    '/movies/+id::DELETE' => $actions['/movies/+id::DELETE']
                                 ]
                             ]
                         ]
@@ -658,31 +563,11 @@ class GeneratorTest extends TestCase
                                 'resource.name' => 'Movie Theaters',
                                 'description.length' => 119,
                                 'actions.data' => [
-                                    '/theaters::GET' => array_merge($common_actions['/theaters::GET'], [
-                                        'params.keys' => [
-                                            'location'
-                                        ]
-                                    ]),
-                                    '/theaters::POST' => array_merge($common_actions['/theaters::POST'], [
-                                        'params.keys' => [
-                                            'address',
-                                            'name',
-                                            'phone_number'
-                                        ]
-                                    ]),
-                                    '/theaters/+id::GET' => array_merge($common_actions['/theaters/+id::GET'], [
-                                        'params.keys' => []
-                                    ]),
-                                    '/theaters/+id::PATCH' => array_merge($common_actions['/theaters/+id::PATCH'], [
-                                        'params.keys' => [
-                                            'address',
-                                            'name',
-                                            'phone_number'
-                                        ]
-                                    ]),
-                                    '/theaters/+id::DELETE' => array_merge($common_actions['/theaters/+id::DELETE'], [
-                                        'params.keys' => []
-                                    ])
+                                    '/theaters::GET' => $actions['/theaters::GET'],
+                                    '/theaters::POST' => $actions['/theaters::POST'],
+                                    '/theaters/+id::GET' => $actions['/theaters/+id::GET'],
+                                    '/theaters/+id::PATCH' => $actions['/theaters/+id::PATCH'],
+                                    '/theaters/+id::DELETE' => $actions['/theaters/+id::DELETE']
                                 ]
                             ]
                         ]

--- a/tests/Parser/Representation/RepresentationParserTest.php
+++ b/tests/Parser/Representation/RepresentationParserTest.php
@@ -154,9 +154,9 @@ class RepresentationParserTest extends TestCase
         }, $annotations);
 
         $this->assertEmpty($annotations['connections']['capability']);
-        $this->assertSame('NONE', $annotations['connections.things']['capability']);
+        $this->assertSame('FEATURE_FLAG', $annotations['connections.things']['capability']);
         $this->assertSame('MOVIE_RATINGS', $annotations['connections.things.name']['capability']);
-        $this->assertSame('NONE', $annotations['connections.things.uri']['capability']);
+        $this->assertSame('FEATURE_FLAG', $annotations['connections.things.uri']['capability']);
         $this->assertEmpty($annotations['unrelated']['capability']);
 
         $this->assertSame('>=3.3', $annotations['connections']['version']);

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -705,7 +705,7 @@ DESCRIPTION;
                   *
                   * @api-contentType application/json
                   * @api-scope delete
-                  * @api-capability NONE
+                  * @api-capability DELETE_CONTENT
                   *
                   * @api-return:private {deleted}
                   */',
@@ -715,7 +715,7 @@ DESCRIPTION;
                         'annotation.name' => 'capability',
                         'data' => [
                             [
-                                'capability' => 'NONE'
+                                'capability' => 'DELETE_CONTENT'
                             ]
                         ]
                     ]

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -38,7 +38,7 @@ class DocumentationTest extends TestCase
             );
         }
 
-        $this->assertEmpty($parser->getCapabilities());
+        $this->assertCount($expected['capabilities.total'], $parser->getCapabilities());
 
         /** @var \Mill\Parser\Annotations\MinVersionAnnotation $min_version */
         $min_version = $parser->getMinimumVersion();
@@ -172,6 +172,7 @@ DESCRIPTION;
                 'expected' => [
                     'label' => 'Get a single movie.',
                     'description' => $get_description,
+                    'capabilities.total' => 0,
                     'content_types.latest-version' => '1.1.2',
                     'content_types' => [
                         [
@@ -283,6 +284,7 @@ DESCRIPTION;
                 'expected' => [
                     'label' => 'Update a movie.',
                     'description' => 'Update a movies data.',
+                    'capabilities.total' => 0,
                     'content_types.latest-version' => '1.1.2',
                     'content_types' => [
                         [
@@ -533,6 +535,7 @@ DESCRIPTION;
                 'expected' => [
                     'label' => 'Delete a movie.',
                     'description' => 'Delete a movie.',
+                    'capabilities.total' => 1,
                     'content_types.latest-version' => null,
                     'content_types' => [
                         [
@@ -544,6 +547,11 @@ DESCRIPTION;
                     'responses.length' => 2,
                     'uri.aliases' => [],
                     'annotations' => [
+                        'capability' => [
+                            [
+                                'capability' => 'DELETE_CONTENT'
+                            ]
+                        ],
                         'uri' => [
                             [
                                 'aliased' => false,

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -44,7 +44,7 @@ These actions will allow you to pull information on a specific movie.', $annotat
 
         foreach ($annotations as $annotation => $data) {
             if (!isset($expected[$annotation])) {
-                $this->fail('A parsed `' . $annotation . '`` annotation was not present in the expected data.');
+                $this->fail('A parsed `' . $annotation . '` annotation was not present in the expected data.');
             }
 
             $this->assertCount($expected[$annotation]['count'], $data, '`' . $annotation . '` mismatch');
@@ -179,6 +179,10 @@ These actions will allow you to pull information on a specific movie.', $annotat
             'DELETE' => [
                 'method' => 'DELETE',
                 'expected' => [
+                    'capability' => [
+                        'class' => '\Mill\Parser\Annotations\CapabilityAnnotation',
+                        'count' => 1
+                    ],
                     'contentType' => [
                         'class' => '\Mill\Parser\Annotations\ContentTypeAnnotation',
                         'count' => 1

--- a/tests/_fixtures/Representations/RepresentationWithVersioningAcrossMultipleAnnotations.php
+++ b/tests/_fixtures/Representations/RepresentationWithVersioningAcrossMultipleAnnotations.php
@@ -18,7 +18,7 @@ class RepresentationWithVersioningAcrossMultipleAnnotations
          */
 
         /**
-         * @api-data connections.things (object, NONE) - Information about this thing.
+         * @api-data connections.things (object, FEATURE_FLAG) - Information about this thing.
          * @api-scope public
          * @api-see self::someMethod connections.things
          */

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -60,6 +60,7 @@
 
     <capabilities>
         <capability name="BUY_TICKETS" />
+        <capability name="DELETE_CONTENT" />
         <capability name="MOVIE_RATINGS" />
         <capability name="NONE" />
     </capabilities>

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -61,8 +61,8 @@
     <capabilities>
         <capability name="BUY_TICKETS" />
         <capability name="DELETE_CONTENT" />
+        <capability name="FEATURE_FLAG" />
         <capability name="MOVIE_RATINGS" />
-        <capability name="NONE" />
     </capabilities>
 
     <parameterTokens>


### PR DESCRIPTION
This implements visibility support on the various Generator systems that Mill has. What this means is that you can now generate documentation that is:

* public-only
* public and private
* public, private, or capability-locked
* public, or capability-locked,
* or everything (public, private, capability-locked. no restrictions)

With this, I've extended the `changelog` command to support this so you can now generate changelogs for specific visibilities (and in your API usages, privileged developers).

```
Usage:
  changelog [options] [--] <output>

Arguments:
  output                         Directory to output your generated `changelog.md` file in.

Options:
      --config[=CONFIG]          Path to your `mill.xml` config file. [default: "mill.xml"]
      --private[=PRIVATE]        Flag designating if you want to generate a changelog that includes private documentation. [default: true]
      --capability[=CAPABILITY]  The name of a capability if you want to generate a changelog that includes capability-locked documentation. (multiple values allowed)
  -h, --help                     Display this help message
  -q, --quiet                    Do not output any message
  -V, --version                  Display this application version
      --ansi                     Force ANSI output
      --no-ansi                  Disable ANSI output
  -n, --no-interaction           Do not ask any interactive question
  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Help:
  Compiles a changelog from your API documentation.
```

```
./bin/mill changelog --config=mill.xml \
  --private=false \
  --capability=BUY_TICKETS \
  --capability=FEATURE_FLAG .
```

So this will generate a changelog of public-only documentation, but also include any documentation that is locked behind both the `BUY_TICKETS` and `FEATURE_FLAG` configured capabilities.

Neat!

Resolves https://github.com/vimeo/mill/issues/97