### PR TITLE
Fixing a compatiblity issue with generated blueprints and `enum` types.

### DIFF
--- a/resources/examples/Showtimes/Controllers/Movie.php
+++ b/resources/examples/Showtimes/Controllers/Movie.php
@@ -66,7 +66,7 @@ class Movie
      * @api-param:public name (string, required) - Name of the movie.
      * @api-param:public description (string, required) - Description, or tagline, for the movie.
      * @api-param:public runtime (string, optional) - Movie runtime, in `HHhr MMmin` format.
-     * @api-param:public content_rating (string, optional) - MPAA rating
+     * @api-param:public content_rating (enum, optional) - MPAA rating
      *  + Members
      *      - `G`
      *      - `PG`

--- a/src/Generator/Blueprint.php
+++ b/src/Generator/Blueprint.php
@@ -283,7 +283,7 @@ class Blueprint extends Generator
                 '- `%s`%s (%s%s) - %s',
                 $param->getField(),
                 (!empty($sample_data)) ? sprintf(': `%s`', $sample_data) : '',
-                (!empty($values)) ? 'enum[' . $type . ']' : $type,
+                (!empty($values) && $param->getType() !== 'enum') ? 'enum[' . $type . ']' : $type,
                 ($param->isRequired()) ? ', required' : null,
                 $param->getDescription()
             );

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -344,7 +344,7 @@ DESCRIPTION;
                                 'field' => 'content_rating',
                                 'required' => false,
                                 'sample_data' => false,
-                                'type' => 'string',
+                                'type' => 'enum',
                                 'values' => [
                                     'G' => '',
                                     'NC-17' => '',


### PR DESCRIPTION
This fixes a compatiblity bug in generated blueprints where if you had an explicit `enum` type in a parameter, the blueprint would be generated with a type of `enum[enum[string]]`:

Resolves #113