### PR TITLE
Some wording changes to the blueprints.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - npm install
 
 script:
+  - vendor/bin/phpcs --standard=PSR2 src/ tests/
+  - vendor/bin/psalm
   - vendor/bin/phpunit
   - npm test
-  - vendor/bin/psalm
-  - vendor/bin/phpcs --standard=PSR2 src/ tests/

--- a/psalm.xml
+++ b/psalm.xml
@@ -20,6 +20,14 @@
             </errorLevel>
         </InvalidArgument>
 
+        <InvalidReturnType>
+            <errorLevel type="suppress">
+                <!-- Our usage of json_encode() in the Json changelog format is always going to return a string. Not
+                    string|false. -->
+                <file name="src/Generator/Changelog/Formats/Json.php" />
+            </errorLevel>
+        </InvalidReturnType>
+
         <InvalidScalarArgument>
             <errorLevel type="suppress">
                 <!-- Masking errors where we're passing methods that return string|bool into test assertions. -->
@@ -45,5 +53,8 @@
 
         <!-- This hides a number of errors that we don't really care about. -->
         <PropertyNotSetInConstructor errorLevel="suppress" />
+
+        <!-- Masking PHP 7 errors and warnings for now. Mill will support only PHP 7.1+ in v3. -->
+        <UntypedParam errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/resources/examples/Showtimes/blueprints/1.0/api.apib
+++ b/resources/examples/Showtimes/blueprints/1.0/api.apib
@@ -77,7 +77,7 @@ Returns all movies for a specific location.
 ### Create a movie. [POST]
 Create a new movie.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes
@@ -102,7 +102,7 @@ This action requires a bearer token with `create` scope.
 + Response 200 (application/json)
     + Attributes (Movie)
 + Response 400 (application/json)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
@@ -127,7 +127,7 @@ Return information on a specific movie theater.
 ### Update a movie theater. [PATCH]
 Update a movie theaters' data.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -148,7 +148,7 @@ This action requires a bearer token with `create` scope.
 ### Delete a movie theater. [DELETE]
 Delete a movie theater.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -175,7 +175,7 @@ Returns all movie theatres for a specific location.
 ### Create a movie theater. [POST]
 Create a new movie theater.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes

--- a/resources/examples/Showtimes/blueprints/1.0/resources/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.0/resources/Movies.apib
@@ -72,7 +72,7 @@ Returns all movies for a specific location.
 ### Create a movie. [POST]
 Create a new movie.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes
@@ -97,7 +97,7 @@ This action requires a bearer token with `create` scope.
 + Response 200 (application/json)
     + Attributes (Movie)
 + Response 400 (application/json)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)

--- a/resources/examples/Showtimes/blueprints/1.0/resources/Theaters.apib
+++ b/resources/examples/Showtimes/blueprints/1.0/resources/Theaters.apib
@@ -18,7 +18,7 @@ Return information on a specific movie theater.
 ### Update a movie theater. [PATCH]
 Update a movie theaters' data.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -39,7 +39,7 @@ This action requires a bearer token with `create` scope.
 ### Delete a movie theater. [DELETE]
 Delete a movie theater.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -66,7 +66,7 @@ Returns all movie theatres for a specific location.
 ### Create a movie theater. [POST]
 Create a new movie theater.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes

--- a/resources/examples/Showtimes/blueprints/1.1.1/api.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.1/api.apib
@@ -61,7 +61,7 @@ sem malesuada magna mollis euismod.
 ### Update a movie. [PATCH]
 Update a movies data.
 
-This action requires a bearer token with `edit` scope.
+This action requires a bearer token with the `edit` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -90,7 +90,7 @@ This action requires a bearer token with `edit` scope.
 + Response 200 (application/json)
     + Attributes (Movie)
 + Response 400 (application/json)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
@@ -100,7 +100,7 @@ This action requires a bearer token with `edit` scope.
 ### Delete a movie. [DELETE]
 Delete a movie.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -128,7 +128,7 @@ Returns all movies for a specific location.
 ### Create a movie. [POST]
 Create a new movie.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes
@@ -155,7 +155,7 @@ This action requires a bearer token with `create` scope.
 + Response 200 (application/json)
     + Attributes (Movie)
 + Response 400 (application/json)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
@@ -180,7 +180,7 @@ Return information on a specific movie theater.
 ### Update a movie theater. [PATCH]
 Update a movie theaters' data.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -201,7 +201,7 @@ This action requires a bearer token with `create` scope.
 ### Delete a movie theater. [DELETE]
 Delete a movie theater.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -228,7 +228,7 @@ Returns all movie theatres for a specific location.
 ### Create a movie theater. [POST]
 Create a new movie theater.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes

--- a/resources/examples/Showtimes/blueprints/1.1.1/resources/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.1/resources/Movies.apib
@@ -56,7 +56,7 @@ sem malesuada magna mollis euismod.
 ### Update a movie. [PATCH]
 Update a movies data.
 
-This action requires a bearer token with `edit` scope.
+This action requires a bearer token with the `edit` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -85,7 +85,7 @@ This action requires a bearer token with `edit` scope.
 + Response 200 (application/json)
     + Attributes (Movie)
 + Response 400 (application/json)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
@@ -95,7 +95,7 @@ This action requires a bearer token with `edit` scope.
 ### Delete a movie. [DELETE]
 Delete a movie.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -123,7 +123,7 @@ Returns all movies for a specific location.
 ### Create a movie. [POST]
 Create a new movie.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes
@@ -150,7 +150,7 @@ This action requires a bearer token with `create` scope.
 + Response 200 (application/json)
     + Attributes (Movie)
 + Response 400 (application/json)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)

--- a/resources/examples/Showtimes/blueprints/1.1.1/resources/Theaters.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.1/resources/Theaters.apib
@@ -18,7 +18,7 @@ Return information on a specific movie theater.
 ### Update a movie theater. [PATCH]
 Update a movie theaters' data.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -39,7 +39,7 @@ This action requires a bearer token with `create` scope.
 ### Delete a movie theater. [DELETE]
 Delete a movie theater.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -66,7 +66,7 @@ Returns all movie theatres for a specific location.
 ### Create a movie theater. [POST]
 Create a new movie theater.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes

--- a/resources/examples/Showtimes/blueprints/1.1.2/api.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.2/api.apib
@@ -61,7 +61,7 @@ sem malesuada magna mollis euismod.
 ### Update a movie. [PATCH]
 Update a movies data.
 
-This action requires a bearer token with `edit` scope.
+This action requires a bearer token with the `edit` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -90,7 +90,7 @@ This action requires a bearer token with `edit` scope.
 + Response 200 (application/mill.example.movie)
     + Attributes (Movie)
 + Response 400 (application/mill.example.movie)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
@@ -100,7 +100,7 @@ This action requires a bearer token with `edit` scope.
 ### Delete a movie. [DELETE]
 Delete a movie.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -128,7 +128,7 @@ Returns all movies for a specific location.
 ### Create a movie. [POST]
 Create a new movie.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes
@@ -155,7 +155,7 @@ This action requires a bearer token with `create` scope.
 + Response 200 (application/mill.example.movie)
     + Attributes (Movie)
 + Response 400 (application/mill.example.movie)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
@@ -180,7 +180,7 @@ Return information on a specific movie theater.
 ### Update a movie theater. [PATCH]
 Update a movie theaters' data.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -199,7 +199,7 @@ This action requires a bearer token with `create` scope.
 ### Delete a movie theater. [DELETE]
 Delete a movie theater.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -226,7 +226,7 @@ Returns all movie theatres for a specific location.
 ### Create a movie theater. [POST]
 Create a new movie theater.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes

--- a/resources/examples/Showtimes/blueprints/1.1.2/resources/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.2/resources/Movies.apib
@@ -56,7 +56,7 @@ sem malesuada magna mollis euismod.
 ### Update a movie. [PATCH]
 Update a movies data.
 
-This action requires a bearer token with `edit` scope.
+This action requires a bearer token with the `edit` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -85,7 +85,7 @@ This action requires a bearer token with `edit` scope.
 + Response 200 (application/mill.example.movie)
     + Attributes (Movie)
 + Response 400 (application/mill.example.movie)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
@@ -95,7 +95,7 @@ This action requires a bearer token with `edit` scope.
 ### Delete a movie. [DELETE]
 Delete a movie.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -123,7 +123,7 @@ Returns all movies for a specific location.
 ### Create a movie. [POST]
 Create a new movie.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes
@@ -150,7 +150,7 @@ This action requires a bearer token with `create` scope.
 + Response 200 (application/mill.example.movie)
     + Attributes (Movie)
 + Response 400 (application/mill.example.movie)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)

--- a/resources/examples/Showtimes/blueprints/1.1.2/resources/Theaters.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.2/resources/Theaters.apib
@@ -18,7 +18,7 @@ Return information on a specific movie theater.
 ### Update a movie theater. [PATCH]
 Update a movie theaters' data.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -37,7 +37,7 @@ This action requires a bearer token with `create` scope.
 ### Delete a movie theater. [DELETE]
 Delete a movie theater.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -64,7 +64,7 @@ Returns all movie theatres for a specific location.
 ### Create a movie theater. [POST]
 Create a new movie theater.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes

--- a/resources/examples/Showtimes/blueprints/1.1.3/api.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.3/api.apib
@@ -29,7 +29,7 @@ sem malesuada magna mollis euismod.
     + Attributes (Movie)
 + Response 304 (application/mill.example.movie)
 + Response 404 (application/mill.example.movie)
-    There are 3 ways that this status code can be encountered.
+    There are three ways that this status code can be encountered:
          * If the movie could not be found.
          * For no reason.
          * For some other reason.
@@ -60,7 +60,7 @@ sem malesuada magna mollis euismod.
     + Attributes (Movie)
 + Response 304 (application/mill.example.movie)
 + Response 404 (application/mill.example.movie)
-    There are 3 ways that this status code can be encountered.
+    There are three ways that this status code can be encountered:
          * If the movie could not be found.
          * For no reason.
          * For some other reason.
@@ -69,7 +69,7 @@ sem malesuada magna mollis euismod.
 ### Update a movie. [PATCH]
 Update a movies data.
 
-This action requires a bearer token with `edit` scope.
+This action requires a bearer token with the `edit` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -100,17 +100,17 @@ This action requires a bearer token with `edit` scope.
 + Response 202 (application/mill.example.movie)
     + Attributes (Movie)
 + Response 400 (application/mill.example.movie)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
 + Response 403 (application/mill.example.movie)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If something cool happened. Unique error code: 1337
          * If the user is not allowed to edit that movie. Unique error code: 666
     + Attributes (Coded error)
 + Response 404 (application/mill.example.movie)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If the movie could not be found.
          * If the trailer URL could not be validated.
     + Attributes (Error)
@@ -118,7 +118,7 @@ This action requires a bearer token with `edit` scope.
 ### Delete a movie. [DELETE]
 Delete a movie.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -146,7 +146,7 @@ Returns all movies for a specific location.
 ### Create a movie. [POST]
 Create a new movie.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes
@@ -174,7 +174,7 @@ This action requires a bearer token with `create` scope.
     + Attributes (Movie)
 + Response 201 (application/mill.example.movie)
 + Response 400 (application/mill.example.movie)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
@@ -199,7 +199,7 @@ Return information on a specific movie theater.
 ### Update a movie theater. [PATCH]
 Update a movie theaters' data.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -218,7 +218,7 @@ This action requires a bearer token with `create` scope.
 ### Delete a movie theater. [DELETE]
 Delete a movie theater.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -245,7 +245,7 @@ Returns all movie theatres for a specific location.
 ### Create a movie theater. [POST]
 Create a new movie theater.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes

--- a/resources/examples/Showtimes/blueprints/1.1.3/resources/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.3/resources/Movies.apib
@@ -24,7 +24,7 @@ sem malesuada magna mollis euismod.
     + Attributes (Movie)
 + Response 304 (application/mill.example.movie)
 + Response 404 (application/mill.example.movie)
-    There are 3 ways that this status code can be encountered.
+    There are three ways that this status code can be encountered:
          * If the movie could not be found.
          * For no reason.
          * For some other reason.
@@ -55,7 +55,7 @@ sem malesuada magna mollis euismod.
     + Attributes (Movie)
 + Response 304 (application/mill.example.movie)
 + Response 404 (application/mill.example.movie)
-    There are 3 ways that this status code can be encountered.
+    There are three ways that this status code can be encountered:
          * If the movie could not be found.
          * For no reason.
          * For some other reason.
@@ -64,7 +64,7 @@ sem malesuada magna mollis euismod.
 ### Update a movie. [PATCH]
 Update a movies data.
 
-This action requires a bearer token with `edit` scope.
+This action requires a bearer token with the `edit` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -95,17 +95,17 @@ This action requires a bearer token with `edit` scope.
 + Response 202 (application/mill.example.movie)
     + Attributes (Movie)
 + Response 400 (application/mill.example.movie)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
 + Response 403 (application/mill.example.movie)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If something cool happened. Unique error code: 1337
          * If the user is not allowed to edit that movie. Unique error code: 666
     + Attributes (Coded error)
 + Response 404 (application/mill.example.movie)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If the movie could not be found.
          * If the trailer URL could not be validated.
     + Attributes (Error)
@@ -113,7 +113,7 @@ This action requires a bearer token with `edit` scope.
 ### Delete a movie. [DELETE]
 Delete a movie.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -141,7 +141,7 @@ Returns all movies for a specific location.
 ### Create a movie. [POST]
 Create a new movie.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes
@@ -169,7 +169,7 @@ This action requires a bearer token with `create` scope.
     + Attributes (Movie)
 + Response 201 (application/mill.example.movie)
 + Response 400 (application/mill.example.movie)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)

--- a/resources/examples/Showtimes/blueprints/1.1.3/resources/Theaters.apib
+++ b/resources/examples/Showtimes/blueprints/1.1.3/resources/Theaters.apib
@@ -18,7 +18,7 @@ Return information on a specific movie theater.
 ### Update a movie theater. [PATCH]
 Update a movie theaters' data.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -37,7 +37,7 @@ This action requires a bearer token with `create` scope.
 ### Delete a movie theater. [DELETE]
 Delete a movie theater.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -64,7 +64,7 @@ Returns all movie theatres for a specific location.
 ### Create a movie theater. [POST]
 Create a new movie theater.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes

--- a/resources/examples/Showtimes/blueprints/1.1/api.apib
+++ b/resources/examples/Showtimes/blueprints/1.1/api.apib
@@ -61,7 +61,7 @@ sem malesuada magna mollis euismod.
 ### Update a movie. [PATCH]
 Update a movies data.
 
-This action requires a bearer token with `edit` scope.
+This action requires a bearer token with the `edit` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -89,7 +89,7 @@ This action requires a bearer token with `edit` scope.
 + Response 200 (application/json)
     + Attributes (Movie)
 + Response 400 (application/json)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
@@ -99,7 +99,7 @@ This action requires a bearer token with `edit` scope.
 ### Delete a movie. [DELETE]
 Delete a movie.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -127,7 +127,7 @@ Returns all movies for a specific location.
 ### Create a movie. [POST]
 Create a new movie.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes
@@ -154,7 +154,7 @@ This action requires a bearer token with `create` scope.
 + Response 200 (application/json)
     + Attributes (Movie)
 + Response 400 (application/json)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
@@ -179,7 +179,7 @@ Return information on a specific movie theater.
 ### Update a movie theater. [PATCH]
 Update a movie theaters' data.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -200,7 +200,7 @@ This action requires a bearer token with `create` scope.
 ### Delete a movie theater. [DELETE]
 Delete a movie theater.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -227,7 +227,7 @@ Returns all movie theatres for a specific location.
 ### Create a movie theater. [POST]
 Create a new movie theater.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes

--- a/resources/examples/Showtimes/blueprints/1.1/resources/Movies.apib
+++ b/resources/examples/Showtimes/blueprints/1.1/resources/Movies.apib
@@ -56,7 +56,7 @@ sem malesuada magna mollis euismod.
 ### Update a movie. [PATCH]
 Update a movies data.
 
-This action requires a bearer token with `edit` scope.
+This action requires a bearer token with the `edit` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -84,7 +84,7 @@ This action requires a bearer token with `edit` scope.
 + Response 200 (application/json)
     + Attributes (Movie)
 + Response 400 (application/json)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)
@@ -94,7 +94,7 @@ This action requires a bearer token with `edit` scope.
 ### Delete a movie. [DELETE]
 Delete a movie.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Movie ID
@@ -122,7 +122,7 @@ Returns all movies for a specific location.
 ### Create a movie. [POST]
 Create a new movie.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes
@@ -149,7 +149,7 @@ This action requires a bearer token with `create` scope.
 + Response 200 (application/json)
     + Attributes (Movie)
 + Response 400 (application/json)
-    There are 2 ways that this status code can be encountered.
+    There are two ways that this status code can be encountered:
          * If there is a problem with the request.
          * If the IMDB URL could not be validated.
     + Attributes (Error)

--- a/resources/examples/Showtimes/blueprints/1.1/resources/Theaters.apib
+++ b/resources/examples/Showtimes/blueprints/1.1/resources/Theaters.apib
@@ -18,7 +18,7 @@ Return information on a specific movie theater.
 ### Update a movie theater. [PATCH]
 Update a movie theaters' data.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -39,7 +39,7 @@ This action requires a bearer token with `create` scope.
 ### Delete a movie theater. [DELETE]
 Delete a movie theater.
 
-This action requires a bearer token with `delete` scope.
+This action requires a bearer token with the `delete` scope.
 
 + Parameters
     - `id` (number, required) - Theater ID
@@ -66,7 +66,7 @@ Returns all movie theatres for a specific location.
 ### Create a movie theater. [POST]
 Create a new movie theater.
 
-This action requires a bearer token with `create` scope.
+This action requires a bearer token with the `create` scope.
 
 + Request
     + Attributes

--- a/src/Generator/Blueprint.php
+++ b/src/Generator/Blueprint.php
@@ -182,7 +182,7 @@ class Blueprint extends Generator
         }
 
         $blueprint = sprintf(
-            'This action requires a bearer token with %s scope%s.',
+            'This action requires a bearer token with the %s scope%s.',
             '`' . implode(', ', $strings) . '`',
             (count($strings) > 1) ? 's' : null
         );
@@ -336,8 +336,10 @@ class Blueprint extends Generator
         if ($multiple_responses) {
             // @todo Blueprint validation doesn't seem to like 200 responses with descriptions. Just skip for now.
             if (!in_array($http_code, [201, 204])) {
+                $response_count = (new \NumberFormatter('en', \NumberFormatter::SPELLOUT))->format(count($responses));
+
                 $blueprint .= $this->tab();
-                $blueprint .= sprintf('There are %d ways that this status code can be encountered.', count($responses));
+                $blueprint .= sprintf('There are %s ways that this status code can be encountered:', $response_count);
                 $blueprint .= $this->line();
 
                 /** @var ReturnAnnotation|ThrowsAnnotation $response */

--- a/tests/Command/ChangelogTest.php
+++ b/tests/Command/ChangelogTest.php
@@ -42,6 +42,7 @@ class ChangelogTest extends \PHPUnit_Framework_TestCase
      */
     public function testChangelog($private_objects, $capabilities, $expected_file)
     {
+        /** @var string $output_dir */
         $output_dir = tempnam(sys_get_temp_dir(), 'mill-generate-test-');
         if (file_exists($output_dir)) {
             unlink($output_dir);

--- a/tests/Command/ErrorMapTest.php
+++ b/tests/Command/ErrorMapTest.php
@@ -42,6 +42,7 @@ class ErrorMapTest extends \PHPUnit_Framework_TestCase
      */
     public function testErrorMap($private_objects, $capabilities, $expected_file)
     {
+        /** @var string $output_dir */
         $output_dir = tempnam(sys_get_temp_dir(), 'mill-generate-test-');
         if (file_exists($output_dir)) {
             unlink($output_dir);

--- a/tests/Command/GenerateTest.php
+++ b/tests/Command/GenerateTest.php
@@ -35,6 +35,7 @@ class GenerateTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerate()
     {
+        /** @var string $output_dir */
         $output_dir = tempnam(sys_get_temp_dir(), 'mill-generate-test-');
         if (file_exists($output_dir)) {
             unlink($output_dir);


### PR DESCRIPTION
This changes the wording of a few generated API Blueprint strings:

* [x] "This action requires a bearer token with `edit` scope." → "This action requires a bearer token with the `edit` scope."
* [x] "There are 2 ways that this status code can be encountered." → "There are two ways that this status code can be encountered:"

Also fixed some new code analysis errors that were detected with a vimeo/psalm upgrade.