### PR TITLE
URI aliases are now filtered for visibility when running the generator.

### DIFF
--- a/src/Parser/Annotation.php
+++ b/src/Parser/Annotation.php
@@ -73,7 +73,7 @@ abstract class Annotation
     /**
      * Array of all available aliases for this annotation.
      *
-     * @var array
+     * @var array<Annotation>
      */
     protected $aliases = [];
 
@@ -468,7 +468,7 @@ abstract class Annotation
     /**
      * Get all available aliases for this annotation.
      *
-     * @return array
+     * @return array<Annotation>
      */
     public function getAliases()
     {

--- a/src/Parser/Resource/Action/Documentation.php
+++ b/src/Parser/Resource/Action/Documentation.php
@@ -479,9 +479,22 @@ class Documentation
         foreach ($this->annotations as $name => $data) {
             /** @var Parser\Annotation $annotation */
             foreach ($data as $k => $annotation) {
-                // URI annotations are already filtered within the generator, so we don't need to further filter them
-                // out from the list of annotations.
+                // While URI annotations are already filtered within the generator, so we don't need to further filter
+                // them out, we do need to filter URI aliases as those can have their independent visibilities.
                 if ($annotation instanceof UriAnnotation) {
+                    $aliases = $annotation->getAliases();
+                    if (!empty($aliases)) {
+                        /** @var UriAnnotation $alias */
+                        foreach ($aliases as $k => $alias) {
+                            // If this annotation isn't visible, and we don't want private documentation, filter it out.
+                            if (!$allow_private && $alias->hasVisibility() && !$alias->isVisible()) {
+                                unset($aliases[$k]);
+                            }
+                        }
+
+                        $annotation->setAliases($aliases);
+                    }
+
                     continue;
                 }
 


### PR DESCRIPTION
This fixes some issues with the new generator visibility work I did as part of #97 where private URI aliases were still being generated when you didn't want private resources.