### PR TITLE
Parsing ALL capabilities now requires a `null` load_capability_docs.

### DIFF
--- a/src/Command/Changelog.php
+++ b/src/Command/Changelog.php
@@ -59,6 +59,7 @@ class Changelog extends Application
         $output_dir = realpath($input->getArgument('output'));
 
         $private_docs = ($private_docs === true || strtolower($private_docs) == 'true') ? true : false;
+        $capabilities = (!empty($capabilities)) ? $capabilities : null;
 
         /** @var Config $config */
         $config = $this->container['config'];

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -49,12 +49,12 @@ class Generator
 
     /**
      * Capabilities to generate documentation against. If this array contains capabilities, only public and
-     * documentation that have that capability will be generated. If this is empty, this will be disregarded, and
+     * documentation that have that capability will be generated. If this is null, this will be disregarded, and
      * everything will be generated.
      *
-     * @var array
+     * @var array|null
      */
-    protected $load_capability_docs = [];
+    protected $load_capability_docs = null;
 
     /**
      * @param Config $config
@@ -325,10 +325,10 @@ class Generator
     /**
      * Set an array of capabilities that we'll be generating documentation against.
      *
-     * @param array $capabilities
+     * @param array|null $capabilities
      * @return $this
      */
-    public function setLoadCapabilityDocs(array $capabilities = [])
+    public function setLoadCapabilityDocs($capabilities = null)
     {
         $this->load_capability_docs = $capabilities;
         return $this;
@@ -347,7 +347,12 @@ class Generator
         $capabilities = $method->getCapabilities();
 
         // Should we generate documentation that is locked behind a capability?
-        if (!empty($capabilities) && !empty($this->load_capability_docs)) {
+        if (!empty($capabilities) && !is_null($this->load_capability_docs)) {
+            // We don't have any configured capabilities to pull documentation for, so this URI shouldn't be parsed.
+            if (empty($this->load_capability_docs)) {
+                return false;
+            }
+
             $all_found = true;
 
             /** @var CapabilityAnnotation $capability */

--- a/tests/Command/ChangelogTest.php
+++ b/tests/Command/ChangelogTest.php
@@ -63,14 +63,9 @@ class ChangelogTest extends \PHPUnit_Framework_TestCase
             $params['--capability'] = $capabilities;
         }
 
-//print_r($params);exit;
-
         $this->tester->execute($params);
 
         $blueprints_dir = __DIR__ . '/../../resources/examples/Showtimes/blueprints';
-
-//print_r(file_get_contents($blueprints_dir . '/' . $expected_file));
-
         $this->assertSame(
             file_get_contents($blueprints_dir . '/' . $expected_file),
             file_get_contents($output_dir . '/changelog.md'),

--- a/tests/Generator/ChangelogTest.php
+++ b/tests/Generator/ChangelogTest.php
@@ -308,7 +308,7 @@ class ChangelogTest extends TestCase
             // Complete changelog. All documentation parsed.
             'complete-changelog' => [
                 'private_objects' => true,
-                'capabilities' => [],
+                'capabilities' => null,
                 'expected' => [
                     '1.1.3' => [
                         'added' => [
@@ -372,7 +372,12 @@ class ChangelogTest extends TestCase
             // Changelog with public-only parsed docs and all capabilities.
             'changelog-public-docs-with-all-capabilities' => [
                 'private_objects' => false,
-                'capabilities' => [],
+                'capabilities' => [
+                    'BUY_TICKETS',
+                    'DELETE_CONTENT',
+                    'FEATURE_FLAG',
+                    'MOVIE_RATINGS'
+                ],
                 'expected' => [
                     '1.1.3' => [
                         'added' => [
@@ -408,9 +413,18 @@ class ChangelogTest extends TestCase
                         'added' => [
                             'representations' => [
                                 'Movie' => $representations['Movie']['1.1']['added']
+
                             ],
                             'resources' => [
-                                '/movies/{id}' => $actions['/movies/{id}']['1.1']['added'],
+                                '/movies/{id}' => call_user_func(function () use ($actions) {
+                                    $action = $actions['/movies/{id}']['1.1']['added'];
+                                    $action[Changelog::CHANGE_ACTION][] = [
+                                        'method' => 'DELETE',
+                                        'uri' => '/movies/{id}'
+                                    ];
+
+                                    return $action;
+                                }),
                                 '/movies' => $actions['/movies']['1.1']['added']
                             ]
                         ],
@@ -542,7 +556,61 @@ class ChangelogTest extends TestCase
                         ]
                     ]
                 ]
-            ]
+            ],
+
+            // Changelog with public-only parsed docs
+            'changelog-public-docs-with-unmatched-capabilities' => [
+                'private_objects' => false,
+                'capabilities' => [],
+                'expected' => [
+                    '1.1.3' => [
+                        'added' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.3']['added'],
+                                '/movies' => $actions['/movies']['1.1.3']['added']
+                            ]
+                        ],
+                        'removed' => [
+                            'representations' => [
+                                'Movie' => $representations['Movie']['1.1.3']['removed']
+                            ]
+                        ]
+                    ],
+                    '1.1.2' => [
+                        'changed' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.2']['changed'],
+                                '/movies' => $actions['/movies']['1.1.2']['changed'],
+                                '/theaters/{id}' => $actions['/theaters/{id}']['1.1.2']['changed'],
+                                '/theaters' => $actions['/theaters']['1.1.2']['changed']
+                            ]
+                        ]
+                    ],
+                    '1.1.1' => [
+                        'added' => [
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1.1']['added']
+                            ]
+                        ]
+                    ],
+                    '1.1' => [
+                        'added' => [
+                            'representations' => [
+                                'Movie' => $representations['Movie']['1.1']['added']
+                            ],
+                            'resources' => [
+                                '/movies/{id}' => $actions['/movies/{id}']['1.1']['added'],
+                                '/movies' => $actions['/movies']['1.1']['added']
+                            ]
+                        ],
+                        'removed' => [
+                            'representations' => [
+                                'Theater' => $representations['Theater']['1.1']['removed']
+                            ]
+                        ]
+                    ]
+                ],
+            ],
         ];
     }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -499,7 +499,7 @@ class GeneratorTest extends TestCase
             'version-1.0' => [
                 'version' => '1.0',
                 'private_objects' => true,
-                'capabilities' => [],
+                'capabilities' => null,
                 'expected.representations' => array_merge($error_representations, [
                     '\Mill\Examples\Showtimes\Representations\Movie' => $representations['Movie'],
                     '\Mill\Examples\Showtimes\Representations\Person' => $representations['Person'],
@@ -552,7 +552,12 @@ class GeneratorTest extends TestCase
             'version-1.0-public-docs-with-all-capabilities' => [
                 'version' => '1.0',
                 'private_objects' => false,
-                'capabilities' => [],
+                'capabilities' => [
+                    'BUY_TICKETS',
+                    'DELETE_CONTENT',
+                    'FEATURE_FLAG',
+                    'MOVIE_RATINGS'
+                ],
                 'expected.representations' => array_merge($error_representations, [
                     '\Mill\Examples\Showtimes\Representations\Movie' => $representations['Movie'],
                     '\Mill\Examples\Showtimes\Representations\Person' => $representations['Person'],
@@ -603,7 +608,7 @@ class GeneratorTest extends TestCase
             'version-1.1' => [
                 'version' => '1.1',
                 'private_objects' => true,
-                'capabilities' => [],
+                'capabilities' => null,
                 'expected.representations' => array_merge($error_representations, [
                     '\Mill\Examples\Showtimes\Representations\Movie' => call_user_func(
                         function () use ($representations) {
@@ -828,7 +833,7 @@ class GeneratorTest extends TestCase
             'version-1.1.1' => [
                 'version' => '1.1.1',
                 'private_objects' => true,
-                'capabilities' => [],
+                'capabilities' => null,
                 'expected.representations' => array_merge($error_representations, [
                     '\Mill\Examples\Showtimes\Representations\Movie' => call_user_func(
                         function () use ($representations) {
@@ -867,6 +872,89 @@ class GeneratorTest extends TestCase
                                         return $action;
                                     }),
                                     '/movies/+id::DELETE' => $actions['/movies/+id::DELETE'],
+                                    '/movies::GET' => call_user_func(function () use ($actions) {
+                                        $action = $actions['/movies::GET'];
+                                        $action['params.keys'][] = 'page';
+                                        $action['annotations.sum']['param']++;
+
+                                        return $action;
+                                    }),
+                                    '/movies::POST' => call_user_func(function () use ($actions) {
+                                        $action = $actions['/movies::POST'];
+                                        $action['params.keys'][] = 'imdb';
+                                        $action['params.keys'][] = 'trailer';
+
+                                        $action['annotations.sum']['param']++;
+                                        $action['annotations.sum']['param']++;
+
+                                        sort($action['params.keys']);
+
+                                        return $action;
+                                    })
+                                ]
+                            ]
+                        ]
+                    ],
+                    'Theaters' => [
+                        'resources' => [
+                            [
+                                'resource.name' => 'Movie Theaters',
+                                'description.length' => 119,
+                                'actions.data' => [
+                                    '/theaters/+id::GET' => $actions['/theaters/+id::GET'],
+                                    '/theaters/+id::PATCH' => $actions['/theaters/+id::PATCH'],
+                                    '/theaters/+id::DELETE' => $actions['/theaters/+id::DELETE'],
+                                    '/theaters::GET' => $actions['/theaters::GET'],
+                                    '/theaters::POST' => $actions['/theaters::POST']
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+
+            // API v1.1.1 with public-only documentation
+            'version-1.1.1-public-only-documentation' => [
+                'version' => '1.1.1',
+                'private_objects' => true,
+                'capabilities' => [],
+                'expected.representations' => array_merge($error_representations, [
+                    '\Mill\Examples\Showtimes\Representations\Movie' => call_user_func(
+                        function () use ($representations) {
+                            $representation = $representations['Movie'];
+                            $representation['content.keys'] = array_merge($representation['content.keys'], [
+                                'external_urls',
+                                'external_urls.imdb',
+                                'external_urls.tickets',
+                                'external_urls.trailer'
+                            ]);
+
+                            sort($representation['content.keys']);
+                            return $representation;
+                        }
+                    ),
+                    '\Mill\Examples\Showtimes\Representations\Person' => $representations['Person'],
+                    '\Mill\Examples\Showtimes\Representations\Theater' => $representations['Theater']
+                ]),
+                'expected.resources' => [
+                    'Movies' => [
+                        'resources' => [
+                            [
+                                'resource.name' => 'Movies',
+                                'description.length' => 103,
+                                'actions.data' => [
+                                    '/movie/+id::GET' => $actions['/movie/+id::GET'],
+                                    '/movies/+id::GET' => $actions['/movies/+id::GET'],
+                                    '/movies/+id::PATCH' => call_user_func(function () use ($actions) {
+                                        $action = $actions['/movies/+id::PATCH'];
+                                        $action['params.keys'][] = 'imdb';
+
+                                        $action['annotations.sum']['param']++;
+
+                                        sort($action['params.keys']);
+
+                                        return $action;
+                                    }),
                                     '/movies::GET' => call_user_func(function () use ($actions) {
                                         $action = $actions['/movies::GET'];
                                         $action['params.keys'][] = 'page';


### PR DESCRIPTION
This fixes some issues where if you're trying to pull capability-locked documentation, but don't actually pass in any capabilities, you don't want to end up getting capability-locked documentation.

Now if you want all documentation, capability-locked or not, you should pass in a `null` value to `Generator::setLoadCapabilityDocs`.