### PR TITLE
Removing doctrine/collections because it's requires >=PHP 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "league/flysystem": "^1.0",
         "composer/semver": "^1.4",
         "gossi/docblock": "^1.5",
-        "nicmart/string-template": "^0.1.1",
-        "doctrine/collections": "^1.4"
+        "nicmart/string-template": "^0.1.1"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.7",

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -25,9 +25,9 @@ class Generator
     protected $version = null;
 
     /**
-     * @var \Doctrine\Common\Collections\ArrayCollection
+     * @var array
      */
-    protected $supported_versions;
+    protected $supported_versions = [];
 
     /**
      * Compiled documentation.

--- a/src/Generator/Changelog.php
+++ b/src/Generator/Changelog.php
@@ -1,8 +1,6 @@
 <?php
 namespace Mill\Generator;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Criteria;
 use Mill\Generator;
 use Mill\Generator\Changelog\Json;
 use Mill\Generator\Changelog\Markdown;
@@ -309,7 +307,7 @@ class Changelog extends Generator
             return false;
         }
 
-        $available_in = $this->supported_versions->filter(function ($supported) use ($data_version) {
+        $available_in = array_filter($this->supported_versions, function ($supported) use ($data_version) {
             if ($data_version->matches($supported['version'])) {
                 return $supported['version'];
             }
@@ -318,7 +316,7 @@ class Changelog extends Generator
         });
 
         // What is the first version that this existed in?
-        $introduced = $available_in->current()['version'];
+        $introduced = current($available_in)['version'];
         if ($introduced === $this->config->getFirstApiVersion()) {
             return false;
         }
@@ -340,7 +338,7 @@ class Changelog extends Generator
             return false;
         }
 
-        $available_in = $this->supported_versions->filter(function ($supported) use ($data_version) {
+        $available_in = array_filter($this->supported_versions, function ($supported) use ($data_version) {
             if ($data_version->matches($supported['version'])) {
                 return $supported['version'];
             }
@@ -349,15 +347,15 @@ class Changelog extends Generator
         });
 
         // What is the most recent version that this was available in?
-        $recent_version = $available_in->last()['version'];
+        $recent_version = end($available_in)['version'];
         if ($recent_version === $this->config->getLatestApiVersion()) {
             return false;
         }
 
         $recent_version_key = key(
-            $this->supported_versions
-                ->matching(new Criteria(Criteria::expr()->eq('version', $recent_version), null))
-                ->toArray()
+            array_filter($this->supported_versions, function ($supported) use ($recent_version) {
+                return $supported['version'] == $recent_version;
+            })
         );
 
         return $this->supported_versions[++$recent_version_key]['version'];

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -15,8 +15,6 @@ class ConfigTest extends TestCase
         $this->assertSame('1.1.2', $config->getDefaultApiVersion());
         $this->assertSame('1.1.3', $config->getLatestApiVersion());
 
-        $versions = $config->getApiVersions();
-        $this->assertInstanceOf('\Doctrine\Common\Collections\ArrayCollection', $versions);
         $this->assertSame([
             [
                 'version' => '1.0',
@@ -43,7 +41,7 @@ class ConfigTest extends TestCase
                 'release_date' => '2017-05-27',
                 'description' => 'Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.'
             ]
-        ], $versions->toArray());
+        ], $config->getApiVersions());
 
         $this->assertSame([
             'FakeExcludeGroup'


### PR DESCRIPTION
Mill 2.x still needs to support PHP 5.4 unfortunately.