### PR TITLE
Fixing some PHP 5.4 compatiblity issues.

### DIFF
--- a/src/Generator/Changelog/Changeset.php
+++ b/src/Generator/Changelog/Changeset.php
@@ -8,6 +8,13 @@ abstract class Changeset
     use ChangelogTemplate;
 
     /**
+     * Get the templates that this changeset will use to generate changesets.
+     *
+     * @return array
+     */
+    abstract public function getTemplates();
+
+    /**
      * Get a changelog entry for a changeset that was added into, or removed from, the API.
      *
      * @param string $definition This is the definition of the changeset, whether it's an "added", "removed", or
@@ -16,7 +23,7 @@ abstract class Changeset
      * @return string|array
      * @throws \Exception If an unsupported definition + change type was supplied.
      */
-    abstract protected function compileAddedOrRemovedChangeset($definition, array $changes = []);
+    abstract public function compileAddedOrRemovedChangeset($definition, array $changes = []);
 
     /**
      * Get a changelog entry for a changeset that was changed within the API.
@@ -27,5 +34,5 @@ abstract class Changeset
      * @return string|array
      * @throws \Exception If an unsupported definition + change type was supplied.
      */
-    abstract protected function compileChangedChangeset($definition, array $changes = []);
+    abstract public function compileChangedChangeset($definition, array $changes = []);
 }

--- a/src/Generator/Changelog/Changesets/Action.php
+++ b/src/Generator/Changelog/Changesets/Action.php
@@ -7,25 +7,30 @@ use Mill\Generator\Changelog\Changeset;
 class Action extends Changeset
 {
     /**
-     * @var array
+     * @inheritdoc
      */
-    protected $templates = [
-        'plural' => [
-            Changelog::DEFINITION_ADDED => '{uri} has been added with support for the following HTTP methods:'
-        ],
-        'singular' => [
-            Changelog::DEFINITION_ADDED => '{method} on {uri} was added.'
-        ]
-    ];
+    public function getTemplates()
+    {
+        return [
+            'plural' => [
+                Changelog::DEFINITION_ADDED => '{uri} has been added with support for the following HTTP methods:'
+            ],
+            'singular' => [
+                Changelog::DEFINITION_ADDED => '{method} on {uri} was added.'
+            ]
+        ];
+    }
 
     /**
      * @inheritdoc
      */
     public function compileAddedOrRemovedChangeset($definition, array $changes = [])
     {
+        $templates = $this->getTemplates();
+
         if (count($changes) === 1) {
             $change = array_shift($changes);
-            $template = $this->templates['singular'][$definition];
+            $template = $templates['singular'][$definition];
             return $this->renderText($template, $change);
         }
 
@@ -34,7 +39,7 @@ class Action extends Changeset
             $methods[] = $this->renderText('{method}', $change);
         }
 
-        $template = $this->templates['plural'][$definition];
+        $template = $templates['plural'][$definition];
         return [
             [
                 // Changes are grouped by URIs so it's safe to just pull the first URI here.

--- a/src/Generator/Changelog/Changesets/ActionParam.php
+++ b/src/Generator/Changelog/Changesets/ActionParam.php
@@ -7,28 +7,33 @@ use Mill\Generator\Changelog\Changeset;
 class ActionParam extends Changeset
 {
     /**
-     * @var array
+     * @inheritdoc
      */
-    protected $templates = [
-        'plural' => [
-            Changelog::DEFINITION_ADDED => 'The following parameters have been added to {method} on {uri}:',
-            Changelog::DEFINITION_REMOVED => 'The following parameters have been removed to {method} on {uri}:'
-        ],
-        'singular' => [
-            Changelog::DEFINITION_ADDED => 'A {parameter} request parameter was added to {method} on {uri}.',
-            Changelog::DEFINITION_REMOVED => 'The {parameter} request parameter has been removed from {method} ' .
-                'requests on {uri}.'
-        ]
-    ];
+    public function getTemplates()
+    {
+        return [
+            'plural' => [
+                Changelog::DEFINITION_ADDED => 'The following parameters have been added to {method} on {uri}:',
+                Changelog::DEFINITION_REMOVED => 'The following parameters have been removed to {method} on {uri}:'
+            ],
+            'singular' => [
+                Changelog::DEFINITION_ADDED => 'A {parameter} request parameter was added to {method} on {uri}.',
+                Changelog::DEFINITION_REMOVED => 'The {parameter} request parameter has been removed from {method} ' .
+                    'requests on {uri}.'
+            ]
+        ];
+    }
 
     /**
      * @inheritdoc
      */
     public function compileAddedOrRemovedChangeset($definition, array $changes = [])
     {
+        $templates = $this->getTemplates();
+
         if (count($changes) === 1) {
             $change = array_shift($changes);
-            $template = $this->templates['singular'][$definition];
+            $template = $templates['singular'][$definition];
             return $this->renderText($template, $change);
         }
 
@@ -48,7 +53,7 @@ class ActionParam extends Changeset
                     ]);
                 }
 
-                $template = $this->templates['plural'][$definition];
+                $template = $templates['plural'][$definition];
                 $entry[] = [
                     $this->renderText($template, [
                         'resource_group' => $changes[0]['resource_group'],
@@ -61,7 +66,7 @@ class ActionParam extends Changeset
                 continue;
             }
 
-            $template = $this->templates['singular'][$definition];
+            $template = $templates['singular'][$definition];
             $entry[] = $this->renderText($template, [
                 'resource_group' => $changes[0]['resource_group'],
                 'parameter' => array_shift($params),

--- a/src/Generator/Changelog/Changesets/ActionReturn.php
+++ b/src/Generator/Changelog/Changesets/ActionReturn.php
@@ -7,38 +7,43 @@ use Mill\Generator\Changelog\Changeset;
 class ActionReturn extends Changeset
 {
     /**
-     * @var array
+     * @inheritdoc
      */
-    protected $templates = [
-        'plural' => [
-            Changelog::DEFINITION_ADDED => 'The {method} on {uri} will now return the following responses:',
-            Changelog::DEFINITION_REMOVED => 'The {method} on {uri} no longer returns the following responses:'
-        ],
-        'singular' => [
-            Changelog::DEFINITION_ADDED => 'On {uri}, {method} requests now returns a {http_code} with a ' .
-                '{representation} representation.',
-            Changelog::DEFINITION_REMOVED => 'On {uri}, {method} requests no longer returns a {http_code} with a ' .
-                '{representation} representation.',
+    public function getTemplates()
+    {
+        return [
+            'plural' => [
+                Changelog::DEFINITION_ADDED => 'The {method} on {uri} will now return the following responses:',
+                Changelog::DEFINITION_REMOVED => 'The {method} on {uri} no longer returns the following responses:'
+            ],
+            'singular' => [
+                Changelog::DEFINITION_ADDED => 'On {uri}, {method} requests now returns a {http_code} with a ' .
+                    '{representation} representation.',
+                Changelog::DEFINITION_REMOVED => 'On {uri}, {method} requests no longer returns a {http_code} with a ' .
+                    '{representation} representation.',
 
-            // Representations are optional on returns, so we need special strings for those cases.
-            'no_representation' => [
-                Changelog::DEFINITION_ADDED => '{method} on {uri} now returns a {http_code}.',
-                Changelog::DEFINITION_REMOVED => '{method} on {uri} no longer will return a {http_code}.'
+                // Representations are optional on returns, so we need special strings for those cases.
+                'no_representation' => [
+                    Changelog::DEFINITION_ADDED => '{method} on {uri} now returns a {http_code}.',
+                    Changelog::DEFINITION_REMOVED => '{method} on {uri} no longer will return a {http_code}.'
+                ]
             ]
-        ]
-    ];
+        ];
+    }
 
     /**
      * @inheritdoc
      */
     public function compileAddedOrRemovedChangeset($definition, array $changes = [])
     {
+        $templates = $this->getTemplates();
+
         if (count($changes) === 1) {
             $change = array_shift($changes);
             if ($change['representation']) {
-                $template = $this->templates['singular'][$definition];
+                $template = $templates['singular'][$definition];
             } else {
-                $template = $this->templates['singular']['no_representation'][$definition];
+                $template = $templates['singular']['no_representation'][$definition];
             }
 
             return $this->renderText($template, $change);
@@ -64,7 +69,7 @@ class ActionReturn extends Changeset
                     }
                 }
 
-                $template = $this->templates['plural'][$definition];
+                $template = $templates['plural'][$definition];
                 $entries[] = [
                     $this->renderText($template, [
                         'resource_group' => $changes[0]['resource_group'],
@@ -78,7 +83,7 @@ class ActionReturn extends Changeset
             }
 
             $change = array_shift($changes);
-            $template = $this->templates['singular'][$definition];
+            $template = $templates['singular'][$definition];
             $entries[] = $this->renderText($template, $change);
         }
 

--- a/src/Generator/Changelog/Changesets/ActionThrows.php
+++ b/src/Generator/Changelog/Changesets/ActionThrows.php
@@ -7,29 +7,34 @@ use Mill\Generator\Changelog\Changeset;
 class ActionThrows extends Changeset
 {
     /**
-     * @var array
+     * @inheritdoc
      */
-    protected $templates = [
-        'plural' => [
-            Changelog::DEFINITION_ADDED => '{uri} will now throw the following errors on {method} requests:',
-            Changelog::DEFINITION_REMOVED => '{uri} will no longer throw the following errors on {method} requests:'
-        ],
-        'singular' => [
-            Changelog::DEFINITION_ADDED => 'On {method} requests to {uri}, a {http_code} with a {representation} ' .
-                'representation will now be returned: {description}',
-            Changelog::DEFINITION_REMOVED => '{method} requests to {uri} longer will return a {http_code} with a ' .
-                '{representation} representation: {description}'
-        ]
-    ];
+    public function getTemplates()
+    {
+        return [
+            'plural' => [
+                Changelog::DEFINITION_ADDED => '{uri} will now throw the following errors on {method} requests:',
+                Changelog::DEFINITION_REMOVED => '{uri} will no longer throw the following errors on {method} requests:'
+            ],
+            'singular' => [
+                Changelog::DEFINITION_ADDED => 'On {method} requests to {uri}, a {http_code} with a {representation} ' .
+                    'representation will now be returned: {description}',
+                Changelog::DEFINITION_REMOVED => '{method} requests to {uri} longer will return a {http_code} with a ' .
+                    '{representation} representation: {description}'
+            ]
+        ];
+    }
 
     /**
      * @inheritdoc
      */
     public function compileAddedOrRemovedChangeset($definition, array $changes = [])
     {
+        $templates = $this->getTemplates();
+
         if (count($changes) === 1) {
             $change = array_shift($changes);
-            $template = $this->templates['singular'][$definition];
+            $template = $templates['singular'][$definition];
             return $this->renderText($template, $change);
         }
 
@@ -51,7 +56,7 @@ class ActionThrows extends Changeset
 
                 $change = array_shift($changes);
 
-                $template = $this->templates['plural'][$definition];
+                $template = $templates['plural'][$definition];
                 $entries[] = [
                     $this->renderText($template, [
                         'resource_group' => $change['resource_group'],
@@ -64,7 +69,7 @@ class ActionThrows extends Changeset
             }
 
             $change = array_shift($changes);
-            $template = $this->templates['singular'][$definition];
+            $template = $templates['singular'][$definition];
             $entries[] = $this->renderText($template, $change);
         }
 

--- a/src/Generator/Changelog/Changesets/ContentType.php
+++ b/src/Generator/Changelog/Changesets/ContentType.php
@@ -7,14 +7,17 @@ use Mill\Generator\Changelog\Changeset;
 class ContentType extends Changeset
 {
     /**
-     * @var array
+     * @inheritdoc
      */
-    protected $templates = [
-        'singular' => [
-            Changelog::DEFINITION_CHANGED => 'On {uri}, {method} requests will return a {content_type} Content-Type ' .
-                'header.'
-        ]
-    ];
+    public function getTemplates()
+    {
+        return [
+            'singular' => [
+                Changelog::DEFINITION_CHANGED => 'On {uri}, {method} requests will return a {content_type} ' .
+                    'Content-Type header.'
+            ]
+        ];
+    }
 
     /**
      * @inheritdoc
@@ -29,6 +32,8 @@ class ContentType extends Changeset
      */
     public function compileChangedChangeset($definition, array $changes = [])
     {
+        $templates = $this->getTemplates();
+
         if (count($changes) > 1) {
             $uris = array_map(function ($change) {
                 return $change['uri'];
@@ -42,7 +47,7 @@ class ContentType extends Changeset
             $change = array_shift($changes);
         }
 
-        $template = $this->templates['singular'][$definition];
+        $template = $templates['singular'][$definition];
         return $this->renderText($template, $change);
     }
 }

--- a/src/Generator/Changelog/Changesets/RepresentationData.php
+++ b/src/Generator/Changelog/Changesets/RepresentationData.php
@@ -7,27 +7,32 @@ use Mill\Generator\Changelog\Changeset;
 class RepresentationData extends Changeset
 {
     /**
-     * @var array
+     * @inheritdoc
      */
-    protected $templates = [
-        'plural' => [
-            Changelog::DEFINITION_ADDED => 'The {representation} representation has added the following fields:',
-            Changelog::DEFINITION_REMOVED => 'The {representation} representation has removed the following fields:'
-        ],
-        'singular' => [
-            Changelog::DEFINITION_ADDED => '{field} has been added to the {representation} representation.',
-            Changelog::DEFINITION_REMOVED => '{field} has been removed from the {representation} representation.'
-        ]
-    ];
+    public function getTemplates()
+    {
+        return [
+            'plural' => [
+                Changelog::DEFINITION_ADDED => 'The {representation} representation has added the following fields:',
+                Changelog::DEFINITION_REMOVED => 'The {representation} representation has removed the following fields:'
+            ],
+            'singular' => [
+                Changelog::DEFINITION_ADDED => '{field} has been added to the {representation} representation.',
+                Changelog::DEFINITION_REMOVED => '{field} has been removed from the {representation} representation.'
+            ]
+        ];
+    }
 
     /**
      * @inheritdoc
      */
     public function compileAddedOrRemovedChangeset($definition, array $changes = [])
     {
+        $templates = $this->getTemplates();
+
         if (count($changes) === 1) {
             $change = array_shift($changes);
-            $template = $this->templates['singular'][$definition];
+            $template = $templates['singular'][$definition];
             return $this->renderText($template, $change);
         }
 
@@ -36,7 +41,7 @@ class RepresentationData extends Changeset
             $fields[] = $this->renderText('{field}', $change);
         }
 
-        $template = $this->templates['plural'][$definition];
+        $template = $templates['plural'][$definition];
         return [
             $this->renderText($template, array_shift($changes)),
             $fields


### PR DESCRIPTION
PHP 5.4 doesn't allow you to conjoin strings on member variables.

Unfortunately this kind of thing wasn't found because we aren't running Travis tests against PHP 5.4 due to some dependency hell issues.