### PR TITLE
Adding more data attributes to generated changelog JSON changesets.

### DIFF
--- a/src/Generator/Changelog.php
+++ b/src/Generator/Changelog.php
@@ -168,6 +168,7 @@ class Changelog extends Generator
                             self::CHANGESET_TYPE_ACTION,
                             $group_name,
                             [
+                                'resource_group' => $group_name,
                                 'method' => $action->getMethod(),
                                 'uri' => $action->getUri()->getCleanPath()
                             ]
@@ -185,6 +186,7 @@ class Changelog extends Generator
                                 self::CHANGESET_TYPE_CONTENT_TYPE,
                                 $group_name,
                                 [
+                                    'resource_group' => $group_name,
                                     'method' => $action->getMethod(),
                                     'uri' => $action->getUri()->getCleanPath(),
                                     'content_type' => $content_type->getContentType()
@@ -208,6 +210,7 @@ class Changelog extends Generator
                             }
 
                             $data = [
+                                'resource_group' => $group_name,
                                 'method' => $action->getMethod(),
                                 'uri' => $action->getUri()->getCleanPath()
                             ];

--- a/src/Generator/Changelog/Changesets/Action.php
+++ b/src/Generator/Changelog/Changesets/Action.php
@@ -39,6 +39,7 @@ class Action extends Changeset
             [
                 // Changes are grouped by URIs so it's safe to just pull the first URI here.
                 $this->renderText($template, [
+                    'resource_group' => $changes[0]['resource_group'],
                     'uri' => $changes[0]['uri']
                 ]),
                 $methods

--- a/src/Generator/Changelog/Changesets/ActionParam.php
+++ b/src/Generator/Changelog/Changesets/ActionParam.php
@@ -51,6 +51,7 @@ class ActionParam extends Changeset
                 $template = $this->templates['plural'][$definition];
                 $entry[] = [
                     $this->renderText($template, [
+                        'resource_group' => $changes[0]['resource_group'],
                         'method' => $method,
                         'uri' => $changes[0]['uri']
                     ]),
@@ -62,6 +63,7 @@ class ActionParam extends Changeset
 
             $template = $this->templates['singular'][$definition];
             $entry[] = $this->renderText($template, [
+                'resource_group' => $changes[0]['resource_group'],
                 'parameter' => array_shift($params),
                 'method' => $method,
                 'uri' => $changes[0]['uri']

--- a/src/Generator/Changelog/Changesets/ActionReturn.php
+++ b/src/Generator/Changelog/Changesets/ActionReturn.php
@@ -67,6 +67,7 @@ class ActionReturn extends Changeset
                 $template = $this->templates['plural'][$definition];
                 $entries[] = [
                     $this->renderText($template, [
+                        'resource_group' => $changes[0]['resource_group'],
                         'method' => $method,
                         'uri' => $changes[0]['uri']
                     ]),

--- a/src/Generator/Changelog/Changesets/ActionThrows.php
+++ b/src/Generator/Changelog/Changesets/ActionThrows.php
@@ -49,11 +49,14 @@ class ActionThrows extends Changeset
                     );
                 }
 
+                $change = array_shift($changes);
+
                 $template = $this->templates['plural'][$definition];
                 $entries[] = [
                     $this->renderText($template, [
+                        'resource_group' => $change['resource_group'],
                         'method' => $method,
-                        'uri' => array_shift($changes)['uri']
+                        'uri' => $change['uri']
                     ]),
                     array_unique($errors)
                 ];

--- a/src/Generator/Traits/ChangelogTemplate.php
+++ b/src/Generator/Traits/ChangelogTemplate.php
@@ -49,11 +49,25 @@ trait ChangelogTemplate
      */
     protected function transformTemplateIntoHtml($template, array $content = [])
     {
+        $data_attributes = [];
+        foreach ($content as $key => $value) {
+            if ($key === 'description') {
+                continue;
+            }
+
+            $data_attributes[] = sprintf(
+                'data-mill-%s="%s"',
+                str_replace('_', '-', $key),
+                $value
+            );
+        }
+
+        $html = '<span class="{css_namespace}_%s" %s>%s</span>';
+        $data_attributes = implode(' ', $data_attributes);
+
         $searches = [];
         $replacements = [];
         foreach ($content as $key => $value) {
-            $data_attribute_key = str_replace('_', '-', $key);
-
             switch ($key) {
                 case 'content_type':
                 case 'field':
@@ -67,24 +81,12 @@ trait ChangelogTemplate
                     $searches[] = '{' . $key . '}';
                     if (is_array($value)) {
                         $replacements[] = $this->joinWords(
-                            array_map(function ($val) use ($data_attribute_key, $key) {
-                                return sprintf(
-                                    '<span class="{css_namespace}_%s" data-mill-%s="%s">%s</span>',
-                                    $key,
-                                    $data_attribute_key,
-                                    $val,
-                                    $val
-                                );
+                            array_map(function ($value) use ($html, $key, $data_attributes) {
+                                return sprintf($html, $key, $data_attributes, $value);
                             }, $value)
                         );
                     } else {
-                        $replacements[] = sprintf(
-                            '<span class="{css_namespace}_%s" data-mill-%s="{%s}">{%s}</span>',
-                            $key,
-                            $data_attribute_key,
-                            $key,
-                            $key
-                        );
+                        $replacements[] = sprintf($html, $key, $data_attributes, $value);
                     }
                     break;
 

--- a/tests/Generator/Changelog/Formats/JsonTest.php
+++ b/tests/Generator/Changelog/Formats/JsonTest.php
@@ -34,59 +34,99 @@ class JsonTest extends TestCase
                             'data-mill-resource-group="Movies">Movies</span> resources have added:',
                         [
                             [
-                                '<span class="mill-changelog_uri" data-mill-uri="/movie/{id}">/movie/{id}</span> ' .
-                                    'will now throw the following errors on <span class="mill-changelog_method" ' .
-                                    'data-mill-method="GET">GET</span> requests:',
+                                '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                    'data-mill-method="GET" data-mill-uri="/movie/{id}">/movie/{id}</span> will now ' .
+                                    'throw the following errors on <span class="mill-changelog_method" ' .
+                                    'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                    'data-mill-uri="/movie/{id}">GET</span> requests:',
                                 [
-                                    '<span class="mill-changelog_http_code" data-mill-http-code="404 Not Found">404 ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
+                                        'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
+                                        'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
+                                        'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                        'data-mill-uri="/movie/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: For no reason.',
-                                    '<span class="mill-changelog_http_code" data-mill-http-code="404 Not Found">404 ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
+                                        'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
+                                        'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
+                                        'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                        'data-mill-uri="/movie/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: For some ' .
                                         'other reason.'
                                 ]
                             ],
                             [
-                                '<span class="mill-changelog_uri" data-mill-uri="/movies/{id}">/movies/{id}</span> ' .
-                                    'will now throw the following errors on <span class="mill-changelog_method" ' .
-                                    'data-mill-method="GET">GET</span> requests:',
+                                '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                    'data-mill-method="GET" data-mill-uri="/movies/{id}">/movies/{id}</span> will ' .
+                                    'now throw the following errors on <span class="mill-changelog_method" ' .
+                                    'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                    'data-mill-uri="/movies/{id}">GET</span> requests:',
                                 [
-                                    '<span class="mill-changelog_http_code" data-mill-http-code="404 Not Found">404 ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
+                                        'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
+                                        'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
+                                        'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                        'data-mill-uri="/movies/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: For no reason.',
-                                    '<span class="mill-changelog_http_code" data-mill-http-code="404 Not Found">404 ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
+                                        'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
+                                        'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
+                                        'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                        'data-mill-uri="/movies/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: For some ' .
                                         'other reason.'
                                 ]
                             ],
-                            'On <span class="mill-changelog_method" data-mill-method="PATCH">PATCH</span> requests ' .
-                                'to <span class="mill-changelog_uri" data-mill-uri="/movies/{id}">/movies/{id}' .
+                            'On <span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
+                                'data-mill-http-code="404 Not Found" data-mill-representation="Error">PATCH</span> ' .
+                                'requests to <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
+                                'data-mill-http-code="404 Not Found" data-mill-representation="Error">/movies/{id}' .
                                 '</span>, a <span class="mill-changelog_http_code" ' .
-                                'data-mill-http-code="404 Not Found">404 Not Found</span> with a <span ' .
-                                'class="mill-changelog_representation" data-mill-representation="Error">Error</span> ' .
+                                'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
+                                'data-mill-uri="/movies/{id}" data-mill-http-code="404 Not Found" ' .
+                                'data-mill-representation="Error">404 Not Found</span> with a <span ' .
+                                'class="mill-changelog_representation" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
+                                'data-mill-http-code="404 Not Found" data-mill-representation="Error">Error</span> ' .
                                 'representation will now be returned: If the trailer URL could not be validated.',
-                            'On <span class="mill-changelog_uri" data-mill-uri="/movies/{id}">/movies/{id}</span>, ' .
-                                '<span class="mill-changelog_method" data-mill-method="PATCH">PATCH</span> requests ' .
-                                'now returns a <span class="mill-changelog_http_code" ' .
-                                'data-mill-http-code="202 Accepted">202 Accepted</span> with a <span ' .
-                                'class="mill-changelog_representation" data-mill-representation="Movie">Movie' .
-                                '</span> representation.',
-                            '<span class="mill-changelog_method" data-mill-method="POST">POST</span> on <span ' .
-                                'class="mill-changelog_uri" data-mill-uri="/movies">/movies</span> now returns a ' .
-                                '<span class="mill-changelog_http_code" data-mill-http-code="201 Created">201 ' .
-                                'Created</span>.'
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
+                                'data-mill-http-code="202 Accepted" data-mill-representation="Movie">/movies/{id}' .
+                                '</span>, <span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
+                                'data-mill-http-code="202 Accepted" data-mill-representation="Movie">PATCH</span> ' .
+                                'requests now returns a <span class="mill-changelog_http_code" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
+                                'data-mill-uri="/movies/{id}" data-mill-http-code="202 Accepted" ' .
+                                'data-mill-representation="Movie">202 Accepted</span> with a <span ' .
+                                'class="mill-changelog_representation" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
+                                'data-mill-http-code="202 Accepted" data-mill-representation="Movie">Movie</span> ' .
+                                'representation.',
+                            '<span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="POST" data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
+                                'data-mill-representation="">POST</span> on <span class="mill-changelog_uri" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="POST" data-mill-uri="/movies" ' .
+                                'data-mill-http-code="201 Created" data-mill-representation="">/movies</span> now ' .
+                                'returns a <span class="mill-changelog_http_code" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="POST" data-mill-uri="/movies" ' .
+                                'data-mill-http-code="201 Created" data-mill-representation="">201 Created</span>.'
                         ]
                     ]
                 ]
             ],
             'removed' => [
                 'representations' => [
-                    '<span class="mill-changelog_field" data-mill-field="external_urls.tickets">' .
-                        'external_urls.tickets</span> has been removed from the <span ' .
-                        'class="mill-changelog_representation" data-mill-representation="Movie">Movie</span> ' .
-                        'representation.'
+                    '<span class="mill-changelog_field" data-mill-field="external_urls.tickets" ' .
+                        'data-mill-representation="Movie">external_urls.tickets</span> has been removed from the ' .
+                        '<span class="mill-changelog_representation" data-mill-field="external_urls.tickets" ' .
+                        'data-mill-representation="Movie">Movie</span> representation.'
                 ]
             ]
         ], $generated['1.1.3'], '1.1.3 changelog does not match');
@@ -102,29 +142,56 @@ class JsonTest extends TestCase
                         'The following <span class="mill-changelog_resource_group" ' .
                             'data-mill-resource-group="Movies">Movies</span> resources have changed:',
                         [
-                            'On <span class="mill-changelog_uri" data-mill-uri="/movie/{id}">/movie/{id}</span>, ' .
-                                '<span class="mill-changelog_method" data-mill-method="GET">GET</span> requests will ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
+                                'data-mill-content-type="application/mill.example.movie">/movie/{id}</span>, <span ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
+                                'data-mill-content-type="application/mill.example.movie">GET</span> requests will ' .
                                 'return a <span class="mill-changelog_content_type" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                'data-mill-uri="/movie/{id}" data-mill-content-type="application/mill.example.movie">' .
+                                'application/mill.example.movie</span> Content-Type header.',
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
+                                'data-mill-content-type="application/mill.example.movie">/movies/{id}</span>, <span ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
+                                'data-mill-content-type="application/mill.example.movie">GET</span> requests will ' .
+                                'return a <span class="mill-changelog_content_type" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                'data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-uri="/movies/{id}">/movies/{id}</span>, ' .
-                                '<span class="mill-changelog_method" data-mill-method="GET">GET</span> requests will ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
+                                'data-mill-content-type="application/mill.example.movie">/movies/{id}</span>, <span ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
+                                'data-mill-content-type="application/mill.example.movie">PATCH</span> requests will ' .
                                 'return a <span class="mill-changelog_content_type" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
+                                'data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-uri="/movies/{id}">/movies/{id}</span>, ' .
-                                '<span class="mill-changelog_method" data-mill-method="PATCH">PATCH</span> requests ' .
-                                'will return a <span class="mill-changelog_content_type" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="GET" data-mill-uri="/movies" ' .
+                                'data-mill-content-type="application/mill.example.movie">/movies</span>, <span ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="GET" data-mill-uri="/movies" ' .
+                                'data-mill-content-type="application/mill.example.movie">GET</span> requests will ' .
+                                'return a <span class="mill-changelog_content_type" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="GET" data-mill-uri="/movies" ' .
                                 'data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-uri="/movies">/movies</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-method="GET">GET</span> requests will ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="POST" data-mill-uri="/movies" ' .
+                                'data-mill-content-type="application/mill.example.movie">/movies</span>, <span ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="POST" data-mill-uri="/movies" ' .
+                                'data-mill-content-type="application/mill.example.movie">POST</span> requests will ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-content-type="application/mill.example.movie">' .
-                                'application/mill.example.movie</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-uri="/movies">/movies</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-method="POST">POST</span> requests will ' .
-                                'return a <span class="mill-changelog_content_type" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="POST" data-mill-uri="/movies" ' .
                                 'data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.'
                         ]
@@ -133,24 +200,48 @@ class JsonTest extends TestCase
                         'The following <span class="mill-changelog_resource_group" ' .
                             'data-mill-resource-group="Theaters">Theaters</span> resources have changed:',
                         [
-                            'On <span class="mill-changelog_uri" data-mill-uri="/theaters/{id}">/theaters/{id}' .
-                                '</span>, <span class="mill-changelog_method" data-mill-method="GET">GET</span> ' .
-                                'requests will return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-content-type="application/mill.example.theater">' .
-                                'application/mill.example.theater</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-uri="/theaters/{id}">/theaters/{id}' .
-                                '</span>, <span class="mill-changelog_method" data-mill-method="PATCH">PATCH</span> ' .
-                                'requests will return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-content-type="application/mill.example.theater">' .
-                                'application/mill.example.theater</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-uri="/theaters">/theaters</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-method="GET">GET</span> requests will ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Theaters" ' .
+                                'data-mill-method="GET" data-mill-uri="/theaters/{id}" ' .
+                                'data-mill-content-type="application/mill.example.theater">/theaters/{id}</span>, ' .
+                                '<span class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
+                                'data-mill-method="GET" data-mill-uri="/theaters/{id}" ' .
+                                'data-mill-content-type="application/mill.example.theater">GET</span> requests will ' .
                                 'return a <span class="mill-changelog_content_type" ' .
+                                'data-mill-resource-group="Theaters" data-mill-method="GET" ' .
+                                'data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">' .
                                 'application/mill.example.theater</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-uri="/theaters">/theaters</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-method="POST">POST</span> requests will ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Theaters" ' .
+                                'data-mill-method="PATCH" data-mill-uri="/theaters/{id}" ' .
+                                'data-mill-content-type="application/mill.example.theater">/theaters/{id}</span>, ' .
+                                '<span class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
+                                'data-mill-method="PATCH" data-mill-uri="/theaters/{id}" ' .
+                                'data-mill-content-type="application/mill.example.theater">PATCH</span> requests ' .
+                                'will return a <span class="mill-changelog_content_type" ' .
+                                'data-mill-resource-group="Theaters" data-mill-method="PATCH" ' .
+                                'data-mill-uri="/theaters/{id}" ' .
+                                'data-mill-content-type="application/mill.example.theater">' .
+                                'application/mill.example.theater</span> Content-Type header.',
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Theaters" ' .
+                                'data-mill-method="GET" data-mill-uri="/theaters" ' .
+                                'data-mill-content-type="application/mill.example.theater">/theaters</span>, <span ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
+                                'data-mill-method="GET" data-mill-uri="/theaters" ' .
+                                'data-mill-content-type="application/mill.example.theater">GET</span> requests will ' .
                                 'return a <span class="mill-changelog_content_type" ' .
+                                'data-mill-resource-group="Theaters" data-mill-method="GET" ' .
+                                'data-mill-uri="/theaters" ' .
+                                'data-mill-content-type="application/mill.example.theater">' .
+                                'application/mill.example.theater</span> Content-Type header.',
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Theaters" ' .
+                                'data-mill-method="POST" data-mill-uri="/theaters" ' .
+                                'data-mill-content-type="application/mill.example.theater">/theaters</span>, <span ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
+                                'data-mill-method="POST" data-mill-uri="/theaters" ' .
+                                'data-mill-content-type="application/mill.example.theater">POST</span> requests ' .
+                                'will return a <span class="mill-changelog_content_type" ' .
+                                'data-mill-resource-group="Theaters" data-mill-method="POST" ' .
+                                'data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">' .
                                 'application/mill.example.theater</span> Content-Type header.'
                         ]
@@ -170,10 +261,14 @@ class JsonTest extends TestCase
                         'The following <span class="mill-changelog_resource_group" ' .
                             'data-mill-resource-group="Movies">Movies</span> resources have added:',
                         [
-                            'A <span class="mill-changelog_parameter" data-mill-parameter="imdb">imdb</span> request ' .
-                                'parameter was added to <span class="mill-changelog_method" ' .
-                                'data-mill-method="PATCH">PATCH</span> on <span class="mill-changelog_uri" ' .
-                                'data-mill-uri="/movies/{id}">/movies/{id}</span>.'
+                            'A <span class="mill-changelog_parameter" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="PATCH" data-mill-uri="/movies/{id}" data-mill-parameter="imdb">' .
+                                'imdb</span> request parameter was added to <span class="mill-changelog_method" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
+                                'data-mill-uri="/movies/{id}" data-mill-parameter="imdb">PATCH</span> on <span ' .
+                                'class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="PATCH" data-mill-uri="/movies/{id}" data-mill-parameter="imdb">' .
+                                '/movies/{id}</span>.'
                         ]
                     ]
                 ]
@@ -188,16 +283,18 @@ class JsonTest extends TestCase
             'added' => [
                 'representations' => [
                     [
-                        'The <span class="mill-changelog_representation" data-mill-representation="Movie">Movie' .
-                            '</span> representation has added the following fields:',
+                        'The <span class="mill-changelog_representation" data-mill-field="external_urls" ' .
+                            'data-mill-representation="Movie">Movie</span> representation has added the following ' .
+                            'fields:',
                         [
-                            '<span class="mill-changelog_field" data-mill-field="external_urls">external_urls</span>',
-                            '<span class="mill-changelog_field" data-mill-field="external_urls.imdb">' .
-                                'external_urls.imdb</span>',
-                            '<span class="mill-changelog_field" data-mill-field="external_urls.tickets">' .
-                                'external_urls.tickets</span>',
-                            '<span class="mill-changelog_field" data-mill-field="external_urls.trailer">' .
-                                'external_urls.trailer</span>'
+                            '<span class="mill-changelog_field" data-mill-field="external_urls" ' .
+                                'data-mill-representation="Movie">external_urls</span>',
+                            '<span class="mill-changelog_field" data-mill-field="external_urls.imdb" ' .
+                                'data-mill-representation="Movie">external_urls.imdb</span>',
+                            '<span class="mill-changelog_field" data-mill-field="external_urls.tickets" ' .
+                                'data-mill-representation="Movie">external_urls.tickets</span>',
+                            '<span class="mill-changelog_field" data-mill-field="external_urls.trailer" ' .
+                                'data-mill-representation="Movie">external_urls.trailer</span>'
                         ]
                     ]
                 ],
@@ -207,25 +304,33 @@ class JsonTest extends TestCase
                             'data-mill-resource-group="Movies">Movies</span> resources have added:',
                         [
                             [
-                                '<span class="mill-changelog_uri" data-mill-uri="/movies/{id}">/movies/{id}</span> ' .
-                                    'has been added with support for the following HTTP methods:',
+                                '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                    'data-mill-uri="/movies/{id}">/movies/{id}</span> has been added with support ' .
+                                    'for the following HTTP methods:',
                                 [
-                                    '<span class="mill-changelog_method" data-mill-method="PATCH">PATCH</span>',
-                                    '<span class="mill-changelog_method" data-mill-method="DELETE">DELETE</span>'
+                                    '<span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                        'data-mill-method="PATCH" data-mill-uri="/movies/{id}">PATCH</span>',
+                                    '<span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                        'data-mill-method="DELETE" data-mill-uri="/movies/{id}">DELETE</span>'
                                 ]
                             ],
-                            'A <span class="mill-changelog_parameter" data-mill-parameter="page">page</span> request ' .
-                                'parameter was added to <span class="mill-changelog_method" ' .
-                                'data-mill-method="GET">GET</span> on <span class="mill-changelog_uri" ' .
-                                'data-mill-uri="/movies">/movies</span>.',
+                            'A <span class="mill-changelog_parameter" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="GET" data-mill-uri="/movies" data-mill-parameter="page">page' .
+                                '</span> request parameter was added to <span class="mill-changelog_method" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="GET" data-mill-uri="/movies" ' .
+                                'data-mill-parameter="page">GET</span> on <span class="mill-changelog_uri" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="GET" data-mill-uri="/movies" ' .
+                                'data-mill-parameter="page">/movies</span>.',
                             [
                                 'The following parameters have been added to <span class="mill-changelog_method" ' .
-                                    'data-mill-method="POST">POST</span> on <span class="mill-changelog_uri" ' .
+                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                    'data-mill-uri="/movies">POST</span> on <span class="mill-changelog_uri" ' .
+                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                     'data-mill-uri="/movies">/movies</span>:',
                                 [
                                     '<span class="mill-changelog_parameter" data-mill-parameter="imdb">imdb</span>',
                                     '<span class="mill-changelog_parameter" data-mill-parameter="trailer">trailer' .
-                                    '</span>'
+                                        '</span>'
                                 ]
                             ]
                         ]
@@ -234,9 +339,10 @@ class JsonTest extends TestCase
             ],
             'removed' => [
                 'representations' => [
-                    '<span class="mill-changelog_field" data-mill-field="website">website</span> has been removed ' .
-                        'from the <span class="mill-changelog_representation" data-mill-representation="Theater">' .
-                        'Theater</span> representation.'
+                    '<span class="mill-changelog_field" data-mill-field="website" ' .
+                        'data-mill-representation="Theater">website</span> has been removed from the <span ' .
+                        'class="mill-changelog_representation" data-mill-field="website" ' .
+                        'data-mill-representation="Theater">Theater</span> representation.'
                 ]
             ]
         ], $generated['1.1'], '1.1 changelog does not match');
@@ -274,12 +380,14 @@ class JsonTest extends TestCase
                                         Changelog::CHANGESET_TYPE_ACTION_RETURN => [
                                             'hashed-set.1' => [
                                                 [
+                                                    'resource_group' => 'Movies',
                                                     'method' => 'POST',
                                                     'uri' => '/movies',
                                                     'http_code' => '201 Created',
                                                     'representation' => false
                                                 ],
                                                 [
+                                                    'resource_group' => 'Movies',
                                                     'method' => 'POST',
                                                     'uri' => '/movies',
                                                     'http_code' => '200 OK',
@@ -288,6 +396,7 @@ class JsonTest extends TestCase
                                             ],
                                             'hashed-set.2' => [
                                                 [
+                                                    'resource_group' => 'Movies',
                                                     'method' => 'GET',
                                                     'uri' => '/movies',
                                                     'http_code' => '200 OK',
@@ -310,25 +419,42 @@ class JsonTest extends TestCase
                                         'data-mill-resource-group="Movies">Movies</span> resources have added:',
                                     [
                                         [
-                                            'The <span class="mill-changelog_method" data-mill-method="POST">POST' .
-                                                '</span> on <span class="mill-changelog_uri" ' .
-                                                'data-mill-uri="/movies">/movies</span> will now return the ' .
-                                                'following responses:',
+                                            'The <span class="mill-changelog_method" ' .
+                                                'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                'data-mill-uri="/movies">POST</span> on <span ' .
+                                                'class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                                'data-mill-method="POST" data-mill-uri="/movies">/movies</span> will ' .
+                                                'now return the following responses:',
                                             [
                                                 '<span class="mill-changelog_http_code" ' .
-                                                    'data-mill-http-code="201 Created">201 Created</span>',
+                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
+                                                    'data-mill-representation="">201 Created</span>',
                                                 '<span class="mill-changelog_http_code" ' .
-                                                    'data-mill-http-code="200 OK">200 OK</span> with a <span ' .
+                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
+                                                    'data-mill-representation="Movie">200 OK</span> with a <span ' .
                                                     'class="mill-changelog_representation" ' .
+                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                                     'data-mill-representation="Movie">Movie</span> representation'
                                             ]
                                         ],
-                                        'On <span class="mill-changelog_uri" data-mill-uri="/movies">/movies</span>, ' .
-                                            '<span class="mill-changelog_method" data-mill-method="GET">GET</span> ' .
-                                            'requests now returns a <span class="mill-changelog_http_code" ' .
-                                            'data-mill-http-code="200 OK">200 OK</span> with a <span ' .
-                                            'class="mill-changelog_representation" data-mill-representation="Movie">' .
-                                            'Movie</span> representation.'
+                                        'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                            'data-mill-method="GET" data-mill-uri="/movies" ' .
+                                            'data-mill-http-code="200 OK" data-mill-representation="Movie">/movies' .
+                                            '</span>, <span class="mill-changelog_method" ' .
+                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                            'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
+                                            'data-mill-representation="Movie">GET</span> requests now returns a ' .
+                                            '<span class="mill-changelog_http_code" ' .
+                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                            'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
+                                            'data-mill-representation="Movie">200 OK</span> with a <span ' .
+                                            'class="mill-changelog_representation" ' .
+                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                            'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
+                                            'data-mill-representation="Movie">Movie</span> representation.'
                                     ]
                                 ]
                             ]
@@ -346,12 +472,14 @@ class JsonTest extends TestCase
                                         Changelog::CHANGESET_TYPE_ACTION_RETURN => [
                                             'hashed-set.1' => [
                                                 [
+                                                    'resource_group' => 'Movies',
                                                     'method' => 'POST',
                                                     'uri' => '/movies',
                                                     'http_code' => '201 Created',
                                                     'representation' => false
                                                 ],
                                                 [
+                                                    'resource_group' => 'Movies',
                                                     'method' => 'POST',
                                                     'uri' => '/movies',
                                                     'http_code' => '200 OK',
@@ -360,6 +488,7 @@ class JsonTest extends TestCase
                                             ],
                                             'hashed-set.2' => [
                                                 [
+                                                    'resource_group' => 'Movies',
                                                     'method' => 'GET',
                                                     'uri' => '/movies',
                                                     'http_code' => '200 OK',
@@ -382,25 +511,42 @@ class JsonTest extends TestCase
                                         'data-mill-resource-group="Movies">Movies</span> resources have removed:',
                                     [
                                         [
-                                            'The <span class="mill-changelog_method" data-mill-method="POST">POST' .
-                                                '</span> on <span class="mill-changelog_uri" ' .
-                                                'data-mill-uri="/movies">/movies</span> no longer returns the ' .
-                                                'following responses:',
+                                            'The <span class="mill-changelog_method" ' .
+                                                'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                'data-mill-uri="/movies">POST</span> on <span ' .
+                                                'class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                                'data-mill-method="POST" data-mill-uri="/movies">/movies</span> no ' .
+                                                'longer returns the following responses:',
                                             [
                                                 '<span class="mill-changelog_http_code" ' .
-                                                    'data-mill-http-code="201 Created">201 Created</span>',
+                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
+                                                    'data-mill-representation="">201 Created</span>',
                                                 '<span class="mill-changelog_http_code" ' .
-                                                    'data-mill-http-code="200 OK">200 OK</span> with a <span ' .
+                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
+                                                    'data-mill-representation="Movie">200 OK</span> with a <span ' .
                                                     'class="mill-changelog_representation" ' .
+                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                                     'data-mill-representation="Movie">Movie</span> representation'
                                             ]
                                         ],
-                                        'On <span class="mill-changelog_uri" data-mill-uri="/movies">/movies</span>, ' .
-                                            '<span class="mill-changelog_method" data-mill-method="GET">GET</span> ' .
-                                            'requests no longer returns a <span class="mill-changelog_http_code" ' .
-                                            'data-mill-http-code="200 OK">200 OK</span> with a <span ' .
-                                            'class="mill-changelog_representation" data-mill-representation="Movie">' .
-                                            'Movie</span> representation.'
+                                        'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                            'data-mill-method="GET" data-mill-uri="/movies" ' .
+                                            'data-mill-http-code="200 OK" data-mill-representation="Movie">/movies' .
+                                            '</span>, <span class="mill-changelog_method" ' .
+                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                            'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
+                                            'data-mill-representation="Movie">GET</span> requests no longer returns ' .
+                                            'a <span class="mill-changelog_http_code" ' .
+                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                            'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
+                                            'data-mill-representation="Movie">200 OK</span> with a <span ' .
+                                            'class="mill-changelog_representation" ' .
+                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                            'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
+                                            'data-mill-representation="Movie">Movie</span> representation.'
                                     ]
                                 ]
                             ]

--- a/tests/Generator/ChangelogTest.php
+++ b/tests/Generator/ChangelogTest.php
@@ -68,6 +68,7 @@ class ChangelogTest extends TestCase
                     'throws' => [
                         '2e302f7f79' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movie/{id}',
                                 'http_code' => '404 Not Found',
@@ -75,6 +76,7 @@ class ChangelogTest extends TestCase
                                 'description' => 'For no reason.'
                             ],
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movie/{id}',
                                 'http_code' => '404 Not Found',
@@ -88,6 +90,7 @@ class ChangelogTest extends TestCase
                     'return' => [
                         '3781891d58' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'POST',
                                 'uri' => '/movies',
                                 'http_code' => '201 Created',
@@ -100,6 +103,7 @@ class ChangelogTest extends TestCase
                     'return' => [
                         '162944fa14' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '202 Accepted',
@@ -110,6 +114,7 @@ class ChangelogTest extends TestCase
                     'throws' => [
                         'e7dc298139' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '404 Not Found',
@@ -117,6 +122,7 @@ class ChangelogTest extends TestCase
                                 'description' => 'For no reason.'
                             ],
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '404 Not Found',
@@ -126,6 +132,7 @@ class ChangelogTest extends TestCase
                         ],
                         '162944fa14' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '404 Not Found',
@@ -141,6 +148,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movie/{id}',
                                 'content_type' => 'application/mill.example.movie'
@@ -152,6 +160,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies',
                                 'content_type' => 'application/mill.example.movie'
@@ -159,6 +168,7 @@ class ChangelogTest extends TestCase
                         ],
                         '066564ef49' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'POST',
                                 'uri' => '/movies',
                                 'content_type' => 'application/mill.example.movie'
@@ -170,6 +180,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies/{id}',
                                 'content_type' => 'application/mill.example.movie'
@@ -177,6 +188,7 @@ class ChangelogTest extends TestCase
                         ],
                         'f4628f751a' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'content_type' => 'application/mill.example.movie'
@@ -188,6 +200,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
+                                'resource_group' => 'Theaters',
                                 'method' => 'GET',
                                 'uri' => '/theaters',
                                 'content_type' => 'application/mill.example.theater'
@@ -195,6 +208,7 @@ class ChangelogTest extends TestCase
                         ],
                         '066564ef49' => [
                             [
+                                'resource_group' => 'Theaters',
                                 'method' => 'POST',
                                 'uri' => '/theaters',
                                 'content_type' => 'application/mill.example.theater'
@@ -206,6 +220,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
+                                'resource_group' => 'Theaters',
                                 'method' => 'GET',
                                 'uri' => '/theaters/{id}',
                                 'content_type' => 'application/mill.example.theater'
@@ -213,6 +228,7 @@ class ChangelogTest extends TestCase
                         ],
                         'f4628f751a' => [
                             [
+                                'resource_group' => 'Theaters',
                                 'method' => 'PATCH',
                                 'uri' => '/theaters/{id}',
                                 'content_type' => 'application/mill.example.theater'
@@ -226,6 +242,7 @@ class ChangelogTest extends TestCase
                     'param' => [
                         '162944fa14' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'parameter' => 'imdb',
@@ -240,6 +257,7 @@ class ChangelogTest extends TestCase
                     'param' => [
                         '776d02bb83' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies',
                                 'parameter' => 'page',
@@ -248,12 +266,14 @@ class ChangelogTest extends TestCase
                         ],
                         '3781891d58' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'POST',
                                 'uri' => '/movies',
                                 'parameter' => 'imdb',
                                 'description' => 'IMDB URL'
                             ],
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'POST',
                                 'uri' => '/movies',
                                 'parameter' => 'trailer',
@@ -266,10 +286,12 @@ class ChangelogTest extends TestCase
                     'action' => [
                         'd81e7058dd' => [
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}'
                             ],
                             [
+                                'resource_group' => 'Movies',
                                 'method' => 'DELETE',
                                 'uri' => '/movies/{id}'
                             ]


### PR DESCRIPTION
This extends the current JSON (HTML) changelog generator to add more data attribute elements to compiled changesets.

Previously only the primary element was present on a data attribute. So if the item was a URI, you would have only `data-mill-uri`, now you have all data pertaining to that URI: `data-mill-resource-group`, `data-mill-method` and `data-mill-uri`.

This change applies to all changeset types.