### PR TITLE
Wrapping important content in the JSON changelog in HTML styles.

### DIFF
--- a/resources/examples/Showtimes/blueprints/changelog-public-only-all-capabilities.md
+++ b/resources/examples/Showtimes/blueprints/changelog-public-only-all-capabilities.md
@@ -3,12 +3,12 @@
 ## 1.1.3
 ### Added
 #### Resources
-- The GET on `/movies/{id}` can now throw the following errors:
+- The `GET` on `/movies/{id}` can now throw the following errors:
     - `404 Not Found` with a `Error` representation: For no reason.
     - `404 Not Found` with a `Error` representation: For some other reason.
-- PATCH on `/movies/{id}` now returns a `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
-- PATCH on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
-- POST on `/movies` now returns a `201 Created`.
+- `PATCH` on `/movies/{id}` now returns a `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
+- `PATCH` on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
+- `POST` on `/movies` now returns a `201 Created`.
 
 ### Removed
 #### Representations
@@ -33,7 +33,7 @@
 ## 1.1.1
 ### Added
 #### Resources
-- A `imdb` request parameter was added to PATCH on `/movies/{id}`.
+- A `imdb` request parameter was added to `PATCH` on `/movies/{id}`.
 
 ## 1.1
 ### Added
@@ -45,9 +45,9 @@
     - `external_urls.trailer`
 
 #### Resources
-- PATCH on `/movies/{id}` was added.
-- A `page` request parameter was added to GET on `/movies`.
-- The following parameters have been added to POST on `/movies`:
+- `PATCH` on `/movies/{id}` was added.
+- A `page` request parameter was added to `GET` on `/movies`.
+- The following parameters have been added to `POST` on `/movies`:
     - `imdb`
     - `trailer`
 

--- a/resources/examples/Showtimes/blueprints/changelog-public-only-matched-capabilities.md
+++ b/resources/examples/Showtimes/blueprints/changelog-public-only-matched-capabilities.md
@@ -3,12 +3,12 @@
 ## 1.1.3
 ### Added
 #### Resources
-- The GET on `/movies/{id}` can now throw the following errors:
+- The `GET` on `/movies/{id}` can now throw the following errors:
     - `404 Not Found` with a `Error` representation: For no reason.
     - `404 Not Found` with a `Error` representation: For some other reason.
-- PATCH on `/movies/{id}` now returns a `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
-- PATCH on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
-- POST on `/movies` now returns a `201 Created`.
+- `PATCH` on `/movies/{id}` now returns a `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
+- `PATCH` on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
+- `POST` on `/movies` now returns a `201 Created`.
 
 ### Removed
 #### Representations
@@ -33,7 +33,7 @@
 ## 1.1.1
 ### Added
 #### Resources
-- A `imdb` request parameter was added to PATCH on `/movies/{id}`.
+- A `imdb` request parameter was added to `PATCH` on `/movies/{id}`.
 
 ## 1.1
 ### Added
@@ -48,8 +48,8 @@
 - `/movies/{id}` has been added with support for the following HTTP methods:
     - `PATCH`
     - `DELETE`
-- A `page` request parameter was added to GET on `/movies`.
-- The following parameters have been added to POST on `/movies`:
+- A `page` request parameter was added to `GET` on `/movies`.
+- The following parameters have been added to `POST` on `/movies`:
     - `imdb`
     - `trailer`
 

--- a/resources/examples/Showtimes/blueprints/changelog-public-only-unmatched-capabilities.md
+++ b/resources/examples/Showtimes/blueprints/changelog-public-only-unmatched-capabilities.md
@@ -3,12 +3,12 @@
 ## 1.1.3
 ### Added
 #### Resources
-- The GET on `/movies/{id}` can now throw the following errors:
+- The `GET` on `/movies/{id}` can now throw the following errors:
     - `404 Not Found` with a `Error` representation: For no reason.
     - `404 Not Found` with a `Error` representation: For some other reason.
-- PATCH on `/movies/{id}` now returns a `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
-- PATCH on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
-- POST on `/movies` now returns a `201 Created`.
+- `PATCH` on `/movies/{id}` now returns a `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
+- `PATCH` on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
+- `POST` on `/movies` now returns a `201 Created`.
 
 ### Removed
 #### Representations
@@ -33,7 +33,7 @@
 ## 1.1.1
 ### Added
 #### Resources
-- A `imdb` request parameter was added to PATCH on `/movies/{id}`.
+- A `imdb` request parameter was added to `PATCH` on `/movies/{id}`.
 
 ## 1.1
 ### Added
@@ -45,9 +45,9 @@
     - `external_urls.trailer`
 
 #### Resources
-- PATCH on `/movies/{id}` was added.
-- A `page` request parameter was added to GET on `/movies`.
-- The following parameters have been added to POST on `/movies`:
+- `PATCH` on `/movies/{id}` was added.
+- A `page` request parameter was added to `GET` on `/movies`.
+- The following parameters have been added to `POST` on `/movies`:
     - `imdb`
     - `trailer`
 

--- a/resources/examples/Showtimes/blueprints/changelog.md
+++ b/resources/examples/Showtimes/blueprints/changelog.md
@@ -3,15 +3,15 @@
 ## 1.1.3
 ### Added
 #### Resources
-- The GET on `/movie/{id}` can now throw the following errors:
+- The `GET` on `/movie/{id}` can now throw the following errors:
     - `404 Not Found` with a `Error` representation: For no reason.
     - `404 Not Found` with a `Error` representation: For some other reason.
-- The GET on `/movies/{id}` can now throw the following errors:
+- The `GET` on `/movies/{id}` can now throw the following errors:
     - `404 Not Found` with a `Error` representation: For no reason.
     - `404 Not Found` with a `Error` representation: For some other reason.
-- PATCH on `/movies/{id}` now returns a `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
-- PATCH on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
-- POST on `/movies` now returns a `201 Created`.
+- `PATCH` on `/movies/{id}` now returns a `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
+- `PATCH` on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
+- `POST` on `/movies` now returns a `201 Created`.
 
 ### Removed
 #### Representations
@@ -20,7 +20,7 @@
 ## 1.1.2
 ### Changed
 #### Resources
-- GET on `/movie/{id}` now returns a `application/mill.example.movie` Content-Type header.
+- `GET` on `/movie/{id}` now returns a `application/mill.example.movie` Content-Type header.
 - `/movies/{id}` now returns a `application/mill.example.movie` Content-Type header on the following HTTP methods:
     - `GET`
     - `PATCH`
@@ -37,7 +37,7 @@
 ## 1.1.1
 ### Added
 #### Resources
-- A `imdb` request parameter was added to PATCH on `/movies/{id}`.
+- A `imdb` request parameter was added to `PATCH` on `/movies/{id}`.
 
 ## 1.1
 ### Added
@@ -52,8 +52,8 @@
 - `/movies/{id}` has been added with support for the following HTTP methods:
     - `PATCH`
     - `DELETE`
-- A `page` request parameter was added to GET on `/movies`.
-- The following parameters have been added to POST on `/movies`:
+- A `page` request parameter was added to `GET` on `/movies`.
+- The following parameters have been added to `POST` on `/movies`:
     - `imdb`
     - `trailer`
 

--- a/src/Generator/Changelog/Json.php
+++ b/src/Generator/Changelog/Json.php
@@ -7,6 +7,8 @@ use StringTemplate\Engine;
 
 class Json extends Generator
 {
+    const CSS_NAMESPACE = 'mill-changelog';
+
     /**
      * Template string engine.
      *
@@ -29,58 +31,57 @@ class Json extends Generator
     protected $changeset_templates = [
         'plural' => [
             Changelog::CHANGE_ACTION => [
-                'added' => '`{uri}` has been added with support for the following HTTP methods:',
+                'added' => '{uri} has been added with support for the following HTTP methods:',
             ],
             Changelog::CHANGE_ACTION_PARAM => [
-                'added' => 'The following parameters have been added to {method} on `{uri}`:',
-                'removed' => 'The following parameters have been removed to {method} on `{uri}`:'
+                'added' => 'The following parameters have been added to {method} on {uri}:',
+                'removed' => 'The following parameters have been removed to {method} on {uri}:'
             ],
             Changelog::CHANGE_ACTION_RETURN => [
-                'added' => 'The {method} on `{uri}` will now return the following responses:',
-                'removed' => 'The {method} on `{uri}` no longer returns the following responses:'
+                'added' => 'The {method} on {uri} will now return the following responses:',
+                'removed' => 'The {method} on {uri} no longer returns the following responses:'
             ],
             Changelog::CHANGE_ACTION_THROWS => [
-                'added' => 'The {method} on `{uri}` can now throw the following errors:',
-                'removed' => 'The {method} on `{uri}` will no longer throw the following errors:'
+                'added' => 'The {method} on {uri} can now throw the following errors:',
+                'removed' => 'The {method} on {uri} will no longer throw the following errors:'
             ],
             Changelog::CHANGE_CONTENT_TYPE => [
-                'changed' => '`{uri}` now returns a `{content_type}` Content-Type header on the following HTTP ' .
+                'changed' => '{uri} now returns a {content_type} Content-Type header on the following HTTP ' .
                     'methods:',
             ],
             Changelog::CHANGE_REPRESENTATION_DATA => [
-                'added' => 'The following fields have been added to the `{representation}` representation:',
-                'removed' => 'The following fields have been removed from the `{representation}` representation:'
+                'added' => 'The following fields have been added to the {representation} representation:',
+                'removed' => 'The following fields have been removed from the {representation} representation:'
             ]
         ],
         'singular' => [
             Changelog::CHANGE_ACTION => [
-                'added' => '{method} on `{uri}` was added.'
+                'added' => '{method} on {uri} was added.'
             ],
             Changelog::CHANGE_ACTION_PARAM => [
-                'added' => 'A `{parameter}` request parameter was added to {method} on `{uri}`.',
-                'removed' => 'The `{parameter}` request parameter has been removed from {method} requests on `{uri}`.'
+                'added' => 'A {parameter} request parameter was added to {method} on {uri}.',
+                'removed' => 'The {parameter} request parameter has been removed from {method} requests on {uri}.'
             ],
             Changelog::CHANGE_ACTION_RETURN => [
-                'added' => '{method} on `{uri}` now returns a `{http_code}` with a `{representation}` representation.',
-                'removed' => '{method} on `{uri}` no longer returns a `{http_code}` with a `{representation}` ' .
-                    'representation.'
+                'added' => '{method} on {uri} now returns a {http_code} with a {representation} representation.',
+                'removed' => '{method} on {uri} no longer returns a {http_code} with a {representation} representation.'
             ],
             Changelog::CHANGE_ACTION_RETURN . '_no_representation' => [
-                'added' => '{method} on `{uri}` now returns a `{http_code}`.',
-                'removed' => '{method} on `{uri}` no longer will return a `{http_code}`.'
+                'added' => '{method} on {uri} now returns a {http_code}.',
+                'removed' => '{method} on {uri} no longer will return a {http_code}.'
             ],
             Changelog::CHANGE_ACTION_THROWS => [
-                'added' => '{method} on `{uri}` now returns a `{http_code}` with a `{representation}` ' .
-                    'representation: {description}',
-                'removed' => '{method} on `{uri}` longer will return a `{http_code}` with a `{representation}` ' .
+                'added' => '{method} on {uri} now returns a {http_code} with a {representation} representation: ' .
+                    '{description}',
+                'removed' => '{method} on {uri} longer will return a {http_code} with a {representation} ' .
                     'representation: {description}'
             ],
             Changelog::CHANGE_CONTENT_TYPE => [
-                'changed' => '{method} on `{uri}` now returns a `{content_type}` Content-Type header.'
+                'changed' => '{method} on {uri} now returns a {content_type} Content-Type header.'
             ],
             Changelog::CHANGE_REPRESENTATION_DATA => [
-                'added' => '`{field}` has been added to the `{representation}` representation.',
-                'removed' => '`{field}` has been removed from the `{representation}` representation.'
+                'added' => '{field} has been added to the {representation} representation.',
+                'removed' => '{field} has been removed from the {representation} representation.'
             ]
         ]
     ];
@@ -151,13 +152,13 @@ class Json extends Generator
                 case Changelog::CHANGE_ACTION:
                     $methods = [];
                     foreach ($changesets as $change) {
-                        $methods[] = sprintf('`%s`', $change['method']);
+                        $methods[] = $this->renderText('{method}', $change);
                     }
 
                     $template = $this->changeset_templates['plural'][$identifier][$change_type];
                     return [
                         [
-                            $this->template_engine->render($template, [
+                            $this->renderText($template, [
                                 'uri' => $header
                             ]),
                             $methods
@@ -168,7 +169,7 @@ class Json extends Generator
                 case Changelog::CHANGE_ACTION_PARAM:
                     $methods = [];
                     foreach ($changesets as $change) {
-                        $methods[$change['method']][] = sprintf('`%s`', $change['parameter']);
+                        $methods[$change['method']][] = $this->renderText('{parameter}', $change);
                     }
 
                     $entry = [];
@@ -176,7 +177,7 @@ class Json extends Generator
                         if (count($params) > 1) {
                             $template = $this->changeset_templates['plural'][$identifier][$change_type];
                             $entry[] = [
-                                $this->template_engine->render($template, [
+                                $this->renderText($template, [
                                     'method' => $method,
                                     'uri' => $header
                                 ]),
@@ -187,7 +188,7 @@ class Json extends Generator
                         }
 
                         $template = $this->changeset_templates['singular'][$identifier][$change_type];
-                        $entry[] = $this->template_engine->render($template, [
+                        $entry[] = $this->renderText($template, [
                             'parameter' => rtrim(ltrim(array_shift($params), '`'), '`'),
                             'method' => $method,
                             'uri' => $header
@@ -209,19 +210,18 @@ class Json extends Generator
                             $returns = [];
                             foreach ($changes as $change) {
                                 if ($change['representation']) {
-                                    $returns[] = sprintf(
-                                        '`%s` with a `%s` representation',
-                                        $change['http_code'],
-                                        $change['representation']
+                                    $returns[] = $this->renderText(
+                                        '{http_code} with a {representation} representation',
+                                        $change
                                     );
                                 } else {
-                                    $returns[] = sprintf('`%s`', $change['http_code']);
+                                    $returns[] = $this->renderText('{http_code}', $change);
                                 }
                             }
 
                             $template = $this->changeset_templates['plural'][$identifier][$change_type];
                             $entry[] = [
-                                $this->template_engine->render($template, [
+                                $this->renderText($template, [
                                     'method' => $method,
                                     'uri' => $header
                                 ]),
@@ -233,7 +233,7 @@ class Json extends Generator
 
                         $change = array_shift($changes);
                         $template = $this->changeset_templates['singular'][$identifier][$change_type];
-                        $entry[] = $this->template_engine->render($template, $change);
+                        $entry[] = $this->renderText($template, $change);
                     }
 
                     return $entry;
@@ -250,17 +250,15 @@ class Json extends Generator
                         if (count($changes) > 1) {
                             $errors = [];
                             foreach ($changes as $change) {
-                                $errors[] = sprintf(
-                                    '`%s` with a `%s` representation: %s',
-                                    $change['http_code'],
-                                    $change['representation'],
-                                    $change['description']
+                                $errors[] = $this->renderText(
+                                    '{http_code} with a {representation} representation: {description}',
+                                    $change
                                 );
                             }
 
                             $template = $this->changeset_templates['plural'][$identifier][$change_type];
                             $entry[] = [
-                                $this->template_engine->render($template, [
+                                $this->renderText($template, [
                                     'method' => $method,
                                     'uri' => $header
                                 ]),
@@ -272,7 +270,7 @@ class Json extends Generator
 
                         $change = array_shift($changes);
                         $template = $this->changeset_templates['singular'][$identifier][$change_type];
-                        $entry[] = $this->template_engine->render($template, $change);
+                        $entry[] = $this->renderText($template, $change);
                     }
 
                     return $entry;
@@ -281,13 +279,13 @@ class Json extends Generator
                 case Changelog::CHANGE_REPRESENTATION_DATA:
                     $fields = [];
                     foreach ($changesets as $change) {
-                        $fields[] = sprintf('`%s`', $change['field']);
+                        $fields[] = $this->renderText('{field}', $change);
                     }
 
                     $template = $this->changeset_templates['plural'][$identifier][$change_type];
                     return [
                         [
-                            $this->template_engine->render($template, [
+                            $this->renderText($template, [
                                 'representation' => $header
                             ]),
                             $fields
@@ -306,7 +304,7 @@ class Json extends Generator
             case Changelog::CHANGE_ACTION_THROWS:
             case Changelog::CHANGE_REPRESENTATION_DATA:
                 $template = $this->changeset_templates['singular'][$identifier][$change_type];
-                return $this->template_engine->render($template, $changeset);
+                return $this->renderText($template, $changeset);
                 break;
 
             case Changelog::CHANGE_ACTION_RETURN:
@@ -317,7 +315,7 @@ class Json extends Generator
                     $template = $this->changeset_templates['singular'][$template_key][$change_type];
                 }
 
-                return $this->template_engine->render($template, $changeset);
+                return $this->renderText($template, $changeset);
                 break;
         }
 
@@ -341,14 +339,14 @@ class Json extends Generator
                 if (count($changesets) > 1) {
                     $content_types = [];
                     foreach ($changesets as $changeset) {
-                        $content_types[$changeset['content_type']][] = sprintf('`%s`', $changeset['method']);
+                        $content_types[$changeset['content_type']][] = $this->renderText('{method}', $changeset);
                     }
 
                     $entry = [];
                     $template = $this->changeset_templates['plural'][$identifier]['changed'];
                     foreach ($content_types as $content_type => $methods) {
                         $entry[] = [
-                            $this->template_engine->render($template, [
+                            $this->renderText($template, [
                                 'uri' => $header,
                                 'content_type' => $content_type
                             ]),
@@ -361,10 +359,53 @@ class Json extends Generator
 
                 $changeset = array_shift($changesets);
                 $template = $this->changeset_templates['singular'][$identifier]['changed'];
-                return $this->template_engine->render($template, $changeset);
+                return $this->renderText($template, $changeset);
                 break;
         }
 
         return false;
+    }
+
+    /**
+     * Render a changelog template with some content.
+     *
+     * @param string $template
+     * @param array $content
+     * @return string
+     */
+    public function renderText($template, array $content)
+    {
+        $searches = [];
+        $replacements = [];
+        foreach ($content as $key => $value) {
+            switch ($key) {
+                case 'content_type':
+                case 'field':
+                case 'http_code':
+                case 'method':
+                case 'parameter':
+                case 'representation':
+                case 'uri':
+                    $searches[] = '{' . $key . '}';
+                    $replacements[] = sprintf(
+                        '<span class="{css_namespace}_%s" data-mill-%s="{%s}">{%s}</span>',
+                        $key,
+                        str_replace('_', '-', $key),
+                        $key,
+                        $key
+                    );
+                    break;
+
+                case 'description':
+                default:
+                    // do nothing
+            }
+        }
+
+        $template = str_replace($searches, $replacements, $template);
+
+        $content['css_namespace'] = self::CSS_NAMESPACE;
+
+        return $this->template_engine->render($template, $content);
     }
 }

--- a/src/Generator/Changelog/Markdown.php
+++ b/src/Generator/Changelog/Markdown.php
@@ -84,4 +84,39 @@ class Markdown extends Json
 
         return $markdown;
     }
+
+    /**
+     * Render a changelog template with some content.
+     *
+     * @param string $template
+     * @param array $content
+     * @return string
+     */
+    public function renderText($template, array $content)
+    {
+        $searches = [];
+        $replacements = [];
+        foreach ($content as $key => $value) {
+            switch ($key) {
+                case 'content_type':
+                case 'field':
+                case 'http_code':
+                case 'method':
+                case 'parameter':
+                case 'representation':
+                case 'uri':
+                    $searches[] = '{' . $key . '}';
+                    $replacements[] = '`{' . $key . '}`';
+                    break;
+
+                case 'description':
+                default:
+                    // do nothing
+            }
+        }
+
+        $template = str_replace($searches, $replacements, $template);
+
+        return $this->template_engine->render($template, $content);
+    }
 }

--- a/tests/Generator/Changelog/JsonTest.php
+++ b/tests/Generator/Changelog/JsonTest.php
@@ -27,92 +27,137 @@ class JsonTest extends TestCase
                 'resources' => [
                     [
                         [
-                            'The GET on `/movie/{id}` can now throw the following errors:',
+                            'The <span class="mill-changelog_method" data-mill-method="GET">GET</span> on <span ' .
+                                'class="mill-changelog_uri" data-mill-uri="/movie/{id}">/movie/{id}</span> can now ' .
+                                'throw the following errors:',
                             [
-                                '`404 Not Found` with a `Error` representation: For no reason.',
-                                '`404 Not Found` with a `Error` representation: For some other reason.'
+                                '<span class="mill-changelog_http_code" data-mill-http-code="404 Not Found">404 Not ' .
+                                    'Found</span> with a <span class="mill-changelog_representation" ' .
+                                    'data-mill-representation="Error">Error</span> representation: For no reason.',
+                                '<span class="mill-changelog_http_code" data-mill-http-code="404 Not Found">404 Not ' .
+                                    'Found</span> with a <span class="mill-changelog_representation" ' .
+                                    'data-mill-representation="Error">Error</span> representation: For some other ' .
+                                    'reason.'
                             ]
                         ]
                     ],
                     [
                         [
-                            'The GET on `/movies/{id}` can now throw the following errors:',
+                            'The <span class="mill-changelog_method" data-mill-method="GET">GET</span> on <span ' .
+                                'class="mill-changelog_uri" data-mill-uri="/movies/{id}">/movies/{id}</span> can ' .
+                                'now throw the following errors:',
                             [
-                                '`404 Not Found` with a `Error` representation: For no reason.',
-                                '`404 Not Found` with a `Error` representation: For some other reason.'
+                                '<span class="mill-changelog_http_code" data-mill-http-code="404 Not Found">404 Not ' .
+                                    'Found</span> with a <span class="mill-changelog_representation" ' .
+                                    'data-mill-representation="Error">Error</span> representation: For no reason.',
+                                '<span class="mill-changelog_http_code" data-mill-http-code="404 Not Found">404 Not ' .
+                                    'Found</span> with a <span class="mill-changelog_representation" ' .
+                                    'data-mill-representation="Error">Error</span> representation: For some other ' .
+                                    'reason.'
                             ]
                         ],
-                        'PATCH on `/movies/{id}` now returns a `404 Not Found` with a `Error` representation: If ' .
-                        'the trailer URL could not be validated.'
+                        '<span class="mill-changelog_method" data-mill-method="PATCH">PATCH</span> on ' .
+                            '<span class="mill-changelog_uri" data-mill-uri="/movies/{id}">/movies/{id}</span> now ' .
+                            'returns a <span class="mill-changelog_http_code" data-mill-http-code="404 Not Found">' .
+                            '404 Not Found</span> with a <span class="mill-changelog_representation" ' .
+                            'data-mill-representation="Error">Error</span> representation: If the trailer URL could ' .
+                            'not be validated.'
                     ],
-                    'PATCH on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.',
-                    'POST on `/movies` now returns a `201 Created`.'
+                    '<span class="mill-changelog_method" data-mill-method="PATCH">PATCH</span> on <span ' .
+                        'class="mill-changelog_uri" data-mill-uri="/movies/{id}">/movies/{id}</span> now returns a ' .
+                        '<span class="mill-changelog_http_code" data-mill-http-code="202 Accepted">202 ' .
+                        'Accepted</span> with a <span class="mill-changelog_representation" ' .
+                        'data-mill-representation="Movie">Movie</span> representation.',
+                    '<span class="mill-changelog_method" data-mill-method="POST">POST</span> on <span ' .
+                        'class="mill-changelog_uri" data-mill-uri="/movies">/movies</span> now returns a <span ' .
+                        'class="mill-changelog_http_code" data-mill-http-code="201 Created">201 Created</span>.'
                 ]
             ],
             'removed' => [
                 'representations' => [
-                    '`external_urls.tickets` has been removed from the `Movie` representation.'
+                    //'external_urls.tickets has been removed from the Movie representation.'
+                    '<span class="mill-changelog_field" data-mill-field="external_urls.tickets">external_urls.tickets' .
+                        '</span> has been removed from the <span class="mill-changelog_representation" ' .
+                        'data-mill-representation="Movie">Movie</span> representation.'
                 ]
             ]
-        ], $generated['1.1.3']);
+        ], $generated['1.1.3'], '1.1.3 changelog does not match');
 
         // v1.1.2
         $this->assertSame([
             'changed' => [
                 'resources' => [
-                    'GET on `/movie/{id}` now returns a `application/mill.example.movie` Content-Type header.',
+                    '<span class="mill-changelog_method" data-mill-method="GET">GET</span> on <span ' .
+                        'class="mill-changelog_uri" data-mill-uri="/movie/{id}">/movie/{id}</span> now returns a ' .
+                        '<span class="mill-changelog_content_type" ' .
+                        'data-mill-content-type="application/mill.example.movie">application/mill.example.movie' .
+                        '</span> Content-Type header.',
                     [
                         [
-                            '`/movies/{id}` now returns a `application/mill.example.movie` Content-Type header on ' .
-                            'the following HTTP methods:',
+                            '<span class="mill-changelog_uri" data-mill-uri="/movies/{id}">/movies/{id}</span> now ' .
+                                'returns a <span class="mill-changelog_content_type" ' .
+                                'data-mill-content-type="application/mill.example.movie">' .
+                                'application/mill.example.movie</span> Content-Type header on the following HTTP ' .
+                                'methods:',
                             [
-                                '`GET`',
-                                '`PATCH`'
+                                '<span class="mill-changelog_method" data-mill-method="GET">GET</span>',
+                                '<span class="mill-changelog_method" data-mill-method="PATCH">PATCH</span>'
                             ]
                         ]
                     ],
                     [
                         [
-                            '`/movies` now returns a `application/mill.example.movie` Content-Type header on the ' .
-                            'following HTTP methods:',
+                            '<span class="mill-changelog_uri" data-mill-uri="/movies">/movies</span> now returns a ' .
+                                '<span class="mill-changelog_content_type" ' .
+                                'data-mill-content-type="application/mill.example.movie">' .
+                                'application/mill.example.movie</span> Content-Type header on the following HTTP ' .
+                                'methods:',
                             [
-                                '`GET`',
-                                '`POST`'
+                                '<span class="mill-changelog_method" data-mill-method="GET">GET</span>',
+                                '<span class="mill-changelog_method" data-mill-method="POST">POST</span>'
                             ]
                         ]
                     ],
                     [
                         [
-                            '`/theaters/{id}` now returns a `application/mill.example.theater` Content-Type header ' .
-                            'on the following HTTP methods:',
+                            '<span class="mill-changelog_uri" data-mill-uri="/theaters/{id}">/theaters/{id}</span> ' .
+                                'now returns a <span class="mill-changelog_content_type" ' .
+                                'data-mill-content-type="application/mill.example.theater">' .
+                                'application/mill.example.theater</span> Content-Type header on the following HTTP ' .
+                                'methods:',
                             [
-                                '`GET`',
-                                '`PATCH`'
+                                '<span class="mill-changelog_method" data-mill-method="GET">GET</span>',
+                                '<span class="mill-changelog_method" data-mill-method="PATCH">PATCH</span>'
                             ]
                         ]
                     ],
                     [
                         [
-                            '`/theaters` now returns a `application/mill.example.theater` Content-Type header on the ' .
-                            'following HTTP methods:',
+                            '<span class="mill-changelog_uri" data-mill-uri="/theaters">/theaters</span> now ' .
+                                'returns a <span class="mill-changelog_content_type" ' .
+                                'data-mill-content-type="application/mill.example.theater">' .
+                                'application/mill.example.theater</span> Content-Type header on the following HTTP ' .
+                                'methods:',
                             [
-                                '`GET`',
-                                '`POST`'
+                                '<span class="mill-changelog_method" data-mill-method="GET">GET</span>',
+                                '<span class="mill-changelog_method" data-mill-method="POST">POST</span>'
                             ]
                         ]
                     ]
                 ]
             ]
-        ], $generated['1.1.2']);
+        ], $generated['1.1.2'], '1.1.2 changelog does not match');
 
         // v1.1.1
         $this->assertSame([
             'added' => [
                 'resources' => [
-                    'A `imdb` request parameter was added to PATCH on `/movies/{id}`.'
+                    'A <span class="mill-changelog_parameter" data-mill-parameter="imdb">imdb</span> request ' .
+                        'parameter was added to <span class="mill-changelog_method" data-mill-method="PATCH">PATCH' .
+                        '</span> on <span class="mill-changelog_uri" data-mill-uri="/movies/{id}">/movies/{id}</span>.'
                 ]
             ]
-        ], $generated['1.1.1']);
+        ], $generated['1.1.1'], '1.1.1 changelog does not match');
 
         // v1.1
         $this->assertSame([
@@ -120,33 +165,45 @@ class JsonTest extends TestCase
                 'representations' => [
                     [
                         [
-                            'The following fields have been added to the `Movie` representation:',
+                            'The following fields have been added to the <span class="mill-changelog_representation" ' .
+                                'data-mill-representation="Movie">Movie</span> representation:',
                             [
-                                '`external_urls`',
-                                '`external_urls.imdb`',
-                                '`external_urls.tickets`',
-                                '`external_urls.trailer`'
+                                '<span class="mill-changelog_field" data-mill-field="external_urls">external_urls' .
+                                    '</span>',
+                                '<span class="mill-changelog_field" data-mill-field="external_urls.imdb">' .
+                                    'external_urls.imdb</span>',
+                                '<span class="mill-changelog_field" data-mill-field="external_urls.tickets">' .
+                                    'external_urls.tickets</span>',
+                                '<span class="mill-changelog_field" data-mill-field="external_urls.trailer">' .
+                                    'external_urls.trailer</span>'
                             ]
                         ]
-                    ],
+                    ]
                 ],
                 'resources' => [
                     [
                         [
-                            '`/movies/{id}` has been added with support for the following HTTP methods:',
+                            '<span class="mill-changelog_uri" data-mill-uri="/movies/{id}">/movies/{id}</span> has ' .
+                                'been added with support for the following HTTP methods:',
                             [
-                                '`PATCH`',
-                                '`DELETE`'
+                                '<span class="mill-changelog_method" data-mill-method="PATCH">PATCH</span>',
+                                '<span class="mill-changelog_method" data-mill-method="DELETE">DELETE</span>'
                             ]
                         ]
                     ],
                     [
-                        'A `page` request parameter was added to GET on `/movies`.',
+                        'A <span class="mill-changelog_parameter" data-mill-parameter="<span ' .
+                            'class="mill-changelog_parameter" data-mill-parameter="page">page</span>"><span ' .
+                            'class="mill-changelog_parameter" data-mill-parameter="page">page</span></span> request ' .
+                            'parameter was added to <span class="mill-changelog_method" data-mill-method="GET">GET' .
+                            '</span> on <span class="mill-changelog_uri" data-mill-uri="/movies">/movies</span>.',
                         [
-                            'The following parameters have been added to POST on `/movies`:',
+                            'The following parameters have been added to <span class="mill-changelog_method" ' .
+                                'data-mill-method="POST">POST</span> on <span class="mill-changelog_uri" ' .
+                                'data-mill-uri="/movies">/movies</span>:',
                             [
-                                '`imdb`',
-                                '`trailer`'
+                                '<span class="mill-changelog_parameter" data-mill-parameter="imdb">imdb</span>',
+                                '<span class="mill-changelog_parameter" data-mill-parameter="trailer">trailer</span>'
                             ]
                         ]
                     ]
@@ -154,10 +211,12 @@ class JsonTest extends TestCase
             ],
             'removed' => [
                 'representations' => [
-                    '`website` has been removed from the `Theater` representation.'
+                    '<span class="mill-changelog_field" data-mill-field="website">website</span> has been removed ' .
+                        'from the <span class="mill-changelog_representation" data-mill-representation="Theater">' .
+                        'Theater</span> representation.'
                 ]
             ]
-        ], $generated['1.1']);
+        ], $generated['1.1'], '1.1 changelog does not match');
     }
 
     /**
@@ -219,13 +278,24 @@ class JsonTest extends TestCase
                             'resources' => [
                                 [
                                     [
-                                        'The POST on `/movies` will now return the following responses:',
+                                        'The <span class="mill-changelog_method" data-mill-method="POST">POST' .
+                                            '</span> on <span class="mill-changelog_uri" data-mill-uri="/movies">' .
+                                            '/movies</span> will now return the following responses:',
                                         [
-                                            '`201 Created`',
-                                            '`200 OK` with a `Movie` representation'
+                                            '<span class="mill-changelog_http_code" ' .
+                                                'data-mill-http-code="201 Created">201 Created</span>',
+                                            '<span class="mill-changelog_http_code" ' .
+                                                'data-mill-http-code="200 OK">200 OK</span> with a <span ' .
+                                                'class="mill-changelog_representation" ' .
+                                                'data-mill-representation="Movie">Movie</span> representation'
                                         ]
                                     ],
-                                    'GET on `/movies` now returns a `200 OK` with a `Movie` representation.'
+                                    '<span class="mill-changelog_method" data-mill-method="GET">GET</span> on <span ' .
+                                        'class="mill-changelog_uri" data-mill-uri="/movies">/movies</span> now ' .
+                                        'returns a <span class="mill-changelog_http_code" ' .
+                                        'data-mill-http-code="200 OK">200 OK</span> with a <span ' .
+                                        'class="mill-changelog_representation" ' .
+                                        'data-mill-representation="Movie">Movie</span> representation.'
                                 ]
                             ]
                         ]
@@ -269,13 +339,23 @@ class JsonTest extends TestCase
                             'resources' => [
                                 [
                                     [
-                                        'The POST on `/movies` no longer returns the following responses:',
+                                        'The <span class="mill-changelog_method" data-mill-method="POST">POST</span> ' .
+                                            'on <span class="mill-changelog_uri" data-mill-uri="/movies">/movies' .
+                                            '</span> no longer returns the following responses:',
                                         [
-                                            '`201 Created`',
-                                            '`200 OK` with a `Movie` representation'
+                                            '<span class="mill-changelog_http_code" ' .
+                                                'data-mill-http-code="201 Created">201 Created</span>',
+                                            '<span class="mill-changelog_http_code" data-mill-http-code="200 OK">' .
+                                                '200 OK</span> with a <span class="mill-changelog_representation" ' .
+                                                'data-mill-representation="Movie">Movie</span> representation'
                                         ]
                                     ],
-                                    'GET on `/movies` no longer returns a `200 OK` with a `Movie` representation.'
+                                    '<span class="mill-changelog_method" data-mill-method="GET">GET</span> on <span ' .
+                                        'class="mill-changelog_uri" data-mill-uri="/movies">/movies</span> no longer ' .
+                                        'returns a <span class="mill-changelog_http_code" ' .
+                                        'data-mill-http-code="200 OK">200 OK</span> with a <span ' .
+                                        'class="mill-changelog_representation" data-mill-representation="Movie">' .
+                                        'Movie</span> representation.'
                                 ]
                             ]
                         ]


### PR DESCRIPTION
This updates the text rendering engine for JSON and Markdown changelog generations to wrap important piece of content in:

- Styleable `<span>` elements, with specific classes, and `data` attributes, in JSON-generated changelogs
- Backticks in Markdown-generated changelogs.

### Styles
The styles, and these will be added to the wiki are:

| Change type | HTML class | `data` attribute |
| :--- | :--- | :--- |
| content_type | mill-changelog_content_type | data-mill-content-type |
| http_code | mill-changelog_http_code | data-mill-http-code |
| method | mill-changelog_method | data-mill-method |
| field | mill-changelog_field | data-mill-field |
| parameter | mill-changelog_parameter | data-mill-parameter |
| representation | mill-changelog_representation | data-mill-representation |
| uri | mill-changelog_uri | data-mill-uri |