### PR TITLE
Adding API version release dates and details to the config file.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "league/flysystem": "^1.0",
         "composer/semver": "^1.4",
         "gossi/docblock": "^1.5",
-        "nicmart/string-template": "^0.1.1"
+        "nicmart/string-template": "^0.1.1",
+        "doctrine/collections": "^1.4"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.7",

--- a/config.xsd
+++ b/config.xsd
@@ -31,8 +31,13 @@
         <xs:choice>
             <xs:element name="version" minOccurs="1" maxOccurs="unbounded">
                 <xs:complexType>
-                    <xs:attribute name="name" type="xs:string" use="required" />
-                    <xs:attribute name="default" type="xs:boolean" use="optional" />
+                    <xs:simpleContent>
+                        <xs:extension base="xs:string">
+                            <xs:attribute name="name" type="xs:string" use="required" />
+                            <xs:attribute name="releaseDate" type="xs:date" use="required" />
+                            <xs:attribute name="default" type="xs:boolean" use="optional" />
+                        </xs:extension>
+                    </xs:simpleContent>
                 </xs:complexType>
             </xs:element>
         </xs:choice>

--- a/psalm.xml
+++ b/psalm.xml
@@ -42,5 +42,8 @@
                 <directory name="tests/" />
             </errorLevel>
         </PossiblyInvalidArgument>
+
+        <!-- This hides a number of errors that we don't really care about. -->
+        <PropertyNotSetInConstructor errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/resources/examples/Showtimes/blueprints/changelog-public-only-all-capabilities.md
+++ b/resources/examples/Showtimes/blueprints/changelog-public-only-all-capabilities.md
@@ -1,8 +1,11 @@
 # Changelog: Mill unit test API, Showtimes
 
-## 1.1.3
-### Added
-#### Resources
+## 1.1.3 (2017-05-27)
+Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
+
+### Reference
+#### Added
+##### Resources
 - The `GET` on `/movies/{id}` can now throw the following errors:
     - `404 Not Found` with a `Error` representation: For no reason.
     - `404 Not Found` with a `Error` representation: For some other reason.
@@ -10,13 +13,14 @@
 - `PATCH` on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
 - `POST` on `/movies` now returns a `201 Created`.
 
-### Removed
-#### Representations
+#### Removed
+##### Representations
 - `external_urls.tickets` has been removed from the `Movie` representation.
 
-## 1.1.2
-### Changed
-#### Resources
+## 1.1.2 (2017-04-01)
+### Reference
+#### Changed
+##### Resources
 - `/movies/{id}` now returns a `application/mill.example.movie` Content-Type header on the following HTTP methods:
     - `GET`
     - `PATCH`
@@ -30,27 +34,29 @@
     - `GET`
     - `POST`
 
-## 1.1.1
-### Added
-#### Resources
+## 1.1.1 (2017-03-01)
+### Reference
+#### Added
+##### Resources
 - A `imdb` request parameter was added to `PATCH` on `/movies/{id}`.
 
-## 1.1
-### Added
-#### Representations
+## 1.1 (2017-02-01)
+### Reference
+#### Added
+##### Representations
 - The following fields have been added to the `Movie` representation:
     - `external_urls`
     - `external_urls.imdb`
     - `external_urls.tickets`
     - `external_urls.trailer`
 
-#### Resources
+##### Resources
 - `PATCH` on `/movies/{id}` was added.
 - A `page` request parameter was added to `GET` on `/movies`.
 - The following parameters have been added to `POST` on `/movies`:
     - `imdb`
     - `trailer`
 
-### Removed
-#### Representations
+#### Removed
+##### Representations
 - `website` has been removed from the `Theater` representation.

--- a/resources/examples/Showtimes/blueprints/changelog-public-only-matched-capabilities.md
+++ b/resources/examples/Showtimes/blueprints/changelog-public-only-matched-capabilities.md
@@ -1,8 +1,11 @@
 # Changelog: Mill unit test API, Showtimes
 
-## 1.1.3
-### Added
-#### Resources
+## 1.1.3 (2017-05-27)
+Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
+
+### Reference
+#### Added
+##### Resources
 - The `GET` on `/movies/{id}` can now throw the following errors:
     - `404 Not Found` with a `Error` representation: For no reason.
     - `404 Not Found` with a `Error` representation: For some other reason.
@@ -10,13 +13,14 @@
 - `PATCH` on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
 - `POST` on `/movies` now returns a `201 Created`.
 
-### Removed
-#### Representations
+#### Removed
+##### Representations
 - `external_urls.tickets` has been removed from the `Movie` representation.
 
-## 1.1.2
-### Changed
-#### Resources
+## 1.1.2 (2017-04-01)
+### Reference
+#### Changed
+##### Resources
 - `/movies/{id}` now returns a `application/mill.example.movie` Content-Type header on the following HTTP methods:
     - `GET`
     - `PATCH`
@@ -30,21 +34,23 @@
     - `GET`
     - `POST`
 
-## 1.1.1
-### Added
-#### Resources
+## 1.1.1 (2017-03-01)
+### Reference
+#### Added
+##### Resources
 - A `imdb` request parameter was added to `PATCH` on `/movies/{id}`.
 
-## 1.1
-### Added
-#### Representations
+## 1.1 (2017-02-01)
+### Reference
+#### Added
+##### Representations
 - The following fields have been added to the `Movie` representation:
     - `external_urls`
     - `external_urls.imdb`
     - `external_urls.tickets`
     - `external_urls.trailer`
 
-#### Resources
+##### Resources
 - `/movies/{id}` has been added with support for the following HTTP methods:
     - `PATCH`
     - `DELETE`
@@ -53,6 +59,6 @@
     - `imdb`
     - `trailer`
 
-### Removed
-#### Representations
+#### Removed
+##### Representations
 - `website` has been removed from the `Theater` representation.

--- a/resources/examples/Showtimes/blueprints/changelog-public-only-unmatched-capabilities.md
+++ b/resources/examples/Showtimes/blueprints/changelog-public-only-unmatched-capabilities.md
@@ -1,8 +1,11 @@
 # Changelog: Mill unit test API, Showtimes
 
-## 1.1.3
-### Added
-#### Resources
+## 1.1.3 (2017-05-27)
+Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
+
+### Reference
+#### Added
+##### Resources
 - The `GET` on `/movies/{id}` can now throw the following errors:
     - `404 Not Found` with a `Error` representation: For no reason.
     - `404 Not Found` with a `Error` representation: For some other reason.
@@ -10,13 +13,14 @@
 - `PATCH` on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
 - `POST` on `/movies` now returns a `201 Created`.
 
-### Removed
-#### Representations
+#### Removed
+##### Representations
 - `external_urls.tickets` has been removed from the `Movie` representation.
 
-## 1.1.2
-### Changed
-#### Resources
+## 1.1.2 (2017-04-01)
+### Reference
+#### Changed
+##### Resources
 - `/movies/{id}` now returns a `application/mill.example.movie` Content-Type header on the following HTTP methods:
     - `GET`
     - `PATCH`
@@ -30,27 +34,29 @@
     - `GET`
     - `POST`
 
-## 1.1.1
-### Added
-#### Resources
+## 1.1.1 (2017-03-01)
+### Reference
+#### Added
+##### Resources
 - A `imdb` request parameter was added to `PATCH` on `/movies/{id}`.
 
-## 1.1
-### Added
-#### Representations
+## 1.1 (2017-02-01)
+### Reference
+#### Added
+##### Representations
 - The following fields have been added to the `Movie` representation:
     - `external_urls`
     - `external_urls.imdb`
     - `external_urls.tickets`
     - `external_urls.trailer`
 
-#### Resources
+##### Resources
 - `PATCH` on `/movies/{id}` was added.
 - A `page` request parameter was added to `GET` on `/movies`.
 - The following parameters have been added to `POST` on `/movies`:
     - `imdb`
     - `trailer`
 
-### Removed
-#### Representations
+#### Removed
+##### Representations
 - `website` has been removed from the `Theater` representation.

--- a/resources/examples/Showtimes/blueprints/changelog.md
+++ b/resources/examples/Showtimes/blueprints/changelog.md
@@ -1,8 +1,11 @@
 # Changelog: Mill unit test API, Showtimes
 
-## 1.1.3
-### Added
-#### Resources
+## 1.1.3 (2017-05-27)
+Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
+
+### Reference
+#### Added
+##### Resources
 - The `GET` on `/movie/{id}` can now throw the following errors:
     - `404 Not Found` with a `Error` representation: For no reason.
     - `404 Not Found` with a `Error` representation: For some other reason.
@@ -13,13 +16,14 @@
 - `PATCH` on `/movies/{id}` now returns a `202 Accepted` with a `Movie` representation.
 - `POST` on `/movies` now returns a `201 Created`.
 
-### Removed
-#### Representations
+#### Removed
+##### Representations
 - `external_urls.tickets` has been removed from the `Movie` representation.
 
-## 1.1.2
-### Changed
-#### Resources
+## 1.1.2 (2017-04-01)
+### Reference
+#### Changed
+##### Resources
 - `GET` on `/movie/{id}` now returns a `application/mill.example.movie` Content-Type header.
 - `/movies/{id}` now returns a `application/mill.example.movie` Content-Type header on the following HTTP methods:
     - `GET`
@@ -34,21 +38,23 @@
     - `GET`
     - `POST`
 
-## 1.1.1
-### Added
-#### Resources
+## 1.1.1 (2017-03-01)
+### Reference
+#### Added
+##### Resources
 - A `imdb` request parameter was added to `PATCH` on `/movies/{id}`.
 
-## 1.1
-### Added
-#### Representations
+## 1.1 (2017-02-01)
+### Reference
+#### Added
+##### Representations
 - The following fields have been added to the `Movie` representation:
     - `external_urls`
     - `external_urls.imdb`
     - `external_urls.tickets`
     - `external_urls.trailer`
 
-#### Resources
+##### Resources
 - `/movies/{id}` has been added with support for the following HTTP methods:
     - `PATCH`
     - `DELETE`
@@ -57,6 +63,6 @@
     - `imdb`
     - `trailer`
 
-### Removed
-#### Representations
+#### Removed
+##### Representations
 - `website` has been removed from the `Theater` representation.

--- a/resources/examples/mill.xml
+++ b/resources/examples/mill.xml
@@ -4,11 +4,13 @@
     bootstrap="../../vendor/autoload.php"
 >
     <versions>
-        <version name="1.0" />
-        <version name="1.1" />
-        <version name="1.1.1" />
-        <version name="1.1.2" default="true" />
-        <version name="1.1.3" />
+        <version name="1.0" releaseDate="2017-01-01" />
+        <version name="1.1" releaseDate="2017-02-01" />
+        <version name="1.1.1" releaseDate="2017-03-01" />
+        <version name="1.1.2" releaseDate="2017-04-01" default="true" />
+        <version name="1.1.3" releaseDate="2017-05-27">
+            Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
+        </version>
     </versions>
 
     <controllers>

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -25,9 +25,9 @@ class Generator
     protected $version = null;
 
     /**
-     * @var array
+     * @var \Doctrine\Common\Collections\ArrayCollection
      */
-    protected $supported_versions = [];
+    protected $supported_versions;
 
     /**
      * Compiled documentation.
@@ -169,7 +169,9 @@ class Generator
                 /** @var Resource\Action\Documentation $action */
                 foreach ($resource['actions'] as $identifier => $action) {
                     // Run through every supported API version and flatten out documentation for it.
-                    foreach ($this->supported_versions as $version) {
+                    foreach ($this->supported_versions as $supported_version) {
+                        $version = $supported_version['version'];
+
                         // If we're generating documentation for a specific version range, and this doesn't fall in
                         // that, then skip it.
                         if ($this->version && !$this->version->matches($version)) {
@@ -257,7 +259,9 @@ class Generator
 
         foreach ($parsed as $identifier => $representation) {
             // Run through every supported API version and flatten out documentation for it.
-            foreach ($this->supported_versions as $version) {
+            foreach ($this->supported_versions as $supported_version) {
+                $version = $supported_version['version'];
+
                 // If we're generating documentation for a specific version range, and this doesn't fall in
                 // that, then skip it.
                 if ($this->version && !$this->version->matches($version)) {

--- a/src/Generator/Changelog/Json.php
+++ b/src/Generator/Changelog/Json.php
@@ -109,13 +109,18 @@ class Json extends Generator
         $json = [];
 
         foreach ($this->changelog as $version => $version_changes) {
-            foreach ($version_changes as $change_type => $data) {
-                foreach ($data as $section => $section_changes) {
+            foreach ($version_changes as $definition => $data) {
+                if ($definition === '_details') {
+                    $json[$version][$definition] = $data;
+                    continue;
+                }
+
+                foreach ($data as $type => $section_changes) {
                     foreach ($section_changes as $header => $changes) {
                         foreach ($changes as $identifier => $changesets) {
-                            if ($change_type === 'added' || $change_type === 'removed') {
+                            if ($definition === 'added' || $definition === 'removed') {
                                 $entry = $this->getEntryForAddedOrRemovedChange(
-                                    $change_type,
+                                    $definition,
                                     $header,
                                     $identifier,
                                     $changesets
@@ -125,7 +130,7 @@ class Json extends Generator
                             }
 
                             if ($entry) {
-                                $json[$version][$change_type][$section][] = $entry;
+                                $json[$version][$definition][$type][] = $entry;
                             }
                         }
                     }

--- a/src/Generator/Changelog/Markdown.php
+++ b/src/Generator/Changelog/Markdown.php
@@ -27,15 +27,27 @@ class Markdown extends Json
 
         $changelog = json_decode(parent::generate(), true);
         foreach ($changelog as $version => $data) {
-            $markdown .= sprintf('## %s', $version);
+            $markdown .= sprintf('## %s (%s)', $version, $data['_details']['release_date']);
             $markdown .= $this->line();
 
-            foreach ($data as $type => $changes) {
-                $markdown .= sprintf('### %s', ucwords($type));
+            if (isset($data['_details']['description'])) {
+                $markdown .= sprintf('%s', $data['_details']['description']);
+                $markdown .= $this->line(2);
+            }
+
+            $markdown .= '### Reference';
+            $markdown .= $this->line();
+
+            foreach ($data as $definition => $changes) {
+                if ($definition === '_details') {
+                    continue;
+                }
+
+                $markdown .= sprintf('#### %s', ucwords($definition));
                 $markdown .= $this->line();
 
-                foreach ($changes as $section => $changesets) {
-                    $markdown .= sprintf('#### %s', ucwords($section));
+                foreach ($changes as $type => $changesets) {
+                    $markdown .= sprintf('##### %s', ucwords($type));
                     $markdown .= $this->line();
 
                     foreach ($changesets as $changeset) {

--- a/src/Parser/Resource/Action/Documentation.php
+++ b/src/Parser/Resource/Action/Documentation.php
@@ -554,7 +554,7 @@ class Documentation
 
         foreach ($this->annotations as $key => $annotations) {
             foreach ($annotations as $annotation) {
-                if (empty($data['annotations'][$key])) {
+                if (!isset($data['annotations'][$key])) {
                     $data['annotations'][$key] = [];
                 }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -15,13 +15,35 @@ class ConfigTest extends TestCase
         $this->assertSame('1.1.2', $config->getDefaultApiVersion());
         $this->assertSame('1.1.3', $config->getLatestApiVersion());
 
+        $versions = $config->getApiVersions();
+        $this->assertInstanceOf('\Doctrine\Common\Collections\ArrayCollection', $versions);
         $this->assertSame([
-            '1.0',
-            '1.1',
-            '1.1.1',
-            '1.1.2',
-            '1.1.3'
-        ], $config->getApiVersions());
+            [
+                'version' => '1.0',
+                'release_date' => '2017-01-01',
+                'description' => null
+            ],
+            [
+                'version' => '1.1',
+                'release_date' => '2017-02-01',
+                'description' => null
+            ],
+            [
+                'version' => '1.1.1',
+                'release_date' => '2017-03-01',
+                'description' => null
+            ],
+            [
+                'version' => '1.1.2',
+                'release_date' => '2017-04-01',
+                'description' => null
+            ],
+            [
+                'version' => '1.1.3',
+                'release_date' => '2017-05-27',
+                'description' => 'Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.'
+            ]
+        ], $versions->toArray());
 
         $this->assertSame([
             'FakeExcludeGroup'
@@ -162,8 +184,8 @@ XML;
         if (in_array('versions', $includes)) {
             $versions = <<<XML
 <versions>
-    <version name="1.0" />
-    <version name="1.1" default="true" />
+    <version name="1.0" releaseDate="2017-01-01" />
+    <version name="1.1" releaseDate="2017-02-01" default="true" />
 </versions>
 XML;
         }
@@ -234,7 +256,7 @@ XML;
                 ],
                 'xml' => <<<XML
 <versions>
-    <version name="1.0" />
+    <version name="1.0" releaseDate="2017-01-01" />
 </versions>
 XML
             ],
@@ -247,8 +269,8 @@ XML
                 ],
                 'xml' => <<<XML
 <versions>
-    <version name="1.0" default="true" />
-    <version name="1.1" default="true" />
+    <version name="1.0" releaseDate="2017-01-01" default="true" />
+    <version name="1.1" releaseDate="2017-02-01" default="true" />
 </versions>
 XML
             ],

--- a/tests/Generator/Changelog/JsonTest.php
+++ b/tests/Generator/Changelog/JsonTest.php
@@ -23,6 +23,10 @@ class JsonTest extends TestCase
 
         // v1.1.3
         $this->assertSame([
+            '_details' => [
+                'release_date' => '2017-05-27',
+                'description' => 'Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.'
+            ],
             'added' => [
                 'resources' => [
                     [
@@ -85,6 +89,9 @@ class JsonTest extends TestCase
 
         // v1.1.2
         $this->assertSame([
+            '_details' => [
+                'release_date' => '2017-04-01'
+            ],
             'changed' => [
                 'resources' => [
                     '<span class="mill-changelog_method" data-mill-method="GET">GET</span> on <span ' .
@@ -150,6 +157,9 @@ class JsonTest extends TestCase
 
         // v1.1.1
         $this->assertSame([
+            '_details' => [
+                'release_date' => '2017-03-01'
+            ],
             'added' => [
                 'resources' => [
                     'A <span class="mill-changelog_parameter" data-mill-parameter="imdb">imdb</span> request ' .
@@ -161,6 +171,9 @@ class JsonTest extends TestCase
 
         // v1.1
         $this->assertSame([
+            '_details' => [
+                'release_date' => '2017-02-01'
+            ],
             'added' => [
                 'representations' => [
                     [

--- a/tests/Generator/ChangelogTest.php
+++ b/tests/Generator/ChangelogTest.php
@@ -311,6 +311,10 @@ class ChangelogTest extends TestCase
                 'capabilities' => null,
                 'expected' => [
                     '1.1.3' => [
+                        '_details' => [
+                            'release_date' => '2017-05-27',
+                            'description' => 'Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.'
+                        ],
                         'added' => [
                             'resources' => [
                                 '/movie/{id}' => $actions['/movie/{id}']['1.1.3']['added'],
@@ -325,6 +329,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1.2' => [
+                        '_details' => [
+                            'release_date' => '2017-04-01'
+                        ],
                         'changed' => [
                             'resources' => [
                                 '/movie/{id}' => $actions['/movie/{id}']['1.1.2']['changed'],
@@ -336,6 +343,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1.1' => [
+                        '_details' => [
+                            'release_date' => '2017-03-01'
+                        ],
                         'added' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.1']['added']
@@ -343,6 +353,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1' => [
+                        '_details' => [
+                            'release_date' => '2017-02-01'
+                        ],
                         'added' => [
                             'representations' => [
                                 'Movie' => $representations['Movie']['1.1']['added']
@@ -380,6 +393,10 @@ class ChangelogTest extends TestCase
                 ],
                 'expected' => [
                     '1.1.3' => [
+                        '_details' => [
+                            'release_date' => '2017-05-27',
+                            'description' => 'Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.'
+                        ],
                         'added' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.3']['added'],
@@ -393,6 +410,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1.2' => [
+                        '_details' => [
+                            'release_date' => '2017-04-01'
+                        ],
                         'changed' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.2']['changed'],
@@ -403,6 +423,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1.1' => [
+                        '_details' => [
+                            'release_date' => '2017-03-01'
+                        ],
                         'added' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.1']['added']
@@ -410,6 +433,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1' => [
+                        '_details' => [
+                            'release_date' => '2017-02-01'
+                        ],
                         'added' => [
                             'representations' => [
                                 'Movie' => $representations['Movie']['1.1']['added']
@@ -446,6 +472,10 @@ class ChangelogTest extends TestCase
                 ],
                 'expected' => [
                     '1.1.3' => [
+                        '_details' => [
+                            'release_date' => '2017-05-27',
+                            'description' => 'Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.'
+                        ],
                         'added' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.3']['added'],
@@ -459,6 +489,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1.2' => [
+                        '_details' => [
+                            'release_date' => '2017-04-01'
+                        ],
                         'changed' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.2']['changed'],
@@ -469,6 +502,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1.1' => [
+                        '_details' => [
+                            'release_date' => '2017-03-01'
+                        ],
                         'added' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.1']['added']
@@ -476,6 +512,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1' => [
+                        '_details' => [
+                            'release_date' => '2017-02-01'
+                        ],
                         'added' => [
                             'representations' => [
                                 'Movie' => $representations['Movie']['1.1']['added']
@@ -502,6 +541,10 @@ class ChangelogTest extends TestCase
                 ],
                 'expected' => [
                     '1.1.3' => [
+                        '_details' => [
+                            'release_date' => '2017-05-27',
+                            'description' => 'Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.'
+                        ],
                         'added' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.3']['added'],
@@ -515,6 +558,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1.2' => [
+                        '_details' => [
+                            'release_date' => '2017-04-01'
+                        ],
                         'changed' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.2']['changed'],
@@ -525,6 +571,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1.1' => [
+                        '_details' => [
+                            'release_date' => '2017-03-01'
+                        ],
                         'added' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.1']['added']
@@ -532,6 +581,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1' => [
+                        '_details' => [
+                            'release_date' => '2017-02-01'
+                        ],
                         'added' => [
                             'representations' => [
                                 'Movie' => $representations['Movie']['1.1']['added']
@@ -564,6 +616,10 @@ class ChangelogTest extends TestCase
                 'capabilities' => [],
                 'expected' => [
                     '1.1.3' => [
+                        '_details' => [
+                            'release_date' => '2017-05-27',
+                            'description' => 'Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.'
+                        ],
                         'added' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.3']['added'],
@@ -577,6 +633,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1.2' => [
+                        '_details' => [
+                            'release_date' => '2017-04-01',
+                        ],
                         'changed' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.2']['changed'],
@@ -587,6 +646,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1.1' => [
+                        '_details' => [
+                            'release_date' => '2017-03-01'
+                        ],
                         'added' => [
                             'resources' => [
                                 '/movies/{id}' => $actions['/movies/{id}']['1.1.1']['added']
@@ -594,6 +656,9 @@ class ChangelogTest extends TestCase
                         ]
                     ],
                     '1.1' => [
+                        '_details' => [
+                            'release_date' => '2017-02-01',
+                        ],
                         'added' => [
                             'representations' => [
                                 'Movie' => $representations['Movie']['1.1']['added']

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -4,11 +4,13 @@
     bootstrap="vendor/autoload.php"
 >
     <versions>
-        <version name="1.0" />
-        <version name="1.1" />
-        <version name="1.1.1" />
-        <version name="1.1.2" default="true" />
-        <version name="1.1.3" />
+        <version name="1.0" releaseDate="2017-01-01" />
+        <version name="1.1" releaseDate="2017-02-01" />
+        <version name="1.1.1" releaseDate="2017-03-01" />
+        <version name="1.1.2" releaseDate="2017-04-01" default="true" />
+        <version name="1.1.3" releaseDate="2017-05-27">
+            Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
+        </version>
     </versions>
 
     <generators>


### PR DESCRIPTION
This adds a new `releaseDate` and description feature into the `versions` config definitions in `mill.xml`. With these, we now add version release dates and some additional details into your generated changelogs. 

These features are intended to make the generated changelogs less "cold" and more accessible.

This also introduces [doctrine/collections](https://packagist.org/packages/doctrine/collections), which I intend to start using more in Mill [3.0](https://github.com/vimeo/mill/milestone/5).