### PR TITLE
PHP 7 typehinting

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -13,41 +13,16 @@
     </fileExtensions>
 
     <issueHandlers>
-        <InvalidArgument>
-            <errorLevel type="suppress">
-                <!-- Masking errors where we're passing methods that return mixed data into test assertions. -->
-                <directory name="tests/" />
-            </errorLevel>
-        </InvalidArgument>
-
-        <InvalidReturnType>
-            <errorLevel type="suppress">
-                <!-- Mill\Generator\Changelog\Formats\Json::generate() returns a JSON-encoded array. Psalm thinks that
-                    the method actually returns `string|false` because that's what `json_encode` can return. Not really
-                    true in this case, so ignore it. -->
-                <file name="src/Generator/Changelog/Formats/Json.php" />
-            </errorLevel>
-        </InvalidReturnType>
-
         <InvalidScalarArgument>
             <errorLevel type="suppress">
-                <!-- Masking errors where we're passing methods that return string|bool into test assertions. -->
+                <!-- Masking errors where we're passing methods that return `bool|string` into test assertions. -->
                 <directory name="tests/" />
             </errorLevel>
         </InvalidScalarArgument>
 
-        <MissingClosureReturnType errorLevel="suppress" />
-        <MissingConstructor errorLevel="suppress" />
-
-        <MissingReturnType>
-            <errorLevel type="suppress">
-                <directory name="tests/" />
-            </errorLevel>
-        </MissingReturnType>
-
         <PossiblyInvalidArgument>
             <errorLevel type="suppress">
-                <!-- Masking errors where we're passing methods that return object|bool into test assertions. -->
+                <!-- Masking errors where we're passing methods that return `bool|object` into test assertions. -->
                 <directory name="tests/" />
             </errorLevel>
         </PossiblyInvalidArgument>

--- a/psalm.xml
+++ b/psalm.xml
@@ -54,15 +54,5 @@
 
         <!-- This hides a number of errors that we don't really care about. -->
         <PropertyNotSetInConstructor errorLevel="suppress" />
-
-        <UntypedParam>
-            <errorLevel type="suppress">
-                <!-- The generator and provider classes use service providers and closures, but we don't really care
-                    that much about documenting the parameters on those closures, so ignore these errors. -->
-                <directory name="src/Generator" />
-                <directory name="src/Provider" />
-                <directory name="tests/" />
-            </errorLevel>
-        </UntypedParam>
     </issueHandlers>
 </psalm>

--- a/src/Config.php
+++ b/src/Config.php
@@ -21,7 +21,7 @@ use SimpleXMLElement;
 class Config
 {
     /**
-     * The base directory for this configuration file.e
+     * The base directory for this configuration file.
      *
      * @var string
      */
@@ -30,7 +30,7 @@ class Config
     /**
      * The name of your API.
      *
-     * @var string|null
+     * @var null|string
      */
     protected $name = null;
 
@@ -130,15 +130,16 @@ class Config
     /**
      * Create a new configuration object from a given config file.
      *
+     * @psalm-suppress UnresolvableInclude Config includes are dynamic and can't be resolved.
      * @param Filesystem $filesystem
      * @param string $config_file
      * @param bool $load_bootstrap
-     * @return Config
+     * @return self
      * @throws InvalidArgumentException If the config file can't be read.
      * @throws InvalidArgumentException If the config file does not exist.
      * @throws ValidationException If there are errors validating the schema of your config file.
      */
-    public static function loadFromXML(Filesystem $filesystem, $config_file, $load_bootstrap = true)
+    public static function loadFromXML(Filesystem $filesystem, string $config_file, bool $load_bootstrap = true): self
     {
         $config = new self();
         $config->base_dir = dirname($config_file) . '/';
@@ -226,11 +227,11 @@ class Config
     /**
      * Load an array of application capabilities into the configuration system.
      *
-     * @param array $capabilities
-     * @return void
+     * @param SimpleXMLElement $capabilities
      */
-    protected function loadCapabilities($capabilities = [])
+    protected function loadCapabilities(SimpleXMLElement $capabilities): void
     {
+        /** @var SimpleXMLElement $capability */
         foreach ($capabilities as $capability) {
             $this->capabilities[] = (string) $capability['name'];
         }
@@ -242,11 +243,11 @@ class Config
     /**
      * Load an array of authentication scopes into the configuration system.
      *
-     * @param array $scopes
-     * @return void
+     * @param SimpleXMLElement $scopes
      */
-    protected function loadScopes($scopes = [])
+    protected function loadScopes(SimpleXMLElement $scopes): void
     {
+        /** @var SimpleXMLElement $scope */
         foreach ($scopes as $scope) {
             $this->scopes[] = (string) $scope['name'];
         }
@@ -258,10 +259,9 @@ class Config
     /**
      * Load an array of URI segment translations into the configuration system.
      *
-     * @param array $translations
-     * @return void
+     * @param SimpleXMLElement $translations
      */
-    protected function loadUriSegmentTranslations($translations = [])
+    protected function loadUriSegmentTranslations($translations): void
     {
         /** @var SimpleXMLElement $translation */
         foreach ($translations as $translation) {
@@ -277,10 +277,9 @@ class Config
      *
      * @param string $from
      * @param string $to
-     * @return void
      * @throws DomainException If an invalid uriSegment translation text was found.
      */
-    public function addUriSegmentTranslation($from, $to)
+    public function addUriSegmentTranslation($from, $to): void
     {
         if (empty($from) || empty($to)) {
             throw new DomainException(
@@ -294,11 +293,11 @@ class Config
     /**
      * Load an array of `@api-param` replacement tokens into the configuration system.
      *
-     * @param array $tokens
-     * @return void
+     * @param SimpleXMLElement $tokens
      */
-    protected function loadParameterTokens($tokens = [])
+    protected function loadParameterTokens(SimpleXMLElement $tokens): void
     {
+        /** @var SimpleXMLElement $token */
         foreach ($tokens as $token) {
             $parameter = trim((string) $token['name']);
             $annotation = trim((string) $token);
@@ -315,10 +314,9 @@ class Config
      *
      * @param string $parameter
      * @param string $annotation
-     * @return void
      * @throws DomainException If an invalid parameterTokens token name was found.
      */
-    public function addParameterToken($parameter, $annotation)
+    public function addParameterToken(string $parameter, string $annotation): void
     {
         if (empty($parameter) || empty($annotation)) {
             throw new DomainException(
@@ -333,12 +331,12 @@ class Config
      * Load in generator settings.
      *
      * @param SimpleXMLElement $generators
-     * @return void
      */
-    protected function loadGeneratorSettings(SimpleXMLElement $generators)
+    protected function loadGeneratorSettings(SimpleXMLElement $generators): void
     {
         if (isset($generators->blueprint)) {
             if (isset($generators->blueprint->excludes)) {
+                /** @var SimpleXMLElement $exclude */
                 foreach ($generators->blueprint->excludes->exclude as $exclude) {
                     $group = trim((string) $exclude['group']);
 
@@ -352,10 +350,9 @@ class Config
      * Add a new API Blueprint resource group generator exclusion.
      *
      * @param string $group
-     * @return void
      * @throws DomainException If an invalid Blueprint generator group exclude was detected.
      */
-    public function addBlueprintGroupExclude($group)
+    public function addBlueprintGroupExclude(string $group): void
     {
         if (empty($group)) {
             throw new DomainException(
@@ -371,9 +368,8 @@ class Config
      * Remove a currently configured API Blueprint resource group generator exclusion.
      *
      * @param string $group
-     * @return void
      */
-    public function removeBlueprintGroupExclude($group)
+    public function removeBlueprintGroupExclude(string $group): void
     {
         $excludes = array_flip($this->blueprint_group_excludes);
         if (isset($excludes[$group])) {
@@ -387,11 +383,10 @@ class Config
      * Load in a versions configuration definition.
      *
      * @param SimpleXMLElement $versions
-     * @return void
      * @throws InvalidArgumentException If multiple configured default API versions were detected.
      * @throws DomainException If no default API version was set.
      */
-    protected function loadVersions(SimpleXMLElement $versions)
+    protected function loadVersions(SimpleXMLElement $versions): void
     {
         $api_versions = [];
         foreach ($versions as $version) {
@@ -406,7 +401,7 @@ class Config
 
             $is_default = (bool) $version['default'];
             if ($is_default) {
-                if ($this->getDefaultApiVersion()) {
+                if (!empty($this->default_api_version)) {
                     throw new InvalidArgumentException(
                         'Multiple default API versions have been detected in the Mill `versions` section.'
                     );
@@ -416,7 +411,7 @@ class Config
             }
         }
 
-        if (!$this->getDefaultApiVersion()) {
+        if (empty($this->default_api_version)) {
             throw new DomainException('You must set a default API version.');
         }
 
@@ -434,11 +429,10 @@ class Config
      * Load in a controllers configuration definition.
      *
      * @param SimpleXMLElement $controllers
-     * @return void
      * @throws InvalidArgumentException If a directory configured does not exist.
      * @throws InvalidArgumentException If no controllers were detected.
      */
-    protected function loadControllers(SimpleXMLElement $controllers)
+    protected function loadControllers(SimpleXMLElement $controllers): void
     {
         /** @var SimpleXMLElement $controllers */
         $controllers = $controllers->filter;
@@ -457,11 +451,7 @@ class Config
             $excludes = array_unique($excludes);
         }
 
-        /**
-         * Process classes.
-         *
-         * @var SimpleXMLElement $file
-         */
+        /** @var SimpleXMLElement $class */
         foreach ($controllers->class as $class) {
             $this->addController((string) $class['name']);
         }
@@ -494,10 +484,9 @@ class Config
      * Add a new resource controller into the instance config.
      *
      * @param string $class
-     * @return void
      * @throws InvalidArgumentException If a class could not be found.
      */
-    public function addController($class)
+    public function addController(string $class): void
     {
         if (!class_exists($class)) {
             throw new InvalidArgumentException(
@@ -515,13 +504,12 @@ class Config
      * Load in a representations configuration definition.
      *
      * @param SimpleXMLElement $representations
-     * @return void
      * @throws UncallableRepresentationException If a configured representation does not exist.
      * @throws DomainException If a representation is configured without a `method` attribute.
      * @throws InvalidArgumentException If a directory configured does not exist.
      * @throws InvalidArgumentException If no representations were detected.
      */
-    protected function loadRepresentations(SimpleXMLElement $representations)
+    protected function loadRepresentations(SimpleXMLElement $representations): void
     {
         /** @var SimpleXMLElement $filters */
         $filters = $representations->filter;
@@ -540,11 +528,7 @@ class Config
             $this->excluded_representations = array_unique($this->excluded_representations);
         }
 
-        /**
-         * Process classes.
-         *
-         * @var SimpleXMLElement $class
-         */
+        /** @var SimpleXMLElement $class */
         foreach ($filters->class as $class) {
             $class_name = (string) $class['name'];
             $method = (string) $class['method'] ?: null;
@@ -560,11 +544,7 @@ class Config
             $this->addRepresentation($class_name, $method);
         }
 
-        /**
-         * Process directories.
-         *
-         * @var SimpleXMLElement $directory
-         */
+        /** @var SimpleXMLElement $directory */
         foreach ($filters->directory as $directory) {
             $directory_name = (string) $this->base_dir . $directory['name'];
             if (!is_dir($directory_name)) {
@@ -598,9 +578,8 @@ class Config
      * Add a representation into the excluded list of representations.
      *
      * @param string $class
-     * @return void
      */
-    public function addExcludedRepresentation($class)
+    public function addExcludedRepresentation(string $class): void
     {
         $this->excluded_representations[] = $class;
     }
@@ -609,9 +588,8 @@ class Config
      * Remove a representation that has been set up to be excluded from compilation, from being excluded.
      *
      * @param string $class
-     * @return void
      */
-    public function removeExcludedRepresentation($class)
+    public function removeExcludedRepresentation(string $class): void
     {
         $excludes = array_flip($this->excluded_representations);
         if (isset($excludes[$class])) {
@@ -625,11 +603,10 @@ class Config
      * Add a new representation into the instance config.
      *
      * @param string $class
-     * @param string|null $method
-     * @return void
+     * @param null|string $method
      * @throws UncallableRepresentationException If the representation is uncallable.
      */
-    public function addRepresentation($class, $method = null)
+    public function addRepresentation(string $class, string $method = null): void
     {
         if (!class_exists($class)) {
             throw UncallableRepresentationException::create($class);
@@ -645,11 +622,10 @@ class Config
      * Load in an error representations configuration definition.
      *
      * @param SimpleXMLElement $representations
-     * @return void
      * @throws UncallableErrorRepresentationException If a configured error representation class does not exist.
      * @throws DomainException If an error representation is missing a `method` attribute.
      */
-    protected function loadErrorRepresentations(SimpleXMLElement $representations)
+    protected function loadErrorRepresentations(SimpleXMLElement $representations): void
     {
         /** @var SimpleXMLElement $errors */
         $errors = $representations->errors;
@@ -685,7 +661,7 @@ class Config
      * @param string $class
      * @return bool
      */
-    public function isRepresentationExcluded($class)
+    public function isRepresentationExcluded(string $class): bool
     {
         return in_array($class, $this->getExcludedRepresentations());
     }
@@ -695,7 +671,7 @@ class Config
      *
      * @return null|string
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -705,7 +681,7 @@ class Config
      *
      * @return string
      */
-    public function getFirstApiVersion()
+    public function getFirstApiVersion(): string
     {
         return $this->first_api_version;
     }
@@ -715,7 +691,7 @@ class Config
      *
      * @return string
      */
-    public function getDefaultApiVersion()
+    public function getDefaultApiVersion(): string
     {
         return $this->default_api_version;
     }
@@ -725,7 +701,7 @@ class Config
      *
      * @return string
      */
-    public function getLatestApiVersion()
+    public function getLatestApiVersion(): string
     {
         return $this->latest_api_version;
     }
@@ -735,7 +711,7 @@ class Config
      *
      * @return array
      */
-    public function getApiVersions()
+    public function getApiVersions(): array
     {
         return $this->api_versions;
     }
@@ -747,7 +723,7 @@ class Config
      * @return array
      * @throws \Exception If a supplied version was not configured.
      */
-    public function getApiVersion($version)
+    public function getApiVersion(string $version): array
     {
         foreach ($this->api_versions as $data) {
             if ($data['version'] == $version) {
@@ -763,7 +739,7 @@ class Config
      *
      * @return array
      */
-    public function getCapabilities()
+    public function getCapabilities(): array
     {
         return $this->capabilities;
     }
@@ -773,7 +749,7 @@ class Config
      *
      * @return array
      */
-    public function getScopes()
+    public function getScopes(): array
     {
         return $this->scopes;
     }
@@ -783,7 +759,7 @@ class Config
      *
      * @return array
      */
-    public function getUriSegmentTranslations()
+    public function getUriSegmentTranslations(): array
     {
         return $this->uri_segment_translations;
     }
@@ -793,7 +769,7 @@ class Config
      *
      * @return array
      */
-    public function getParameterTokens()
+    public function getParameterTokens(): array
     {
         return $this->parameter_tokens;
     }
@@ -803,7 +779,7 @@ class Config
      *
      * @return array
      */
-    public function getControllers()
+    public function getControllers(): array
     {
         return $this->controllers;
     }
@@ -813,7 +789,7 @@ class Config
      *
      * @return array
      */
-    public function getRepresentations()
+    public function getRepresentations(): array
     {
         return $this->representations;
     }
@@ -823,7 +799,7 @@ class Config
      *
      * @return array
      */
-    public function getErrorRepresentations()
+    public function getErrorRepresentations(): array
     {
         return $this->error_representations;
     }
@@ -833,7 +809,7 @@ class Config
      *
      * @return array
      */
-    public function getAllRepresentations()
+    public function getAllRepresentations(): array
     {
         return array_merge($this->getRepresentations(), $this->getErrorRepresentations());
     }
@@ -843,7 +819,7 @@ class Config
      *
      * @return array
      */
-    public function getExcludedRepresentations()
+    public function getExcludedRepresentations(): array
     {
         return $this->excluded_representations;
     }
@@ -853,7 +829,7 @@ class Config
      *
      * @return array
      */
-    public function getBlueprintGroupExcludes()
+    public function getBlueprintGroupExcludes(): array
     {
         return $this->blueprint_group_excludes;
     }
@@ -866,7 +842,7 @@ class Config
      * @param array $excludes
      * @return array
      */
-    protected function scanDirectoryForClasses($directory, $suffix, array $excludes = [])
+    protected function scanDirectoryForClasses(string $directory, string $suffix, array $excludes = []): array
     {
         $classes = [];
 
@@ -894,7 +870,7 @@ class Config
      * @return bool
      * @throws UnconfiguredRepresentationException If the representation hasn't been configured, or excluded.
      */
-    public function doesRepresentationExist($class)
+    public function doesRepresentationExist(string $class): bool
     {
         $representations = $this->getRepresentations();
         $excluded = $this->getExcludedRepresentations();
@@ -919,7 +895,7 @@ class Config
      * @return bool
      * @throws UnconfiguredErrorRepresentationException If the error representation hasn't been configured.
      */
-    public function doesErrorRepresentationExist($class)
+    public function doesErrorRepresentationExist(string $class): bool
     {
         $representations = $this->getErrorRepresentations();
         if (!isset($representations[$class])) {
@@ -935,7 +911,7 @@ class Config
      * @param string $representation
      * @return bool
      */
-    public function doesErrorRepresentationNeedAnErrorCode($representation)
+    public function doesErrorRepresentationNeedAnErrorCode(string $representation): bool
     {
         $representations = $this->getErrorRepresentations();
         return $representations[$representation]['needs_error_code'];
@@ -945,12 +921,12 @@ class Config
      * Tokenize a given file and return back the FQN of the class inside.
      *
      * @link http://stackoverflow.com/a/7153391/105698
-     * @param string $file
-     * @return string
      * @psalm-suppress MixedArrayAccess
      * @codeCoverageIgnore
+     * @param string $file
+     * @return string
      */
-    private function getClassFQNFromFile($file)
+    private function getClassFQNFromFile(string $file): string
     {
         /** @var resource $fp */
         $fp = fopen($file, 'r');

--- a/src/Container.php
+++ b/src/Container.php
@@ -17,8 +17,8 @@ class Container extends \Pimple\Container
      *
      * Objects and parameters can be passed as argument to the constructor.
      *
-     * @param array $values The parameters or objects.
      * @codeCoverageIgnore
+     * @param array $values The parameters or objects.
      */
     public function __construct(array $values = [])
     {
@@ -42,10 +42,10 @@ class Container extends \Pimple\Container
     /**
      * Return the current instance of the container.
      *
-     * @return Container
      * @codeCoverageIgnore
+     * @return self
      */
-    public static function getInstance()
+    public static function getInstance(): self
     {
         if (!self::$instance instanceof Container) {
             throw new \InvalidArgumentException(
@@ -61,7 +61,7 @@ class Container extends \Pimple\Container
      *
      * @return \Mill\Config
      */
-    public static function getConfig()
+    public static function getConfig(): \Mill\Config
     {
         return self::getInstance()['config'];
     }
@@ -71,7 +71,7 @@ class Container extends \Pimple\Container
      *
      * @return \League\Flysystem\Filesystem
      */
-    public static function getFilesystem()
+    public static function getFilesystem(): \League\Flysystem\Filesystem
     {
         return self::getInstance()['filesystem'];
     }
@@ -81,7 +81,7 @@ class Container extends \Pimple\Container
      *
      * @return \Closure
      */
-    public static function getAnnotationReader()
+    public static function getAnnotationReader(): \Closure
     {
         return self::getInstance()['reader.annotations'];
     }
@@ -91,7 +91,7 @@ class Container extends \Pimple\Container
      *
      * @return \Closure
      */
-    public static function getRepresentationAnnotationReader()
+    public static function getRepresentationAnnotationReader(): \Closure
     {
         return self::getInstance()['reader.annotations.representation'];
     }

--- a/src/Exceptions/Annotations/AbsoluteMinimumVersionException.php
+++ b/src/Exceptions/Annotations/AbsoluteMinimumVersionException.php
@@ -1,18 +1,17 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class AbsoluteMinimumVersionException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class AbsoluteMinimumVersionException extends BaseException
 {
     use AnnotationExceptionTrait;
 
-    /**
-     * @param string $annotation
-     * @param string $class
-     * @param string $method
-     * @return AbsoluteMinimumVersionException
-     */
-    public static function create($annotation, $class, $method)
-    {
+    public static function create(
+        string $annotation,
+        string $class,
+        string $method
+    ): AbsoluteMinimumVersionException {
         $message = sprintf(
             'The version on `@api-minVersion %s` in %s::%s is not an absolute version.',
             $annotation,

--- a/src/Exceptions/Annotations/AnnotationExceptionTrait.php
+++ b/src/Exceptions/Annotations/AnnotationExceptionTrait.php
@@ -1,33 +1,23 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-use Mill\Exceptions\ExceptionTrait;
-
 trait AnnotationExceptionTrait
 {
-    use ExceptionTrait;
-
-    /**
-     * @var string|null
-     */
+    /** @var null|string */
     public $docblock = null;
 
-    /**
-     * @var string|null
-     */
+    /** @var null|string */
     public $required_field = null;
 
-    /**
-     * @var array
-     */
+    /** @var array */
     public $values = [];
 
     /**
      * Get the raw docblock for this annotation.
      *
-     * @return string|null
+     * @return null|string
      */
-    public function getDocblock()
+    public function getDocblock(): ?string
     {
         return $this->docblock;
     }
@@ -35,9 +25,9 @@ trait AnnotationExceptionTrait
     /**
      * Get the required field that this annotation is missing.
      *
-     * @return string|null
+     * @return null|string
      */
-    public function getRequiredField()
+    public function getRequiredField(): ?string
     {
         return $this->required_field;
     }
@@ -47,7 +37,7 @@ trait AnnotationExceptionTrait
      *
      * @return array
      */
-    public function getValues()
+    public function getValues(): array
     {
         return $this->values;
     }

--- a/src/Exceptions/Annotations/BadOptionsListException.php
+++ b/src/Exceptions/Annotations/BadOptionsListException.php
@@ -1,20 +1,19 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class BadOptionsListException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class BadOptionsListException extends BaseException
 {
     use AnnotationExceptionTrait;
 
-    /**
-     * @param string $annotation
-     * @param string $docblock
-     * @param array $values
-     * @param string $class
-     * @param string $method
-     * @return BadOptionsListException
-     */
-    public static function create($annotation, $docblock, array $values, $class, $method)
-    {
+    public static function create(
+        string $annotation,
+        string $docblock,
+        array $values,
+        string $class,
+        string $method
+    ): BadOptionsListException {
         $message = sprintf(
             'The options list on `@api-%s %s`in %s::%s should written as `[%s]`, not `[%s]`.',
             $annotation,

--- a/src/Exceptions/Annotations/InvalidCapabilitySuppliedException.php
+++ b/src/Exceptions/Annotations/InvalidCapabilitySuppliedException.php
@@ -1,7 +1,9 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class InvalidCapabilitySuppliedException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class InvalidCapabilitySuppliedException extends BaseException
 {
     use AnnotationExceptionTrait;
 
@@ -10,14 +12,11 @@ class InvalidCapabilitySuppliedException extends \Exception
      */
     public $capability;
 
-    /**
-     * @param string $capability
-     * @param string $class
-     * @param string $method
-     * @return InvalidCapabilitySuppliedException
-     */
-    public static function create($capability, $class, $method)
-    {
+    public static function create(
+        string $capability,
+        string $class,
+        string $method
+    ): InvalidCapabilitySuppliedException {
         $message = sprintf(
             'The capability on `@api-capability %s` in %s::%s is not present in your config.',
             $capability,
@@ -38,7 +37,7 @@ class InvalidCapabilitySuppliedException extends \Exception
      *
      * @return string
      */
-    public function getCapability()
+    public function getCapability(): string
     {
         return $this->capability;
     }

--- a/src/Exceptions/Annotations/InvalidMSONSyntaxException.php
+++ b/src/Exceptions/Annotations/InvalidMSONSyntaxException.php
@@ -1,20 +1,19 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class InvalidMSONSyntaxException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class InvalidMSONSyntaxException extends BaseException
 {
     use AnnotationExceptionTrait;
 
-    /**
-     * @param string $required_field
-     * @param string $annotation
-     * @param string $docblock
-     * @param string $class
-     * @param string $method
-     * @return InvalidMSONSyntaxException
-     */
-    public static function create($required_field, $annotation, $docblock, $class, $method)
-    {
+    public static function create(
+        string $required_field,
+        string $annotation,
+        string $docblock,
+        string $class,
+        string $method
+    ): InvalidMSONSyntaxException {
         $message = sprintf(
             'Unable to parse a `%s` in the MSON on %s::%s for: `@api-%s %s`',
             $required_field,

--- a/src/Exceptions/Annotations/InvalidScopeSuppliedException.php
+++ b/src/Exceptions/Annotations/InvalidScopeSuppliedException.php
@@ -1,7 +1,9 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class InvalidScopeSuppliedException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class InvalidScopeSuppliedException extends BaseException
 {
     use AnnotationExceptionTrait;
 
@@ -10,13 +12,7 @@ class InvalidScopeSuppliedException extends \Exception
      */
     public $scope;
 
-    /**
-     * @param string $scope
-     * @param string $class
-     * @param string $method
-     * @return InvalidScopeSuppliedException
-     */
-    public static function create($scope, $class, $method)
+    public static function create(string $scope, string $class, string $method): InvalidScopeSuppliedException
     {
         $message = sprintf(
             'The scope on `@api-scope %s` in %s::%s is not present in your config.',
@@ -38,7 +34,7 @@ class InvalidScopeSuppliedException extends \Exception
      *
      * @return string
      */
-    public function getScope()
+    public function getScope(): string
     {
         return $this->scope;
     }

--- a/src/Exceptions/Annotations/MissingRepresentationErrorCodeException.php
+++ b/src/Exceptions/Annotations/MissingRepresentationErrorCodeException.php
@@ -1,18 +1,17 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class MissingRepresentationErrorCodeException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class MissingRepresentationErrorCodeException extends BaseException
 {
     use AnnotationExceptionTrait;
 
-    /**
-     * @param string $representation
-     * @param string $class
-     * @param string $method
-     * @return MissingRepresentationErrorCodeException
-     */
-    public static function create($representation, $class, $method)
-    {
+    public static function create(
+        string $representation,
+        string $class,
+        string $method
+    ): MissingRepresentationErrorCodeException {
         $message = sprintf(
             'The `%s` error representation on `@api-throws %s` in %s::%s is missing an error code, but is required ' .
                 'to have one in your config file.',

--- a/src/Exceptions/Annotations/MissingRequiredFieldException.php
+++ b/src/Exceptions/Annotations/MissingRequiredFieldException.php
@@ -1,20 +1,19 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class MissingRequiredFieldException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class MissingRequiredFieldException extends BaseException
 {
     use AnnotationExceptionTrait;
 
-    /**
-     * @param string $required_field
-     * @param string $annotation
-     * @param string $docblock
-     * @param string $class
-     * @param string $method
-     * @return MissingRequiredFieldException
-     */
-    public static function create($required_field, $annotation, $docblock, $class, $method)
-    {
+    public static function create(
+        string $required_field,
+        string $annotation,
+        string $docblock,
+        string $class,
+        string $method
+    ): MissingRequiredFieldException {
         $message = sprintf(
             'You must add a `%s` to `@api-%s %s` in %s::%s.',
             $required_field,

--- a/src/Exceptions/Annotations/MultipleAnnotationsException.php
+++ b/src/Exceptions/Annotations/MultipleAnnotationsException.php
@@ -1,18 +1,17 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class MultipleAnnotationsException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class MultipleAnnotationsException extends BaseException
 {
     use AnnotationExceptionTrait;
 
-    /**
-     * @param string $annotation
-     * @param string $class
-     * @param string|null $method
-     * @return MultipleAnnotationsException
-     */
-    public static function create($annotation, $class, $method = null)
-    {
+    public static function create(
+        string $annotation,
+        string $class,
+        string $method = null
+    ): MultipleAnnotationsException {
         $message = sprintf(
             'Multiple `@api-%s` annotations were found on %s%s. Only one is permissible.',
             $annotation,

--- a/src/Exceptions/Annotations/RequiredAnnotationException.php
+++ b/src/Exceptions/Annotations/RequiredAnnotationException.php
@@ -1,17 +1,13 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class RequiredAnnotationException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class RequiredAnnotationException extends BaseException
 {
     use AnnotationExceptionTrait;
 
-    /**
-     * @param string $annotation
-     * @param string $class
-     * @param string|null $method
-     * @return RequiredAnnotationException
-     */
-    public static function create($annotation, $class, $method = null)
+    public static function create(string $annotation, string $class, string $method = null): RequiredAnnotationException
     {
         $message = sprintf(
             'A required annotation, `@api-%s`, is missing from %s%s.',

--- a/src/Exceptions/Annotations/UncallableErrorCodeException.php
+++ b/src/Exceptions/Annotations/UncallableErrorCodeException.php
@@ -1,17 +1,13 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class UncallableErrorCodeException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class UncallableErrorCodeException extends BaseException
 {
     use AnnotationExceptionTrait;
 
-    /**
-     * @param string $docblock
-     * @param string $class
-     * @param string $method
-     * @return UncallableErrorCodeException
-     */
-    public static function create($docblock, $class, $method)
+    public static function create(string $docblock, string $class, string $method): UncallableErrorCodeException
     {
         $message = sprintf(
             'The `@api-throws %s` in %s::%s has an uncallable error code.',

--- a/src/Exceptions/Annotations/UnknownErrorRepresentationException.php
+++ b/src/Exceptions/Annotations/UnknownErrorRepresentationException.php
@@ -1,18 +1,17 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class UnknownErrorRepresentationException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class UnknownErrorRepresentationException extends BaseException
 {
     use AnnotationExceptionTrait;
 
-    /**
-     * @param string $representation
-     * @param string $class
-     * @param string $method
-     * @return UnknownErrorRepresentationException
-     */
-    public static function create($representation, $class, $method)
-    {
+    public static function create(
+        string $representation,
+        string $class,
+        string $method
+    ): UnknownErrorRepresentationException {
         $message = sprintf(
             'The `@api-throws %s` in %s::%s has an unknown representation. Is it present in your config file?',
             $representation,

--- a/src/Exceptions/Annotations/UnknownRepresentationException.php
+++ b/src/Exceptions/Annotations/UnknownRepresentationException.php
@@ -1,18 +1,17 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class UnknownRepresentationException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class UnknownRepresentationException extends BaseException
 {
     use AnnotationExceptionTrait;
 
-    /**
-     * @param string $representation
-     * @param string $class
-     * @param string $method
-     * @return UnknownRepresentationException
-     */
-    public static function create($representation, $class, $method)
-    {
+    public static function create(
+        string $representation,
+        string $class,
+        string $method
+    ): UnknownRepresentationException {
         $message = sprintf(
             'The `@api-return %s` in %s::%s has an unknown representation. Is it present in your config file?',
             $representation,

--- a/src/Exceptions/Annotations/UnknownReturnCodeException.php
+++ b/src/Exceptions/Annotations/UnknownReturnCodeException.php
@@ -1,19 +1,18 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class UnknownReturnCodeException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class UnknownReturnCodeException extends BaseException
 {
     use AnnotationExceptionTrait;
 
-    /**
-     * @param string $annotation
-     * @param string $docblock
-     * @param string $class
-     * @param string $method
-     * @return UnknownReturnCodeException
-     */
-    public static function create($annotation, $docblock, $class, $method)
-    {
+    public static function create(
+        string $annotation,
+        string $docblock,
+        string $class,
+        string $method
+    ): UnknownReturnCodeException {
         $message = sprintf(
             'Could not find a code for `@api-%s %s` in %s::%s.',
             $annotation,

--- a/src/Exceptions/Annotations/UnsupportedTypeException.php
+++ b/src/Exceptions/Annotations/UnsupportedTypeException.php
@@ -1,17 +1,13 @@
 <?php
 namespace Mill\Exceptions\Annotations;
 
-class UnsupportedTypeException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class UnsupportedTypeException extends BaseException
 {
     use AnnotationExceptionTrait;
 
-    /**
-     * @param string $annotation
-     * @param string $class
-     * @param string $method
-     * @return UnsupportedTypeException
-     */
-    public static function create($annotation, $class, $method)
+    public static function create(string $annotation, string $class, ?string $method): UnsupportedTypeException
     {
         $message = sprintf(
             'The type on `%s` in %s::%s is unsupported. Please check the documentation for supported types.',

--- a/src/Exceptions/BaseException.php
+++ b/src/Exceptions/BaseException.php
@@ -1,21 +1,15 @@
 <?php
 namespace Mill\Exceptions;
 
-trait ExceptionTrait
+class BaseException extends \Exception
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $class;
 
-    /**
-     * @var string|null
-     */
+    /** @var null|string */
     public $method = null;
 
-    /**
-     * @var string|null
-     */
+    /** @var null|string */
     public $annotation = null;
 
     /**
@@ -23,7 +17,7 @@ trait ExceptionTrait
      *
      * @return string
      */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }
@@ -31,9 +25,9 @@ trait ExceptionTrait
     /**
      * Get the class method that this exception occurred in.
      *
-     * @return string|null
+     * @return null|string
      */
-    public function getMethod()
+    public function getMethod(): ?string
     {
         return $this->method;
     }
@@ -41,9 +35,9 @@ trait ExceptionTrait
     /**
      * Get the name of the annotation that this exception is for.
      *
-     * @return string|null
+     * @return null|string
      */
-    public function getAnnotation()
+    public function getAnnotation(): ?string
     {
         return $this->annotation;
     }

--- a/src/Exceptions/Config/UncallableErrorRepresentationException.php
+++ b/src/Exceptions/Config/UncallableErrorRepresentationException.php
@@ -1,18 +1,14 @@
 <?php
 namespace Mill\Exceptions\Config;
 
-class UncallableErrorRepresentationException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class UncallableErrorRepresentationException extends BaseException
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $representation;
 
-    /**
-     * @param string $representation
-     * @return UncallableErrorRepresentationException
-     */
-    public static function create($representation)
+    public static function create(string $representation): UncallableErrorRepresentationException
     {
         $message = sprintf(
             'The `%s` error representation is being used, but is uncallable.',

--- a/src/Exceptions/Config/UncallableRepresentationException.php
+++ b/src/Exceptions/Config/UncallableRepresentationException.php
@@ -1,18 +1,14 @@
 <?php
 namespace Mill\Exceptions\Config;
 
-class UncallableRepresentationException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class UncallableRepresentationException extends BaseException
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $representation;
 
-    /**
-     * @param string $representation
-     * @return UncallableRepresentationException
-     */
-    public static function create($representation)
+    public static function create(string $representation): UncallableRepresentationException
     {
         $message = sprintf(
             'The `%s` representation is being used, but is uncallable.',

--- a/src/Exceptions/Config/UnconfiguredErrorRepresentationException.php
+++ b/src/Exceptions/Config/UnconfiguredErrorRepresentationException.php
@@ -1,18 +1,14 @@
 <?php
 namespace Mill\Exceptions\Config;
 
-class UnconfiguredErrorRepresentationException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class UnconfiguredErrorRepresentationException extends BaseException
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $representation;
 
-    /**
-     * @param string $representation
-     * @return UnconfiguredErrorRepresentationException
-     */
-    public static function create($representation)
+    public static function create(string $representation): UnconfiguredErrorRepresentationException
     {
         $message = sprintf(
             'The `%s` error representation is being used, but has not been configured for use.',

--- a/src/Exceptions/Config/UnconfiguredRepresentationException.php
+++ b/src/Exceptions/Config/UnconfiguredRepresentationException.php
@@ -1,18 +1,14 @@
 <?php
 namespace Mill\Exceptions\Config;
 
-class UnconfiguredRepresentationException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class UnconfiguredRepresentationException extends BaseException
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     public $representation;
 
-    /**
-     * @param string $representation
-     * @return UnconfiguredRepresentationException
-     */
-    public static function create($representation)
+    public static function create(string $representation): UnconfiguredRepresentationException
     {
         $message = sprintf(
             'The `%s` representation is being used, but has not been configured for use (or excluded).',

--- a/src/Exceptions/Config/ValidationException.php
+++ b/src/Exceptions/Config/ValidationException.php
@@ -1,14 +1,11 @@
 <?php
 namespace Mill\Exceptions\Config;
 
-class ValidationException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class ValidationException extends BaseException
 {
-    /**
-     * @param integer $line
-     * @param string $message
-     * @return ValidationException
-     */
-    public static function create($line, $message)
+    public static function create(int $line, string $message): ValidationException
     {
         $message = sprintf(
             'Error parsing Mill configuration file on line %s: "%s"',

--- a/src/Exceptions/MSON/MissingOptionsException.php
+++ b/src/Exceptions/MSON/MissingOptionsException.php
@@ -1,24 +1,16 @@
 <?php
 namespace Mill\Exceptions\MSON;
 
-use Mill\Exceptions\ExceptionTrait;
+use Mill\Exceptions\BaseException;
 
-class MissingOptionsException extends \Exception
+class MissingOptionsException extends BaseException
 {
-    use ExceptionTrait;
-
     /**
-     * @var string|null
+     * @var null|string
      */
     public $type = null;
 
-    /**
-     * @param string $type
-     * @param string $class
-     * @param string $method
-     * @return MissingOptionsException
-     */
-    public static function create($type, $class, $method)
+    public static function create(string $type, string $class, string $method): MissingOptionsException
     {
         $message = sprintf(
             'A MSON type of `%s` in %s::%s requires accompanying acceptable values.',
@@ -38,9 +30,9 @@ class MissingOptionsException extends \Exception
     /**
      * Get the type that this response exception was triggered for.
      *
-     * @return string|null
+     * @return null|string
      */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->type;
     }

--- a/src/Exceptions/MethodNotImplementedException.php
+++ b/src/Exceptions/MethodNotImplementedException.php
@@ -1,16 +1,9 @@
 <?php
 namespace Mill\Exceptions;
 
-class MethodNotImplementedException extends \Exception
+class MethodNotImplementedException extends BaseException
 {
-    use ExceptionTrait;
-
-    /**
-     * @param string $class
-     * @param string $method
-     * @return MethodNotImplementedException
-     */
-    public static function create($class, $method)
+    public static function create(string $class, string $method): MethodNotImplementedException
     {
         $message = sprintf(
             '%s does not implement %s.',

--- a/src/Exceptions/MethodNotSuppliedException.php
+++ b/src/Exceptions/MethodNotSuppliedException.php
@@ -1,15 +1,9 @@
 <?php
 namespace Mill\Exceptions;
 
-class MethodNotSuppliedException extends \Exception
+class MethodNotSuppliedException extends BaseException
 {
-    use ExceptionTrait;
-
-    /**
-     * @param string $class
-     * @return MethodNotSuppliedException
-     */
-    public static function create($class)
+    public static function create(string $class): MethodNotSuppliedException
     {
         $message = sprintf(
             'No method was supplied on %s.',

--- a/src/Exceptions/Representation/DuplicateFieldException.php
+++ b/src/Exceptions/Representation/DuplicateFieldException.php
@@ -1,17 +1,13 @@
 <?php
 namespace Mill\Exceptions\Representation;
 
-class DuplicateFieldException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class DuplicateFieldException extends BaseException
 {
     use RepresentationExceptionTrait;
 
-    /**
-     * @param string $field
-     * @param string $class
-     * @param string $method
-     * @return DuplicateFieldException
-     */
-    public static function create($field, $class, $method)
+    public static function create(string $field, string $class, string $method): DuplicateFieldException
     {
         $message = sprintf(
             '`%s` has been found twice in %s::%s. This is not allowed.',

--- a/src/Exceptions/Representation/RepresentationExceptionTrait.php
+++ b/src/Exceptions/Representation/RepresentationExceptionTrait.php
@@ -1,23 +1,17 @@
 <?php
 namespace Mill\Exceptions\Representation;
 
-use Mill\Exceptions\ExceptionTrait;
-
 trait RepresentationExceptionTrait
 {
-    use ExceptionTrait;
-
-    /**
-     * @var string|null
-     */
+    /** @var null|string */
     public $field = null;
 
     /**
      * Get the field that this response exception was triggered for.
      *
-     * @return string|null
+     * @return null|string
      */
-    public function getField()
+    public function getField(): ?string
     {
         return $this->field;
     }

--- a/src/Exceptions/Representation/RestrictedFieldNameException.php
+++ b/src/Exceptions/Representation/RestrictedFieldNameException.php
@@ -1,18 +1,14 @@
 <?php
 namespace Mill\Exceptions\Representation;
 
+use Mill\Exceptions\BaseException;
 use Mill\Parser\Representation\Documentation;
 
-class RestrictedFieldNameException extends \Exception
+class RestrictedFieldNameException extends BaseException
 {
     use RepresentationExceptionTrait;
 
-    /**
-     * @param string $class
-     * @param string $method
-     * @return RestrictedFieldNameException
-     */
-    public static function create($class, $method)
+    public static function create(string $class, ?string $method): RestrictedFieldNameException
     {
         $message = sprintf(
             '`%s` is a reserved `@api-field` name, and cannot be used in %s::%s.',

--- a/src/Exceptions/Resource/MissingVisibilityDecoratorException.php
+++ b/src/Exceptions/Resource/MissingVisibilityDecoratorException.php
@@ -1,18 +1,17 @@
 <?php
 namespace Mill\Exceptions\Resource;
 
-class MissingVisibilityDecoratorException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class MissingVisibilityDecoratorException extends BaseException
 {
     use ResourceExceptionTrait;
 
-    /**
-     * @param string $annotation
-     * @param string $class
-     * @param string $method
-     * @return MissingVisibilityDecoratorException
-     */
-    public static function create($annotation, $class, $method)
-    {
+    public static function create(
+        string $annotation,
+        string $class,
+        string $method
+    ): MissingVisibilityDecoratorException {
         $message = sprintf(
             'An `@api-%s` annotation in %s::%s, is missing a visibility decorator.',
             $annotation,

--- a/src/Exceptions/Resource/NoAnnotationsException.php
+++ b/src/Exceptions/Resource/NoAnnotationsException.php
@@ -1,16 +1,13 @@
 <?php
 namespace Mill\Exceptions\Resource;
 
-class NoAnnotationsException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class NoAnnotationsException extends BaseException
 {
     use ResourceExceptionTrait;
 
-    /**
-     * @param string $class
-     * @param string|null $method
-     * @return NoAnnotationsException
-     */
-    public static function create($class, $method)
+    public static function create(string $class, ?string $method): NoAnnotationsException
     {
         if (empty($method)) {
             $message = sprintf('No annotations could be found on %s, does it have a docblock?', $class);

--- a/src/Exceptions/Resource/PublicDecoratorOnPrivateActionException.php
+++ b/src/Exceptions/Resource/PublicDecoratorOnPrivateActionException.php
@@ -1,18 +1,17 @@
 <?php
 namespace Mill\Exceptions\Resource;
 
-class PublicDecoratorOnPrivateActionException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class PublicDecoratorOnPrivateActionException extends BaseException
 {
     use ResourceExceptionTrait;
 
-    /**
-     * @param string $annotation
-     * @param string $class
-     * @param string $method
-     * @return PublicDecoratorOnPrivateActionException
-     */
-    public static function create($annotation, $class, $method)
-    {
+    public static function create(
+        string $annotation,
+        string $class,
+        string $method
+    ): PublicDecoratorOnPrivateActionException {
         $message = sprintf(
             'An `@api-%s` annotation in %s::%s has a `:public` decorator, but is on a private endpoint.',
             $annotation,

--- a/src/Exceptions/Resource/ResourceExceptionTrait.php
+++ b/src/Exceptions/Resource/ResourceExceptionTrait.php
@@ -1,23 +1,17 @@
 <?php
 namespace Mill\Exceptions\Resource;
 
-use Mill\Exceptions\ExceptionTrait;
-
 trait ResourceExceptionTrait
 {
-    use ExceptionTrait;
-
-    /**
-     * @var string|null
-     */
+    /** @var null|string */
     public $decorator = null;
 
     /**
      * Get the decorator that this resource exception was triggered for.
      *
-     * @return string|null
+     * @return null|string
      */
-    public function getDecorator()
+    public function getDecorator(): ?string
     {
         return $this->decorator;
     }

--- a/src/Exceptions/Resource/TooManyAliasedUrisException.php
+++ b/src/Exceptions/Resource/TooManyAliasedUrisException.php
@@ -1,16 +1,13 @@
 <?php
 namespace Mill\Exceptions\Resource;
 
-class TooManyAliasedUrisException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class TooManyAliasedUrisException extends BaseException
 {
     use ResourceExceptionTrait;
 
-    /**
-     * @param string $class
-     * @param string|null $method
-     * @return TooManyAliasedUrisException
-     */
-    public static function create($class, $method)
+    public static function create(string $class, ?string $method): TooManyAliasedUrisException
     {
         $message = sprintf(
             'In %s::%s, you have too many URI aliases set. If you have an alias present, there must be exactly one ' .

--- a/src/Exceptions/Resource/UnsupportedDecoratorException.php
+++ b/src/Exceptions/Resource/UnsupportedDecoratorException.php
@@ -1,19 +1,18 @@
 <?php
 namespace Mill\Exceptions\Resource;
 
-class UnsupportedDecoratorException extends \Exception
+use Mill\Exceptions\BaseException;
+
+class UnsupportedDecoratorException extends BaseException
 {
     use ResourceExceptionTrait;
 
-    /**
-     * @param string $decorator
-     * @param string $annotation
-     * @param string $class
-     * @param string $method
-     * @return UnsupportedDecoratorException
-     */
-    public static function create($decorator, $annotation, $class, $method)
-    {
+    public static function create(
+        string $decorator,
+        string $annotation,
+        string $class,
+        string $method
+    ): UnsupportedDecoratorException {
         $message = sprintf(
             'An unsupported decorator, `%s`, was found on `@api-%s` in %s::%s.',
             $decorator,

--- a/src/Exceptions/Version/UnrecognizedSchemaException.php
+++ b/src/Exceptions/Version/UnrecognizedSchemaException.php
@@ -1,24 +1,16 @@
 <?php
 namespace Mill\Exceptions\Version;
 
-use Mill\Exceptions\ExceptionTrait;
+use Mill\Exceptions\BaseException;
 
-class UnrecognizedSchemaException extends \Exception
+class UnrecognizedSchemaException extends BaseException
 {
-    use ExceptionTrait;
-
     /**
-     * @var string|null
+     * @var string
      */
     public $version = null;
 
-    /**
-     * @param string $version
-     * @param string $class
-     * @param string $method
-     * @return UnrecognizedSchemaException
-     */
-    public static function create($version, $class, $method)
+    public static function create(string $version, string $class, string $method): UnrecognizedSchemaException
     {
         $message = sprintf(
             'A `@api-version` annotation in %s::%s was found with an unrecognized schema of `%s`.',
@@ -40,7 +32,7 @@ class UnrecognizedSchemaException extends \Exception
      *
      * @return string
      */
-    public function getValidationMessage()
+    public function getValidationMessage(): string
     {
         return sprintf(
             'The supplied version, `%s`, has an unrecognized schema. Please consult the versioning documentation.',
@@ -51,9 +43,9 @@ class UnrecognizedSchemaException extends \Exception
     /**
      * Get the version that an annotation exception was triggered for.
      *
-     * @return string|null
+     * @return string
      */
-    public function getVersion()
+    public function getVersion(): string
     {
         return $this->version;
     }

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -30,9 +30,7 @@ class Generator
     protected $supported_versions = [];
 
     /**
-     * Compiled documentation.
-     *
-     * @var array
+     * @var array Compiled documentation.
      */
     protected $compiled = [
         'representations' => [],
@@ -58,7 +56,7 @@ class Generator
 
     /**
      * @param Config $config
-     * @param Version|null $version
+     * @param null|Version $version
      */
     public function __construct(Config $config, Version $version = null)
     {
@@ -73,7 +71,7 @@ class Generator
      *
      * @return array
      */
-    public function generate()
+    public function generate(): array
     {
         // Generate resources.
         $resources = $this->compileResources($this->parseResources());
@@ -101,7 +99,7 @@ class Generator
      *
      * @return array
      */
-    protected function parseResources()
+    protected function parseResources(): array
     {
         $resources = [];
         foreach ($this->config->getControllers() as $controller) {
@@ -161,7 +159,7 @@ class Generator
      * @param array $parsed
      * @return array
      */
-    private function compileResources(array $parsed = [])
+    private function compileResources(array $parsed = []): array
     {
         $resources = [];
         foreach ($parsed as $group => $group_data) {
@@ -224,7 +222,7 @@ class Generator
      *
      * @return array
      */
-    protected function parseRepresentations()
+    protected function parseRepresentations(): array
     {
         $representations = [];
         $error_representations = $this->config->getErrorRepresentations();
@@ -253,7 +251,7 @@ class Generator
      * @param array $parsed
      * @return array
      */
-    private function compileRepresentations(array $parsed = [])
+    private function compileRepresentations(array $parsed = []): array
     {
         $representations = [];
 
@@ -283,10 +281,10 @@ class Generator
     /**
      * Get compiled representations.
      *
-     * @param Version|string|null $version
+     * @param null|string|Version $version
      * @return array
      */
-    public function getRepresentations($version = null)
+    public function getRepresentations($version = null): array
     {
         if (empty($version)) {
             return $this->compiled['representations'];
@@ -302,10 +300,10 @@ class Generator
     /**
      * Get compiled resources.
      *
-     * @param string|null $version
+     * @param null|string $version
      * @return array
      */
-    public function getResources($version = null)
+    public function getResources(string $version = null): array
     {
         if (empty($version)) {
             return $this->compiled['resources'];
@@ -318,9 +316,9 @@ class Generator
      * Set if we'll be loading documentation that's been marked as being private.
      *
      * @param bool $load_private_docs
-     * @return $this
+     * @return self
      */
-    public function setLoadPrivateDocs($load_private_docs = true)
+    public function setLoadPrivateDocs(bool $load_private_docs = true): self
     {
         $this->load_private_docs = $load_private_docs;
         return $this;
@@ -333,9 +331,9 @@ class Generator
      * that either has no capability, or specific ones, supply an array with those capability names.
      *
      * @param array|null $capabilities
-     * @return $this
+     * @return self
      */
-    public function setLoadCapabilityDocs($capabilities = null)
+    public function setLoadCapabilityDocs(array $capabilities = null): self
     {
         $this->load_capability_docs = $capabilities;
         return $this;
@@ -348,7 +346,7 @@ class Generator
      * @param UriAnnotation $uri
      * @return bool
      */
-    private function shouldParseUri(Resource\Action\Documentation $method, UriAnnotation $uri)
+    private function shouldParseUri(Resource\Action\Documentation $method, UriAnnotation $uri): bool
     {
         $uri_data = $uri->toArray();
         $capabilities = $method->getCapabilities();

--- a/src/Generator/Blueprint.php
+++ b/src/Generator/Blueprint.php
@@ -17,6 +17,7 @@ class Blueprint extends Generator
 
     /**
      * Current list of representations for the current API version we're working with.
+     *
      * @var array
      */
     private $representations = [];
@@ -26,7 +27,7 @@ class Blueprint extends Generator
      *
      * @return array
      */
-    public function generate()
+    public function generate(): array
     {
         parent::generate();
 
@@ -75,16 +76,10 @@ class Blueprint extends Generator
                             $action_contents .= $this->line(2);
                         }
 
-                        // Generate scopes
                         $action_contents .= $this->processScopes($action);
-
-                        // Process parameters
                         $action_contents .= $this->processParameters($action);
-
-                        // Generate request
                         $action_contents .= $this->processRequest($action);
 
-                        // Generate response
                         $coded_responses = [];
                         /** @var ReturnAnnotation|ThrowsAnnotation $response */
                         foreach ($action->getResponses() as $response) {
@@ -166,7 +161,7 @@ class Blueprint extends Generator
      * Process an action and generate a scopes description.
      *
      * @param Action\Documentation $action
-     * @return string|false
+     * @return false|string
      */
     protected function processScopes(Action\Documentation $action)
     {
@@ -196,7 +191,7 @@ class Blueprint extends Generator
      * Process an action and generate a parameters Blueprint.
      *
      * @param Action\Documentation $action
-     * @return string|false
+     * @return false|string
      */
     protected function processParameters(Action\Documentation $action)
     {
@@ -217,6 +212,7 @@ class Blueprint extends Generator
                 $field = str_replace($from, $to, $field);
             }
 
+            /** @var array $values */
             $values = $segment->getValues();
             $type = $this->convertTypeToCompatibleType($segment->getType());
 
@@ -257,7 +253,7 @@ class Blueprint extends Generator
      * @param Action\Documentation $action
      * @return string
      */
-    protected function processRequest(Action\Documentation $action)
+    protected function processRequest(Action\Documentation $action): string
     {
         $params = $action->getParameters();
         if (empty($params)) {
@@ -322,7 +318,7 @@ class Blueprint extends Generator
      * @throws \Exception If a non-200 response is missing a description.
      * @throws NoAnnotationsException If a used representation does not have any documentation.
      */
-    protected function processResponses(Action\Documentation $action, $http_code, array $responses = [])
+    protected function processResponses(Action\Documentation $action, string $http_code, array $responses = []): string
     {
         $http_code = substr($http_code, 0, 3);
 
@@ -392,10 +388,10 @@ class Blueprint extends Generator
      * Recursively process an array of representation fields.
      *
      * @param array $fields
-     * @param integer $indent
+     * @param int $indent
      * @return string
      */
-    private function processRepresentationFields($fields = [], $indent = 2)
+    private function processRepresentationFields(array $fields = [], int $indent = 2): string
     {
         $blueprint = '';
 
@@ -492,7 +488,7 @@ class Blueprint extends Generator
      * @param array $structures
      * @return string
      */
-    protected function processCombinedFile($groups = [], $structures = [])
+    protected function processCombinedFile(array $groups = [], array $structures = []): string
     {
         $blueprint = 'FORMAT: 1A';
         $blueprint .= $this->line(2);
@@ -534,10 +530,10 @@ class Blueprint extends Generator
      *
      * @link https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#2-types
      * @param string $type
-     * @param mixed $subtype
+     * @param false|string $subtype
      * @return string
      */
-    private function convertTypeToCompatibleType($type, $subtype = false)
+    private function convertTypeToCompatibleType(string $type, $subtype = false): string
     {
         switch ($type) {
             case 'enum':
@@ -588,9 +584,9 @@ class Blueprint extends Generator
      * Pull a representation from the current versioned set of representations.
      *
      * @param string $representation
-     * @return \Mill\Parser\Representation\Documentation|false
+     * @return false|\Mill\Parser\Representation\Documentation
      */
-    private function getRepresentation($representation)
+    private function getRepresentation(string $representation)
     {
         return (isset($this->representations[$representation])) ? $this->representations[$representation] : false;
     }

--- a/src/Generator/Changelog/Changeset.php
+++ b/src/Generator/Changelog/Changeset.php
@@ -12,7 +12,7 @@ abstract class Changeset
      *
      * @return array
      */
-    abstract public function getTemplates();
+    abstract public function getTemplates(): array;
 
     /**
      * Get a changelog entry for a changeset that was added into, or removed from, the API.
@@ -20,10 +20,10 @@ abstract class Changeset
      * @param string $definition This is the definition of the changeset, whether it's an "added", "removed", or
      *  "changed" set.
      * @param array $changes
-     * @return string|array
+     * @return array|string
      * @throws \Exception If an unsupported definition + change type was supplied.
      */
-    abstract public function compileAddedOrRemovedChangeset($definition, array $changes = []);
+    abstract public function compileAddedOrRemovedChangeset(string $definition, array $changes = []);
 
     /**
      * Get a changelog entry for a changeset that was changed within the API.
@@ -31,8 +31,8 @@ abstract class Changeset
      * @param string $definition This is the definition of the changeset, whether it's an "added", "removed", or
      *  "changed" set.
      * @param array $changes
-     * @return string|array
+     * @return array|string
      * @throws \Exception If an unsupported definition + change type was supplied.
      */
-    abstract public function compileChangedChangeset($definition, array $changes = []);
+    abstract public function compileChangedChangeset(string $definition, array $changes = []);
 }

--- a/src/Generator/Changelog/Changesets/Action.php
+++ b/src/Generator/Changelog/Changesets/Action.php
@@ -7,9 +7,9 @@ use Mill\Generator\Changelog\Changeset;
 class Action extends Changeset
 {
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         return [
             'plural' => [
@@ -22,9 +22,9 @@ class Action extends Changeset
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function compileAddedOrRemovedChangeset($definition, array $changes = [])
+    public function compileAddedOrRemovedChangeset(string $definition, array $changes = [])
     {
         $templates = $this->getTemplates();
 
@@ -53,9 +53,9 @@ class Action extends Changeset
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function compileChangedChangeset($definition, array $changes = [])
+    public function compileChangedChangeset(string $definition, array $changes = [])
     {
         throw new \Exception($definition . ' action changes are not yet supported.');
     }

--- a/src/Generator/Changelog/Changesets/ActionParam.php
+++ b/src/Generator/Changelog/Changesets/ActionParam.php
@@ -7,9 +7,9 @@ use Mill\Generator\Changelog\Changeset;
 class ActionParam extends Changeset
 {
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         return [
             'plural' => [
@@ -25,9 +25,9 @@ class ActionParam extends Changeset
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function compileAddedOrRemovedChangeset($definition, array $changes = [])
+    public function compileAddedOrRemovedChangeset(string $definition, array $changes = [])
     {
         $templates = $this->getTemplates();
 
@@ -79,9 +79,9 @@ class ActionParam extends Changeset
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function compileChangedChangeset($definition, array $changes = [])
+    public function compileChangedChangeset(string $definition, array $changes = [])
     {
         throw new \Exception($definition . ' action param changes are not yet supported.');
     }

--- a/src/Generator/Changelog/Changesets/ActionReturn.php
+++ b/src/Generator/Changelog/Changesets/ActionReturn.php
@@ -7,9 +7,9 @@ use Mill\Generator\Changelog\Changeset;
 class ActionReturn extends Changeset
 {
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         return [
             'plural' => [
@@ -32,9 +32,9 @@ class ActionReturn extends Changeset
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function compileAddedOrRemovedChangeset($definition, array $changes = [])
+    public function compileAddedOrRemovedChangeset(string $definition, array $changes = [])
     {
         $templates = $this->getTemplates();
 
@@ -91,9 +91,9 @@ class ActionReturn extends Changeset
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function compileChangedChangeset($definition, array $changes = [])
+    public function compileChangedChangeset(string $definition, array $changes = [])
     {
         throw new \Exception($definition . ' action return changes are not yet supported.');
     }

--- a/src/Generator/Changelog/Changesets/ActionThrows.php
+++ b/src/Generator/Changelog/Changesets/ActionThrows.php
@@ -7,9 +7,9 @@ use Mill\Generator\Changelog\Changeset;
 class ActionThrows extends Changeset
 {
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         return [
             'plural' => [
@@ -26,9 +26,9 @@ class ActionThrows extends Changeset
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function compileAddedOrRemovedChangeset($definition, array $changes = [])
+    public function compileAddedOrRemovedChangeset(string $definition, array $changes = [])
     {
         $templates = $this->getTemplates();
 
@@ -77,9 +77,9 @@ class ActionThrows extends Changeset
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function compileChangedChangeset($definition, array $changes = [])
+    public function compileChangedChangeset(string $definition, array $changes = [])
     {
         throw new \Exception($definition . ' action throws changes are not yet supported.');
     }

--- a/src/Generator/Changelog/Changesets/ContentType.php
+++ b/src/Generator/Changelog/Changesets/ContentType.php
@@ -7,9 +7,9 @@ use Mill\Generator\Changelog\Changeset;
 class ContentType extends Changeset
 {
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         return [
             'singular' => [
@@ -20,22 +20,22 @@ class ContentType extends Changeset
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function compileAddedOrRemovedChangeset($definition, array $changes = [])
+    public function compileAddedOrRemovedChangeset(string $definition, array $changes = [])
     {
         throw new \Exception($definition . ' content type changes are not yet supported.');
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function compileChangedChangeset($definition, array $changes = [])
+    public function compileChangedChangeset(string $definition, array $changes = [])
     {
         $templates = $this->getTemplates();
 
         if (count($changes) > 1) {
-            $uris = array_map(function ($change) {
+            $uris = array_map(function (array $change): string {
                 return $change['uri'];
             }, $changes);
 

--- a/src/Generator/Changelog/Changesets/RepresentationData.php
+++ b/src/Generator/Changelog/Changesets/RepresentationData.php
@@ -7,9 +7,9 @@ use Mill\Generator\Changelog\Changeset;
 class RepresentationData extends Changeset
 {
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function getTemplates()
+    public function getTemplates(): array
     {
         return [
             'plural' => [
@@ -24,9 +24,9 @@ class RepresentationData extends Changeset
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function compileAddedOrRemovedChangeset($definition, array $changes = [])
+    public function compileAddedOrRemovedChangeset(string $definition, array $changes = [])
     {
         $templates = $this->getTemplates();
 
@@ -49,9 +49,9 @@ class RepresentationData extends Changeset
     }
 
     /**
-     * @inheritdoc
+     * {@inheritDoc}
      */
-    public function compileChangedChangeset($definition, array $changes = [])
+    public function compileChangedChangeset(string $definition, array $changes = [])
     {
         throw new \Exception($definition . ' representation data changes are not yet supported.');
     }

--- a/src/Generator/Changelog/Formats/Json.php
+++ b/src/Generator/Changelog/Formats/Json.php
@@ -20,9 +20,9 @@ class Json extends Generator
      * Set the current changelog we're going to build a representation for.
      *
      * @param array $changelog
-     * @return Json
+     * @return self
      */
-    public function setChangelog(array $changelog = [])
+    public function setChangelog(array $changelog = []): self
     {
         $this->changelog = $changelog;
         return $this;
@@ -31,9 +31,9 @@ class Json extends Generator
     /**
      * Take compiled API documentation and generate a JSON-encoded changelog over the life of the API.
      *
-     * @return string
+     * @return array
      */
-    public function generate()
+    public function generate(): array
     {
         $json = [];
 
@@ -56,7 +56,9 @@ class Json extends Generator
             }
         }
 
-        return json_encode($json);
+        return [
+            json_encode($json)
+        ];
     }
 
     /**
@@ -66,7 +68,7 @@ class Json extends Generator
      * @param array $changesets
      * @return array
      */
-    private function parseRepresentationChangesets($definition, array $changesets = [])
+    private function parseRepresentationChangesets(string $definition, array $changesets = []): array
     {
         $entries = [];
         foreach ($changesets as $representation => $change_types) {
@@ -101,7 +103,7 @@ class Json extends Generator
      * @param array $changesets
      * @return array
      */
-    private function parseResourceChangesets($definition, array $changesets = [])
+    private function parseResourceChangesets(string $definition, array $changesets = []): array
     {
         $entries = [];
         foreach ($changesets as $group => $data) {
@@ -149,7 +151,7 @@ class Json extends Generator
      * @return string|array
      * @throws \Exception If an unsupported definition + change type was supplied.
      */
-    private function getAddedOrRemovedChangesetFactory($definition, $change_type, array $changes)
+    private function getAddedOrRemovedChangesetFactory(string $definition, string $change_type, array $changes)
     {
         switch ($change_type) {
             case Changelog::CHANGESET_TYPE_ACTION:
@@ -189,7 +191,7 @@ class Json extends Generator
      * @return string|array
      * @throws \Exception If an unsupported definition + change type was supplied.
      */
-    private function getChangedChangesetFactory($definition, $change_type, array $changes)
+    private function getChangedChangesetFactory(string $definition, string $change_type, array $changes)
     {
         // Due to versioning restrictions in the Mill syntax (that will be fixed), only `@api-contentType` annotations
         // will generate a "changed" entry in the changelog.

--- a/src/Generator/Changelog/Formats/Markdown.php
+++ b/src/Generator/Changelog/Formats/Markdown.php
@@ -16,9 +16,9 @@ class Markdown extends Json
     /**
      * Take compiled API documentation and generate a Markdown-based changelog over the life of the API.
      *
-     * @return string
+     * @return array
      */
-    public function generate()
+    public function generate(): array
     {
         $markdown = '';
 
@@ -31,7 +31,9 @@ class Markdown extends Json
             $markdown .= $this->line(2);
         }
 
-        $changelog = json_decode(parent::generate(), true);
+        $changelog = parent::generate();
+        $changelog = array_shift($changelog);
+        $changelog = json_decode($changelog, true);
         foreach ($changelog as $version => $data) {
             $markdown .= sprintf('## %s (%s)', $version, $data['_details']['release_date']);
             $markdown .= $this->line();
@@ -65,17 +67,17 @@ class Markdown extends Json
             }
         }
 
-        return $markdown;
+        return [$markdown];
     }
 
     /**
      * Get Markdown syntax for a given changeset.
      *
      * @param array|string $changeset
-     * @param integer $tab
+     * @param int $tab
      * @return string
      */
-    private function getChangesetMarkdown($changeset, $tab = 0)
+    private function getChangesetMarkdown($changeset, int $tab = 0): string
     {
         $markdown = '';
         if (!is_array($changeset)) {

--- a/src/Generator/ErrorMap.php
+++ b/src/Generator/ErrorMap.php
@@ -23,7 +23,7 @@ class ErrorMap extends Generator
      *
      * @return array
      */
-    public function generate()
+    public function generate(): array
     {
         parent::generate();
 
@@ -68,7 +68,7 @@ class ErrorMap extends Generator
         foreach ($this->error_map as $version => $groups) {
             foreach ($groups as $group => $resources) {
                 foreach ($resources as $identifier => $errors) {
-                    usort($this->error_map[$version][$group][$identifier], function ($a, $b) {
+                    usort($this->error_map[$version][$group][$identifier], function (array $a, array $b): int {
                         // If the error codes match, then fallback to sorting by the URI.
                         if ($a['error_code'] == $b['error_code']) {
                             // If the URIs match, then fallback to sorting by their methods.
@@ -95,7 +95,7 @@ class ErrorMap extends Generator
      *
      * @return array
      */
-    public function generateMarkdown()
+    public function generateMarkdown(): array
     {
         $markdown = new Markdown($this->config);
         $markdown->setErrorMap($this->generate());

--- a/src/Generator/ErrorMap/Formats/Markdown.php
+++ b/src/Generator/ErrorMap/Formats/Markdown.php
@@ -25,9 +25,9 @@ class Markdown extends Generator
      * Set the current error map we're going to build a representation for.
      *
      * @param array $error_map
-     * @return Markdown
+     * @return self
      */
-    public function setErrorMap(array $error_map = [])
+    public function setErrorMap(array $error_map = []): self
     {
         $this->error_map = $error_map;
         return $this;
@@ -38,7 +38,7 @@ class Markdown extends Generator
      *
      * @return array
      */
-    public function generate()
+    public function generate(): array
     {
         $markdown = [];
 

--- a/src/Generator/Traits/ChangelogTemplate.php
+++ b/src/Generator/Traits/ChangelogTemplate.php
@@ -25,7 +25,7 @@ trait ChangelogTemplate
      * @param array $content
      * @return string
      */
-    protected function renderText($template, array $content = [])
+    protected function renderText(string $template, array $content = []): string
     {
         if (is_null($this->template_engine)) {
             $this->template_engine = new Engine;
@@ -47,7 +47,7 @@ trait ChangelogTemplate
      * @param array $content
      * @return array
      */
-    protected function transformTemplateIntoHtml($template, array $content = [])
+    protected function transformTemplateIntoHtml(string $template, array $content = []): array
     {
         $data_attributes = [];
         foreach ($content as $key => $value) {
@@ -81,7 +81,7 @@ trait ChangelogTemplate
                     $searches[] = '{' . $key . '}';
                     if (is_array($value)) {
                         $replacements[] = $this->joinWords(
-                            array_map(function ($value) use ($html, $key, $data_attributes) {
+                            array_map(function (string $value) use ($html, $key, $data_attributes): string {
                                 return sprintf($html, $key, $data_attributes, $value);
                             }, $value)
                         );
@@ -110,7 +110,7 @@ trait ChangelogTemplate
      * @param array $content
      * @return array
      */
-    protected function transformTemplateIntoMarkdown($template, array $content = [])
+    protected function transformTemplateIntoMarkdown(string $template, array $content = []): array
     {
         $searches = [];
         $replacements = [];
@@ -126,7 +126,7 @@ trait ChangelogTemplate
                     $searches[] = '{' . $key . '}';
                     if (is_array($value)) {
                         $replacements[] = $this->joinWords(
-                            array_map(function ($val) {
+                            array_map(function (string $val): string {
                                 return sprintf('`%s`', $val);
                             }, $value)
                         );
@@ -155,7 +155,7 @@ trait ChangelogTemplate
      * @param array $words
      * @return string
      */
-    protected function joinWords(array $words)
+    protected function joinWords(array $words): string
     {
         if (count($words) <= 2) {
             return implode(' and ', $words);
@@ -169,9 +169,8 @@ trait ChangelogTemplate
      * Set the current changelog template output format.
      *
      * @param string $format
-     * @return void
      */
-    public function setOutputFormat($format = 'json')
+    public function setOutputFormat($format = 'json'): void
     {
         $this->output_format = $format;
     }

--- a/src/Generator/Traits/Markdown.php
+++ b/src/Generator/Traits/Markdown.php
@@ -6,10 +6,10 @@ trait Markdown
     /**
      * Return a repeated new line character.
      *
-     * @param integer $repeat
+     * @param int $repeat
      * @return string
      */
-    protected function line($repeat = 1)
+    protected function line(int $repeat = 1): string
     {
         return str_repeat("\n", $repeat);
     }
@@ -17,10 +17,10 @@ trait Markdown
     /**
      * Return a repeated tab character.
      *
-     * @param integer $repeat
+     * @param int $repeat
      * @return string
      */
-    protected function tab($repeat = 1)
+    protected function tab(int $repeat = 1): string
     {
         return str_repeat('    ', $repeat);
     }

--- a/src/Parser/Annotations/CapabilityAnnotation.php
+++ b/src/Parser/Annotations/CapabilityAnnotation.php
@@ -12,10 +12,6 @@ use Mill\Parser\Version;
  */
 class CapabilityAnnotation extends Annotation
 {
-    const REQUIRES_VISIBILITY_DECORATOR = false;
-    const SUPPORTS_DEPRECATION = false;
-    const SUPPORTS_VERSIONING = false;
-
     /**
      * Return an array of items that should be included in an array representation of this annotation.
      *
@@ -32,7 +28,7 @@ class CapabilityAnnotation extends Annotation
      * @return array
      * @throws InvalidCapabilitySuppliedException If a found capability is not present in your config file.
      */
-    protected function parser()
+    protected function parser(): array
     {
         $capability = $this->docblock;
 
@@ -40,7 +36,9 @@ class CapabilityAnnotation extends Annotation
             // Validate the supplied capability with what has been configured as allowable.
             $capabilities = Container::getConfig()->getCapabilities();
             if (!in_array($capability, $capabilities)) {
-                throw InvalidCapabilitySuppliedException::create($capability, $this->class, $this->method);
+                /** @var string $method */
+                $method = $this->method;
+                throw InvalidCapabilitySuppliedException::create($capability, $this->class, $method);
             }
         }
 
@@ -57,7 +55,7 @@ class CapabilityAnnotation extends Annotation
      *
      * @return void
      */
-    protected function interpreter()
+    protected function interpreter(): void
     {
         $this->capability = $this->required('capability');
     }
@@ -66,7 +64,7 @@ class CapabilityAnnotation extends Annotation
      * With an array of data that was output from an Annotation, via `toArray()`, hydrate a new Annotation object.
      *
      * @param array $data
-     * @param Version|null $version
+     * @param null|Version $version
      * @return self
      */
     public static function hydrate(array $data = [], Version $version = null): self

--- a/src/Parser/Annotations/ContentTypeAnnotation.php
+++ b/src/Parser/Annotations/ContentTypeAnnotation.php
@@ -10,8 +10,6 @@ use Mill\Parser\Version;
  */
 class ContentTypeAnnotation extends Annotation
 {
-    const REQUIRES_VISIBILITY_DECORATOR = false;
-    const SUPPORTS_DEPRECATION = false;
     const SUPPORTS_VERSIONING = true;
 
     /**
@@ -36,7 +34,7 @@ class ContentTypeAnnotation extends Annotation
      *
      * @return array
      */
-    protected function parser()
+    protected function parser(): array
     {
         return [
             'content_type' => $this->docblock
@@ -51,7 +49,7 @@ class ContentTypeAnnotation extends Annotation
      *
      * @return void
      */
-    protected function interpreter()
+    protected function interpreter(): void
     {
         $this->content_type = $this->required('content_type');
     }
@@ -60,7 +58,7 @@ class ContentTypeAnnotation extends Annotation
      * With an array of data that was output from an Annotation, via `toArray()`, hydrate a new Annotation object.
      *
      * @param array $data
-     * @param Version|null $version
+     * @param null|Version $version
      * @return self
      */
     public static function hydrate(array $data = [], Version $version = null): self
@@ -77,7 +75,7 @@ class ContentTypeAnnotation extends Annotation
      *
      * @return string
      */
-    public function getContentType()
+    public function getContentType(): string
     {
         return $this->content_type;
     }

--- a/src/Parser/Annotations/DataAnnotation.php
+++ b/src/Parser/Annotations/DataAnnotation.php
@@ -13,8 +13,6 @@ use Mill\Parser\Version;
  */
 class DataAnnotation extends Annotation
 {
-    const REQUIRES_VISIBILITY_DECORATOR = false;
-    const SUPPORTS_DEPRECATION = false;
     const SUPPORTS_MSON = true;
     const SUPPORTS_SCOPES = true;
     const SUPPORTS_VERSIONING = true;
@@ -29,9 +27,9 @@ class DataAnnotation extends Annotation
     /**
      * Sample data that this might represent.
      *
-     * @var string|false
+     * @var false|string
      */
-    protected $sample_data;
+    protected $sample_data = false;
 
     /**
      * Type of data that this represents.
@@ -43,7 +41,7 @@ class DataAnnotation extends Annotation
     /**
      * Subtype of the type of data that this represents.
      *
-     * @var string|false
+     * @var false|string
      */
     protected $subtype = false;
 
@@ -57,7 +55,7 @@ class DataAnnotation extends Annotation
     /**
      * Array of acceptable values for this data.
      *
-     * @var array|null|false
+     * @var array|false|null
      */
     protected $values = [];
 
@@ -91,11 +89,14 @@ class DataAnnotation extends Annotation
      * @return array
      * @throws RestrictedFieldNameException If a restricted `@api-field` name is detected.
      */
-    protected function parser()
+    protected function parser(): array
     {
         $content = trim($this->docblock);
 
-        $mson = (new MSON($this->class, $this->method))->parse($content);
+        /** @var string $method */
+        $method = $this->method;
+
+        $mson = (new MSON($this->class, $method))->parse($content);
         $parsed = [
             'identifier' => $mson->getField(),
             'sample_data' => $mson->getSampleData(),
@@ -138,7 +139,7 @@ class DataAnnotation extends Annotation
      *
      * @return void
      */
-    protected function interpreter()
+    protected function interpreter(): void
     {
         $this->identifier = $this->required('identifier');
         $this->sample_data = $this->optional('sample_data');
@@ -155,7 +156,7 @@ class DataAnnotation extends Annotation
      * With an array of data that was output from an Annotation, via `toArray()`, hydrate a new Annotation object.
      *
      * @param array $data
-     * @param Version|null $version
+     * @param null|Version $version
      * @return self
      */
     public static function hydrate(array $data = [], Version $version = null): self
@@ -215,7 +216,7 @@ class DataAnnotation extends Annotation
      * @param string $prefix
      * @return self
      */
-    public function setIdentifierPrefix($prefix)
+    public function setIdentifierPrefix($prefix): self
     {
         $this->identifier = $prefix . '.' . $this->identifier;
         return $this;

--- a/src/Parser/Annotations/DescriptionAnnotation.php
+++ b/src/Parser/Annotations/DescriptionAnnotation.php
@@ -10,13 +10,7 @@ use Mill\Parser\Version;
  */
 class DescriptionAnnotation extends Annotation
 {
-    const REQUIRES_VISIBILITY_DECORATOR = false;
-    const SUPPORTS_DEPRECATION = false;
-    const SUPPORTS_VERSIONING = false;
-
     /**
-     * Description.
-     *
      * @var string
      */
     protected $description;
@@ -36,7 +30,7 @@ class DescriptionAnnotation extends Annotation
      *
      * @return array
      */
-    protected function parser()
+    protected function parser(): array
     {
         return [
             'description' => $this->docblock
@@ -51,7 +45,7 @@ class DescriptionAnnotation extends Annotation
      *
      * @return void
      */
-    protected function interpreter()
+    protected function interpreter(): void
     {
         $this->description = $this->required('description');
     }
@@ -60,7 +54,7 @@ class DescriptionAnnotation extends Annotation
      * With an array of data that was output from an Annotation, via `toArray()`, hydrate a new Annotation object.
      *
      * @param array $data
-     * @param Version|null $version
+     * @param null|Version $version
      * @return self
      */
     public static function hydrate(array $data = [], Version $version = null): self
@@ -77,7 +71,7 @@ class DescriptionAnnotation extends Annotation
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }

--- a/src/Parser/Annotations/LabelAnnotation.php
+++ b/src/Parser/Annotations/LabelAnnotation.php
@@ -10,13 +10,7 @@ use Mill\Parser\Version;
  */
 class LabelAnnotation extends Annotation
 {
-    const REQUIRES_VISIBILITY_DECORATOR = false;
-    const SUPPORTS_DEPRECATION = false;
-    const SUPPORTS_VERSIONING = false;
-
     /**
-     * Label
-     *
      * @var string
      */
     protected $label;
@@ -36,7 +30,7 @@ class LabelAnnotation extends Annotation
      *
      * @return array
      */
-    protected function parser()
+    protected function parser(): array
     {
         return [
             'label' => $this->docblock
@@ -51,7 +45,7 @@ class LabelAnnotation extends Annotation
      *
      * @return void
      */
-    protected function interpreter()
+    protected function interpreter(): void
     {
         $this->label = $this->required('label');
     }
@@ -60,7 +54,7 @@ class LabelAnnotation extends Annotation
      * With an array of data that was output from an Annotation, via `toArray()`, hydrate a new Annotation object.
      *
      * @param array $data
-     * @param Version|null $version
+     * @param null|Version $version
      * @return self
      */
     public static function hydrate(array $data = [], Version $version = null): self
@@ -77,13 +71,13 @@ class LabelAnnotation extends Annotation
      *
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return $this->label;
     }
 
     /**
-     * @param $label
+     * @param string $label
      * @return self
      */
     public function setLabel(string $label): self

--- a/src/Parser/Annotations/MinVersionAnnotation.php
+++ b/src/Parser/Annotations/MinVersionAnnotation.php
@@ -17,10 +17,6 @@ use Mill\Parser\Version;
  */
 class MinVersionAnnotation extends Annotation
 {
-    const REQUIRES_VISIBILITY_DECORATOR = false;
-    const SUPPORTS_DEPRECATION = false;
-    const SUPPORTS_VERSIONING = false;
-
     /**
      * Minimum version.
      *
@@ -44,11 +40,14 @@ class MinVersionAnnotation extends Annotation
      * @return array
      * @throws AbsoluteMinimumVersionException If an `@api-minVersion` annotation version is not absolute.
      */
-    protected function parser()
+    protected function parser(): array
     {
-        $parsed = new Version($this->docblock, $this->class, $this->method);
+        /** @var string $method */
+        $method = $this->method;
+
+        $parsed = new Version($this->docblock, $this->class, $method);
         if ($parsed->isRange()) {
-            throw AbsoluteMinimumVersionException::create($this->docblock, $this->class, $this->method);
+            throw AbsoluteMinimumVersionException::create($this->docblock, $this->class, $method);
         }
 
         return [
@@ -64,7 +63,7 @@ class MinVersionAnnotation extends Annotation
      *
      * @return void
      */
-    protected function interpreter()
+    protected function interpreter(): void
     {
         // The Version class already does all of our validation, so if we're at this point, we have a good version and
         // don't need to run it through `$this->required()` again.
@@ -75,7 +74,7 @@ class MinVersionAnnotation extends Annotation
      * With an array of data that was output from an Annotation, via `toArray()`, hydrate a new Annotation object.
      *
      * @param array $data
-     * @param Version|null $version
+     * @param null|Version $version
      * @return self
      */
     public static function hydrate(array $data = [], Version $version = null): self
@@ -92,7 +91,7 @@ class MinVersionAnnotation extends Annotation
      *
      * @return string
      */
-    public function getMinimumVersion()
+    public function getMinimumVersion(): string
     {
         return $this->minimum_version;
     }

--- a/src/Parser/Annotations/ParamAnnotation.php
+++ b/src/Parser/Annotations/ParamAnnotation.php
@@ -28,9 +28,9 @@ class ParamAnnotation extends Annotation
     /**
      * Sample data that this parameter might accept.
      *
-     * @var string|false
+     * @var false|string
      */
-    protected $sample_data;
+    protected $sample_data = false;
 
     /**
      * Type of data that this parameter supports.
@@ -68,7 +68,7 @@ class ParamAnnotation extends Annotation
     protected $values = [];
 
     /**
-     * Array of items that should be included in an array representation of this annotation.
+     * Return an array of items that should be included in an array representation of this annotation.
      *
      * @var array
      */
@@ -91,7 +91,7 @@ class ParamAnnotation extends Annotation
      * @return array
      * @throws UnsupportedTypeException If an unsupported parameter type has been supplied.
      */
-    protected function parser()
+    protected function parser(): array
     {
         $content = trim($this->docblock);
 
@@ -101,7 +101,9 @@ class ParamAnnotation extends Annotation
             $content = str_replace(array_keys($tokens), array_values($tokens), $content);
         }
 
-        $mson = (new MSON($this->class, $this->method))->parse($content);
+        /** @var string $method */
+        $method = $this->method;
+        $mson = (new MSON($this->class, $method))->parse($content);
         $parsed = [
             'field' => $mson->getField(),
             'sample_data' => $mson->getSampleData(),
@@ -133,7 +135,7 @@ class ParamAnnotation extends Annotation
      *
      * @return void
      */
-    protected function interpreter()
+    protected function interpreter(): void
     {
         $this->field = $this->required('field');
         $this->sample_data = $this->optional('sample_data');
@@ -150,7 +152,7 @@ class ParamAnnotation extends Annotation
      * With an array of data that was output from an Annotation, via `toArray()`, hydrate a new Annotation object.
      *
      * @param array $data
-     * @param Version|null $version
+     * @param null|Version $version
      * @return self
      */
     public static function hydrate(array $data = [], Version $version = null): self
@@ -173,7 +175,7 @@ class ParamAnnotation extends Annotation
      *
      * @return string
      */
-    public function getField()
+    public function getField(): string
     {
         return $this->field;
     }
@@ -191,7 +193,7 @@ class ParamAnnotation extends Annotation
     /**
      * Get the sample data that this parameter might accept.
      *
-     * @return string|false
+     * @return false|string
      */
     public function getSampleData()
     {
@@ -199,7 +201,7 @@ class ParamAnnotation extends Annotation
     }
 
     /**
-     * @param string|false $sample_data
+     * @param false|string $sample_data
      * @return self
      */
     public function setSampleData($sample_data): self
@@ -213,7 +215,7 @@ class ParamAnnotation extends Annotation
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -233,7 +235,7 @@ class ParamAnnotation extends Annotation
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
@@ -253,7 +255,7 @@ class ParamAnnotation extends Annotation
      *
      * @return bool
      */
-    public function isRequired()
+    public function isRequired(): bool
     {
         return $this->required;
     }
@@ -273,7 +275,7 @@ class ParamAnnotation extends Annotation
      *
      * @return bool
      */
-    public function isNullable()
+    public function isNullable(): bool
     {
         return $this->nullable;
     }

--- a/src/Parser/Annotations/ReturnAnnotation.php
+++ b/src/Parser/Annotations/ReturnAnnotation.php
@@ -18,7 +18,6 @@ class ReturnAnnotation extends Annotation
     use HasHttpCodeResponseTrait;
 
     const REQUIRES_VISIBILITY_DECORATOR = true;
-    const SUPPORTS_DEPRECATION = false;
     const SUPPORTS_VERSIONING = true;
 
     const REGEX_TYPE = '/^({[^}]*})/';
@@ -26,7 +25,7 @@ class ReturnAnnotation extends Annotation
     /**
      * Description for what this annotations' action return is.
      *
-     * @var string|null|false
+     * @var false|null|string
      */
     protected $description = null;
 
@@ -56,7 +55,7 @@ class ReturnAnnotation extends Annotation
      * @return array
      * @throws UnknownRepresentationException If a supplied representation has not been configured.
      */
-    protected function parser()
+    protected function parser(): array
     {
         $parsed = [];
         $content = trim($this->docblock);
@@ -87,7 +86,9 @@ class ReturnAnnotation extends Annotation
                 try {
                     Container::getConfig()->doesRepresentationExist($representation);
                 } catch (UnconfiguredRepresentationException $e) {
-                    throw UnknownRepresentationException::create($representation, $this->class, $this->method);
+                    /** @var string $method */
+                    $method = $this->method;
+                    throw UnknownRepresentationException::create($representation, $this->class, $method);
                 }
             } else {
                 $description = trim($representation . ' ' . $description);
@@ -109,7 +110,7 @@ class ReturnAnnotation extends Annotation
      *
      * @return void
      */
-    protected function interpreter()
+    protected function interpreter(): void
     {
         $this->http_code = $this->required('http_code');
         $this->representation = $this->optional('representation');
@@ -127,7 +128,7 @@ class ReturnAnnotation extends Annotation
      * With an array of data that was output from an Annotation, via `toArray()`, hydrate a new Annotation object.
      *
      * @param array $data
-     * @param Version|null $version
+     * @param null|Version $version
      * @return self
      */
     public static function hydrate(array $data = [], Version $version = null): self
@@ -146,10 +147,10 @@ class ReturnAnnotation extends Annotation
      * Grab the HTTP code for a given response type.
      *
      * @param string $type
-     * @return integer
+     * @return int
      * @throws UnknownReturnCodeException If an unrecognized return code is found.
      */
-    private function findReturnCodeForType($type)
+    private function findReturnCodeForType(string $type): int
     {
         switch ($type) {
             case 'collection':
@@ -174,14 +175,16 @@ class ReturnAnnotation extends Annotation
                 return 304;
 
             default:
-                throw UnknownReturnCodeException::create('return', $this->docblock, $this->class, $this->method);
+                /** @var string $method */
+                $method = $this->method;
+                throw UnknownReturnCodeException::create('return', $this->docblock, $this->class, $method);
         }
     }
 
     /**
      * Get the description for this response.
      *
-     * @return string|null|false
+     * @return false|null|string
      */
     public function getDescription()
     {
@@ -191,7 +194,7 @@ class ReturnAnnotation extends Annotation
     /**
      * Set the description for this response.
      *
-     * @param string|null|false $description
+     * @param false|null|string $description
      * @return self
      */
     public function setDescription($description): self
@@ -205,7 +208,7 @@ class ReturnAnnotation extends Annotation
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }

--- a/src/Parser/Annotations/ScopeAnnotation.php
+++ b/src/Parser/Annotations/ScopeAnnotation.php
@@ -12,10 +12,6 @@ use Mill\Parser\Version;
  */
 class ScopeAnnotation extends Annotation
 {
-    const REQUIRES_VISIBILITY_DECORATOR = false;
-    const SUPPORTS_DEPRECATION = false;
-    const SUPPORTS_VERSIONING = false;
-
     /**
      * Name of the scope type that is required for this annotations' method.
      *
@@ -26,7 +22,7 @@ class ScopeAnnotation extends Annotation
     /**
      * Description for why this scope is required.
      *
-     * @var string|null|false
+     * @var false|null|string
      */
     protected $description = null;
 
@@ -47,7 +43,7 @@ class ScopeAnnotation extends Annotation
      * @return array
      * @throws InvalidScopeSuppliedException If a supplied scope isn't present in the config file.
      */
-    protected function parser()
+    protected function parser(): array
     {
         $parts = explode(' ', $this->docblock);
 
@@ -58,7 +54,9 @@ class ScopeAnnotation extends Annotation
             // Validate the supplied scope with what has been configured as allowable.
             $scopes = Container::getConfig()->getScopes();
             if (!in_array($scope, $scopes)) {
-                throw InvalidScopeSuppliedException::create($scope, $this->class, $this->method);
+                /** @var string $method */
+                $method = $this->method;
+                throw InvalidScopeSuppliedException::create($scope, $this->class, $method);
             }
         }
 
@@ -76,7 +74,7 @@ class ScopeAnnotation extends Annotation
      *
      * @return void
      */
-    protected function interpreter()
+    protected function interpreter(): void
     {
         $this->scope = $this->required('scope');
         $this->description = $this->optional('description');
@@ -86,7 +84,7 @@ class ScopeAnnotation extends Annotation
      * With an array of data that was output from an Annotation, via `toArray()`, hydrate a new Annotation object.
      *
      * @param array $data
-     * @param Version|null $version
+     * @param null|Version  $version
      * @return self
      */
     public static function hydrate(array $data = [], Version $version = null): self
@@ -104,7 +102,7 @@ class ScopeAnnotation extends Annotation
      *
      * @return string
      */
-    public function getScope()
+    public function getScope(): string
     {
         return $this->scope;
     }
@@ -124,7 +122,7 @@ class ScopeAnnotation extends Annotation
     /**
      * Get the description for this scope.
      *
-     * @return string|null|false
+     * @return false|null|string
      */
     public function getDescription()
     {
@@ -134,7 +132,7 @@ class ScopeAnnotation extends Annotation
     /**
      * Set the description for this scope.
      *
-     * @param string|null|false $description
+     * @param false|null|string $description
      * @return self
      */
     public function setDescription($description): self

--- a/src/Parser/Annotations/Traits/HasHttpCodeResponseTrait.php
+++ b/src/Parser/Annotations/Traits/HasHttpCodeResponseTrait.php
@@ -18,15 +18,11 @@ trait HasHttpCodeResponseTrait
      * Name of the representation that this annotation responds with. Can be either a fully qualified class name, or
      * `string`.
      *
-     * @var string|false
+     * @var false|string
      */
-    protected $representation;
+    protected $representation = false;
 
-    /**
-     * Mapping array of HTTP code to the string that that code represents.
-     *
-     * @var array
-     */
+    /** @var array Mapping array of HTTP code to the string that that code represents. */
     private static $http_codes = [
         // 2xx Success
         200 => 'OK',
@@ -100,7 +96,7 @@ trait HasHttpCodeResponseTrait
      *
      * @return string
      */
-    public function getHttpCode()
+    public function getHttpCode(): string
     {
         return $this->http_code;
     }
@@ -120,10 +116,10 @@ trait HasHttpCodeResponseTrait
     /**
      * Get the HTTP message for a specific HTTP code.
      *
-     * @param string|integer $http_code
+     * @param int|string $http_code
      * @return string
      */
-    public function getHttpCodeMessage($http_code)
+    public function getHttpCodeMessage($http_code): string
     {
         return self::$http_codes[$http_code];
     }
@@ -133,7 +129,7 @@ trait HasHttpCodeResponseTrait
      *
      * @return bool
      */
-    public function isNon200HttpCode()
+    public function isNon200HttpCode(): bool
     {
         $message = explode(' ', $this->http_code);
         $code = array_shift($message);
@@ -147,7 +143,7 @@ trait HasHttpCodeResponseTrait
      * @param string $http_code
      * @return bool
      */
-    public function isValidHttpCode($http_code)
+    public function isValidHttpCode(string $http_code): bool
     {
         return isset(self::$http_codes[$http_code]);
     }
@@ -155,7 +151,7 @@ trait HasHttpCodeResponseTrait
     /**
      * Get the representation that this response returns data in.
      *
-     * @return string|false
+     * @return false|string
      */
     public function getRepresentation()
     {
@@ -165,7 +161,7 @@ trait HasHttpCodeResponseTrait
     /**
      * Set the representation that this response returns data in.
      *
-     * @param string|false $representation
+     * @param false|string $representation
      * @return self
      */
     public function setRepresentation($representation): self

--- a/src/Parser/Annotations/UriAnnotation.php
+++ b/src/Parser/Annotations/UriAnnotation.php
@@ -14,7 +14,6 @@ class UriAnnotation extends Annotation
     const REQUIRES_VISIBILITY_DECORATOR = true;
     const SUPPORTS_ALIASING = true;
     const SUPPORTS_DEPRECATION = true;
-    const SUPPORTS_VERSIONING = false;
 
     const GROUP_REGEX = '/{([\w\/\\\ ]+)}/';
 
@@ -48,7 +47,7 @@ class UriAnnotation extends Annotation
      *
      * @return array
      */
-    protected function parser()
+    protected function parser(): array
     {
         $parsed = [];
         $content = $this->docblock;
@@ -72,7 +71,7 @@ class UriAnnotation extends Annotation
      *
      * @return void
      */
-    protected function interpreter()
+    protected function interpreter(): void
     {
         $this->group = $this->required('group');
         $this->path = $this->required('path');
@@ -82,10 +81,10 @@ class UriAnnotation extends Annotation
      * With an array of data that was output from an Annotation, via `toArray()`, hydrate a new Annotation object.
      *
      * @param array $data
-     * @param Version|null $version
+     * @param null|Version $version
      * @return self
      */
-    public static function hydrate(array $data = [], Version $version = null): self
+    public static function hydrate(array $data = [], Version $version = null)
     {
         /** @var UriAnnotation $annotation */
         $annotation = parent::hydrate($data, $version);
@@ -122,7 +121,7 @@ class UriAnnotation extends Annotation
      *
      * @return string
      */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
@@ -144,7 +143,7 @@ class UriAnnotation extends Annotation
      *
      * @return string
      */
-    public function getCleanPath()
+    public function getCleanPath(): string
     {
         $path = preg_replace('/[@#+*!~]((\w|_)+)(\/|$)/', '{$1}$3', $this->getPath());
 

--- a/src/Parser/Annotations/UriSegmentAnnotation.php
+++ b/src/Parser/Annotations/UriSegmentAnnotation.php
@@ -11,10 +11,7 @@ use Mill\Parser\Version;
  */
 class UriSegmentAnnotation extends Annotation
 {
-    const REQUIRES_VISIBILITY_DECORATOR = false;
-    const SUPPORTS_DEPRECATION = false;
     const SUPPORTS_MSON = true;
-    const SUPPORTS_VERSIONING = false;
 
     const REGEX_URI = '/^({[^}]*})/';
 
@@ -49,7 +46,7 @@ class UriSegmentAnnotation extends Annotation
     /**
      * Array of acceptable values for this parameter.
      *
-     * @var array|null|false
+     * @var array|false|null
      */
     protected $values = [];
 
@@ -72,7 +69,7 @@ class UriSegmentAnnotation extends Annotation
      *
      * @return array
      */
-    protected function parser()
+    protected function parser(): array
     {
         $parsed = [];
         $content = trim($this->docblock);
@@ -83,7 +80,9 @@ class UriSegmentAnnotation extends Annotation
             $content = trim(preg_replace(self::REGEX_URI, '', $content));
         }
 
-        $mson = (new MSON($this->class, $this->method))->parse($content);
+        /** @var string $method */
+        $method = $this->method;
+        $mson = (new MSON($this->class, $method))->parse($content);
         $parsed = array_merge($parsed, [
             'field' => $mson->getField(),
             'type' => $mson->getType(),
@@ -102,7 +101,7 @@ class UriSegmentAnnotation extends Annotation
      *
      * @return void
      */
-    protected function interpreter()
+    protected function interpreter(): void
     {
         $this->uri = $this->required('uri', false);
 
@@ -117,10 +116,10 @@ class UriSegmentAnnotation extends Annotation
      * With an array of data that was output from an Annotation, via `toArray()`, hydrate a new Annotation object.
      *
      * @param array $data
-     * @param Version|null $version
-     * @return self
+     * @param null|Version $version
+     * @return UriSegmentAnnotation
      */
-    public static function hydrate(array $data = [], Version $version = null): self
+    public static function hydrate(array $data = [], Version $version = null)
     {
         /** @var UriSegmentAnnotation $annotation */
         $annotation = parent::hydrate($data, $version);
@@ -138,7 +137,7 @@ class UriSegmentAnnotation extends Annotation
      *
      * @return string
      */
-    public function getUri()
+    public function getUri(): string
     {
         return $this->uri;
     }
@@ -160,7 +159,7 @@ class UriSegmentAnnotation extends Annotation
      *
      * @return string
      */
-    public function getField()
+    public function getField(): string
     {
         return $this->field;
     }
@@ -182,7 +181,7 @@ class UriSegmentAnnotation extends Annotation
      *
      * @return string
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -204,7 +203,7 @@ class UriSegmentAnnotation extends Annotation
      *
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
@@ -224,7 +223,7 @@ class UriSegmentAnnotation extends Annotation
     /**
      * Get the enumerated values that are allowed on this URI segment.
      *
-     * @return array|null|false
+     * @return array|false|null
      */
     public function getValues()
     {
@@ -234,7 +233,7 @@ class UriSegmentAnnotation extends Annotation
     /**
      * Set the enumerated values that are allowed on this URI segment.
      *
-     * @param array|null|false $values
+     * @param array|false|null $values
      * @return self
      */
     public function setValues($values): self

--- a/src/Parser/MSON.php
+++ b/src/Parser/MSON.php
@@ -53,35 +53,35 @@ class MSON
     /**
      * Controller method that MSON is being parsed from.
      *
-     * @var mixed
+     * @var string
      */
     protected $method;
 
     /**
      * Name of the field that was parsed out of the MSON content.
      *
-     * @var string
+     * @var null|string
      */
-    protected $field;
+    protected $field = null;
 
     /**
      * Sample data that was parsed out of the MSON content.
      *
-     * @var string|false
+     * @var false|string
      */
     protected $sample_data = false;
 
     /**
      * Type of field that this MSON content represents.
      *
-     * @var string
+     * @var null|string
      */
-    protected $type;
+    protected $type = null;
 
     /**
      * Subtype of the type of field that this MSON content represents.
      *
-     * @var string|false
+     * @var false|string
      */
     protected $subtype = false;
 
@@ -102,16 +102,16 @@ class MSON
     /**
      * Application-specific capability that was parsed out of the MSON content.
      *
-     * @var string|false
+     * @var false|string
      */
     protected $capability = false;
 
     /**
      * Parsed description from the MSON content.
      *
-     * @var string
+     * @var null|string
      */
-    protected $description;
+    protected $description = null;
 
     /**
      * Array of enumerated values from the MSON content.
@@ -144,7 +144,7 @@ class MSON
      * @param string $class
      * @param string $method
      */
-    public function __construct($class, $method)
+    public function __construct(string $class, string $method)
     {
         $this->class = $class;
         $this->method = $method;
@@ -154,11 +154,11 @@ class MSON
      * Given a piece of Mill-flavored MSON content, parse it out.
      *
      * @param string $content
-     * @return MSON
+     * @return self
      * @throws UnsupportedTypeException If an unsupported MSON field type has been supplied.
      * @throws MissingOptionsException If a supplied MSON type of `enum` missing corresponding acceptable values.
      */
-    public function parse($content)
+    public function parse(string $content): self
     {
         /**
          * This is the regex to match a Mill-flavored MSON string.
@@ -264,7 +264,7 @@ class MSON
      * @param array $descriptions
      * @return array<string, string>
      */
-    protected function parseValues($values, $descriptions)
+    protected function parseValues(array $values, array $descriptions): array
     {
         $enum = [];
         foreach ($values as $k => $value) {
@@ -283,9 +283,9 @@ class MSON
     /**
      * Name of the field that was parsed out of the MSON content.
      *
-     * @return false|string
+     * @return null|string
      */
-    public function getField()
+    public function getField(): ?string
     {
         return $this->field;
     }
@@ -303,9 +303,9 @@ class MSON
     /**
      * Type of field that this MSON content represents.
      *
-     * @return string
+     * @return null|string
      */
-    public function getType()
+    public function getType(): ?string
     {
         return $this->type;
     }
@@ -325,7 +325,7 @@ class MSON
      *
      * @return bool
      */
-    public function isRequired()
+    public function isRequired(): bool
     {
         return $this->is_required;
     }
@@ -335,7 +335,7 @@ class MSON
      *
      * @return bool
      */
-    public function isNullable()
+    public function isNullable(): bool
     {
         return $this->is_nullable;
     }
@@ -343,7 +343,7 @@ class MSON
     /**
      * Application-specific capability that was parsed out of the MSON content.
      *
-     * @return string|false
+     * @return false|string
      */
     public function getCapability()
     {
@@ -353,9 +353,9 @@ class MSON
     /**
      * Parsed description from the MSON content.
      *
-     * @return false|string
+     * @return null|string
      */
-    public function getDescription()
+    public function getDescription(): ?string
     {
         return $this->description;
     }
@@ -365,7 +365,7 @@ class MSON
      *
      * @return array<string, string>
      */
-    public function getValues()
+    public function getValues(): array
     {
         return $this->values;
     }
@@ -375,7 +375,7 @@ class MSON
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'capability' => $this->getCapability(),

--- a/src/Parser/Representation/Documentation.php
+++ b/src/Parser/Representation/Documentation.php
@@ -16,6 +16,8 @@ class Documentation
     /**
      * When building out dot-notation annotation keys for generating API Blueprint files (or any other generator),
      * we use this key to designate the content of an annotations' data.
+     *
+     * @var string
      */
     const DOT_NOTATION_ANNOTATION_DATA_KEY = '__FIELD_DATA__';
 
@@ -43,7 +45,7 @@ class Documentation
     /**
      * Fuller description of what this representation handles. This should normally consist of Markdown.
      *
-     * @var string|null
+     * @var null|string
      */
     protected $description = null;
 
@@ -58,7 +60,7 @@ class Documentation
      * @param string $class
      * @param string $method
      */
-    public function __construct($class, $method)
+    public function __construct(string $class, string $method)
     {
         $this->class = $class;
         $this->method = $method;
@@ -67,15 +69,15 @@ class Documentation
     /**
      * Parse the instance controller and method into actionable annotations and documentation.
      *
-     * @return Documentation
+     * @return self
      * @throws NoAnnotationsException If no annotations were found on the class.
      * @throws NoAnnotationsException If no annotations were found on the method.
      * @throws RequiredAnnotationException If a required `@api-label` annotation is missing.
      * @throws MultipleAnnotationsException If multiple `@api-label` annotations were found.
      */
-    public function parse()
+    public function parse(): self
     {
-        $annotations = (new Parser($this->class))->getAnnotations();
+        $annotations = (new Parser($this->class))->setMethod($this->method)->getAnnotations();
 
         $this->representation = (new RepresentationParser($this->class))->getAnnotations($this->method);
 
@@ -112,7 +114,7 @@ class Documentation
      * @param string $version
      * @return array
      */
-    public function filterRepresentationForVersion($version)
+    public function filterRepresentationForVersion(string $version): array
     {
         /** @var Parser\Annotation $annotation */
         foreach ($this->representation as $name => $annotation) {
@@ -134,7 +136,7 @@ class Documentation
      *
      * @return string
      */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }
@@ -144,7 +146,7 @@ class Documentation
      *
      * @return string
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->method;
     }
@@ -154,7 +156,7 @@ class Documentation
      *
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return $this->label;
     }
@@ -164,7 +166,7 @@ class Documentation
      *
      * @return array
      */
-    public function getRawContent()
+    public function getRawContent(): array
     {
         return $this->representation;
     }
@@ -174,7 +176,7 @@ class Documentation
      *
      * @return array
      */
-    public function getContent()
+    public function getContent(): array
     {
         return $this->toArray()['content'];
     }
@@ -184,7 +186,7 @@ class Documentation
      *
      * @return array
      */
-    public function getExplodedContentDotNotation()
+    public function getExplodedContentDotNotation(): array
     {
         $content = new Data;
 
@@ -203,7 +205,7 @@ class Documentation
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $data = [
             'label' => $this->label,

--- a/src/Parser/Representation/RepresentationParser.php
+++ b/src/Parser/Representation/RepresentationParser.php
@@ -24,36 +24,20 @@ class RepresentationParser extends Parser
     const DOC_BODY_MATCH = '~\s*\*\s+(.*)~';
 
     /**
-     * Representation class that we want to parse.
-     *
-     * @var string
-     */
-    protected $class;
-
-    /**
-     * @param string $class
-     */
-    public function __construct($class)
-    {
-        $this->class = $class;
-
-        parent::__construct($class);
-    }
-
-    /**
      * Locate, and parse, the annotations for a representation method.
      *
-     * @param string|null $method_name
+     * @param null|string $method_name
      * @return array An array containing all the found annotations.
      * @throws MethodNotSuppliedException If a method is not supplied to parse.
      * @throws MethodNotImplementedException If the supplied method does not exist on the supplied controller.
      */
-    public function getAnnotations($method_name = null)
+    public function getAnnotations(string $method_name = null): array
     {
         if (empty($method_name)) {
             throw MethodNotSuppliedException::create($this->class);
         }
 
+        /** @var string method */
         $this->method = $method_name;
 
         $reader = Container::getRepresentationAnnotationReader();
@@ -86,7 +70,7 @@ class RepresentationParser extends Parser
      * @param string $original_content
      * @return array
      */
-    public function parseAnnotations(array $tags, $original_content)
+    public function parseAnnotations(array $tags, string $original_content): array
     {
         $scopes = [];
         $see_pointers = [];
@@ -95,6 +79,9 @@ class RepresentationParser extends Parser
 
         /** @var Version|null $version */
         $version = null;
+
+        /** @var string $method */
+        $method = $this->method;
 
         // Does this have any `@api-see` pointers or a `@api-version` declaration?
         /** @var UnknownTag $tag */
@@ -109,7 +96,7 @@ class RepresentationParser extends Parser
                     break;
 
                 case 'scope':
-                    $scopes[] = (new ScopeAnnotation($content, $this->class, $this->method))->process();
+                    $scopes[] = (new ScopeAnnotation($content, $this->class, $method))->process();
                     break;
 
                 case 'see':
@@ -117,13 +104,14 @@ class RepresentationParser extends Parser
                     break;
 
                 case 'version':
-                    $version = new Version($content, $this->class, $this->method);
+                    $version = new Version($content, $this->class, $method);
                     break;
             }
         }
 
         foreach ($data as $content) {
-            $annotation = (new DataAnnotation($content, $this->class, $this->method, $version))->process();
+            $annotation = new DataAnnotation($content, $this->class, $method, $version);
+            $annotation->process();
             if (!empty($scopes)) {
                 $annotation->setScopes($scopes);
             }
@@ -164,7 +152,7 @@ class RepresentationParser extends Parser
                             $annotation_version->getConstraint()
                         ]);
 
-                        $updated_version = new Version($new_constraint, $this->class, $this->method);
+                        $updated_version = new Version($new_constraint, $this->class, $method);
                         $annotation->setVersion($updated_version);
                     } else {
                         $annotation->setVersion($version);
@@ -191,7 +179,7 @@ class RepresentationParser extends Parser
      * @return array
      * @throws DuplicateFieldException If a found field exists more than once.
      */
-    public function parse($code)
+    public function parse(string $code): array
     {
         $representation = [];
 
@@ -204,7 +192,9 @@ class RepresentationParser extends Parser
 
                 foreach ($annotations as $field_name => $annotation) {
                     if (isset($representation[$field_name])) {
-                        throw DuplicateFieldException::create($field_name, $this->class, $this->method);
+                        /** @var string $method */
+                        $method = $this->method;
+                        throw DuplicateFieldException::create($field_name, $this->class, $method);
                     }
 
                     $representation[$field_name] = $annotations[$field_name];
@@ -221,9 +211,8 @@ class RepresentationParser extends Parser
      *
      * @param DataAnnotation $parent
      * @param array $annotations
-     * @return void
      */
-    private function carryAnnotationSettingsToChildren(DataAnnotation $parent, array &$annotations = [])
+    private function carryAnnotationSettingsToChildren(DataAnnotation $parent, array &$annotations = []): void
     {
         $parent_identifier = $parent->getIdentifier();
         $parent_version = $parent->getVersion();

--- a/src/Parser/Resource/Action/Documentation.php
+++ b/src/Parser/Resource/Action/Documentation.php
@@ -41,7 +41,7 @@ class Documentation
     /**
      * Fuller description of the action. This should normally consist of Markdown.
      *
-     * @var string|null
+     * @var null|string
      */
     protected $description = null;
 
@@ -88,7 +88,7 @@ class Documentation
      * @param string $class
      * @param string $method
      */
-    public function __construct($class, $method)
+    public function __construct(string $class, string $method)
     {
         $this->class = $class;
         $this->method = $method;
@@ -246,7 +246,7 @@ class Documentation
      *
      * @return string
      */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }
@@ -256,7 +256,7 @@ class Documentation
      *
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return $this->label;
     }
@@ -266,7 +266,7 @@ class Documentation
      *
      * @return string
      */
-    public function getMethod()
+    public function getMethod(): string
     {
         return $this->method;
     }
@@ -276,7 +276,7 @@ class Documentation
      *
      * @return array
      */
-    public function getAnnotations()
+    public function getAnnotations(): array
     {
         return $this->annotations;
     }
@@ -286,7 +286,7 @@ class Documentation
      *
      * @return array
      */
-    public function getContentTypes()
+    public function getContentTypes(): array
     {
         return $this->content_types;
     }
@@ -304,10 +304,10 @@ class Documentation
     /**
      * Get the HTTP Content-Type that this action returns content in.
      *
-     * @param Version|string|null $version
+     * @param null|string|Version $version
      * @return string
      */
-    public function getContentType($version = null)
+    public function getContentType($version = null): string
     {
         if ($version instanceof Version) {
             $version = $version->getConstraint();
@@ -344,7 +344,7 @@ class Documentation
      *
      * @return array
      */
-    public function getUris()
+    public function getUris(): array
     {
         return $this->annotations['uri'];
     }
@@ -354,7 +354,7 @@ class Documentation
      *
      * @return UriAnnotation
      */
-    public function getUri()
+    public function getUri(): UriAnnotation
     {
         $uris = $this->getUris();
         return array_shift($uris);
@@ -367,10 +367,9 @@ class Documentation
      * and `Users\Videos` groups, we don't want the action in the `Me\Videos` group to have actions with
      * `Users\Videos` URIs.
      *
-     * @param \Mill\Parser\Annotations\UriAnnotation $uri
-     * @return void
+     * @param UriAnnotation $uri
      */
-    public function setUri(UriAnnotation $uri)
+    public function setUri(UriAnnotation $uri): void
     {
         $this->annotations['uri'] = [$uri];
     }
@@ -380,7 +379,7 @@ class Documentation
      *
      * @return array
      */
-    public function getUriSegments()
+    public function getUriSegments(): array
     {
         return (isset($this->annotations['uriSegment'])) ? $this->annotations['uriSegment'] : [];
     }
@@ -393,9 +392,8 @@ class Documentation
      * compiled `/me/videos` action.
      *
      * @param array $segments
-     * @return void
      */
-    public function setUriSegments(array $segments = [])
+    public function setUriSegments(array $segments = []): void
     {
         $this->annotations['uriSegment'] = $segments;
     }
@@ -405,7 +403,7 @@ class Documentation
      *
      * @return array
      */
-    public function getCapabilities()
+    public function getCapabilities(): array
     {
         return (isset($this->annotations['capability'])) ? $this->annotations['capability'] : [];
     }
@@ -415,7 +413,7 @@ class Documentation
      *
      * @return array
      */
-    public function getScopes()
+    public function getScopes(): array
     {
         return (isset($this->annotations['scope'])) ? $this->annotations['scope'] : [];
     }
@@ -425,7 +423,7 @@ class Documentation
      *
      * @return array
      */
-    public function getParameters()
+    public function getParameters(): array
     {
         return (isset($this->annotations['param'])) ? $this->annotations['param'] : [];
     }
@@ -436,7 +434,7 @@ class Documentation
      *
      * @return array
      */
-    public function getResponses()
+    public function getResponses(): array
     {
         $return = (isset($this->annotations['return'])) ? $this->annotations['return'] : [];
         $throws = (isset($this->annotations['throws'])) ? $this->annotations['throws'] : [];
@@ -447,9 +445,10 @@ class Documentation
     /**
      * Get the (absolute) minimum version that this action is supported on.
      *
-     * @return Parser\Annotations\MinVersionAnnotation|null
+    /**
+     * @return null|Parser\Annotations\MinVersionAnnotation
      */
-    public function getMinimumVersion()
+    public function getMinimumVersion(): ?Parser\Annotations\MinVersionAnnotation
     {
         return (isset($this->annotations['minVersion'])) ? $this->annotations['minVersion'][0] : null;
     }
@@ -460,7 +459,7 @@ class Documentation
      * @param string $version
      * @return array
      */
-    public function filterAnnotationsForVersion($version)
+    public function filterAnnotationsForVersion(string $version): array
     {
         foreach ($this->annotations as $name => $data) {
             /** @var Parser\Annotation $annotation */
@@ -483,11 +482,11 @@ class Documentation
      * Filter down, and return, all annotations on this action that match a specific visibility. This can either be
      * public, public+private, or capability-locked.
      *
-     * @param boolean $allow_private
-     * @param null|array $only_capabilities
+     * @param bool $allow_private
+     * @param array|null $only_capabilities
      * @return array
      */
-    public function filterAnnotationsForVisibility($allow_private, $only_capabilities)
+    public function filterAnnotationsForVisibility(bool $allow_private, ?array $only_capabilities): array
     {
         if ($allow_private && empty($only_capabilities)) {
             return $this->annotations;
@@ -609,7 +608,7 @@ class Documentation
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $data = [
             'class' => $this->class,

--- a/src/Parser/Resource/Documentation.php
+++ b/src/Parser/Resource/Documentation.php
@@ -36,7 +36,7 @@ class Documentation
     /**
      * Fuller description of what this resource handles. This should normally consist of Markdown.
      *
-     * @var string|null
+     * @var null|string
      */
     protected $description = null;
 
@@ -50,7 +50,7 @@ class Documentation
     /**
      * @param string $class
      */
-    public function __construct($class)
+    public function __construct(string $class)
     {
         $this->class = $class;
         $this->parser = new Parser($this->class);
@@ -59,11 +59,11 @@ class Documentation
     /**
      * Parse the instance class into actionable annotations and documentation.
      *
-     * @return Documentation
+     * @return self
      * @throws RequiredAnnotationException If a required `@api-label` annotation is missing.
      * @throws MultipleAnnotationsException If multiple `@api-label` annotations were found.
      */
-    public function parse()
+    public function parse(): self
     {
         $annotations = $this->parser->getAnnotations();
 
@@ -91,9 +91,9 @@ class Documentation
      *
      * Example: `$documentation = (new Documentation($class))->parseMethods()->toArray();`
      *
-     * @return Documentation
+     * @return self
      */
-    public function parseMethods()
+    public function parseMethods(): self
     {
         $this->getMethods();
         return $this;
@@ -104,7 +104,7 @@ class Documentation
      *
      * @return array
      */
-    public function getMethods()
+    public function getMethods(): array
     {
         if (!empty($this->methods)) {
             return $this->methods;
@@ -123,7 +123,7 @@ class Documentation
      *
      * @return string
      */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }
@@ -135,7 +135,7 @@ class Documentation
      * @return Action\Documentation
      * @throws MethodNotImplementedException If the instance class does not implement the supplied method.
      */
-    public function getMethod($method)
+    public function getMethod(string $method): Action\Documentation
     {
         if (empty($this->methods)) {
             $this->getMethods();
@@ -153,7 +153,7 @@ class Documentation
      *
      * @return array
      */
-    public function toArray()
+    public function toArray(): array
     {
         $data = [
             'class' => $this->class,

--- a/src/Parser/Version.php
+++ b/src/Parser/Version.php
@@ -40,7 +40,7 @@ class Version
      * @param string $method
      * @throws UnrecognizedSchemaException If an `@api-version` annotation was found with an unrecognized schema.
      */
-    public function __construct($constraint, $class, $method)
+    public function __construct(string $constraint, string $class, string $method)
     {
         $this->class = $class;
         $this->method = $method;
@@ -59,7 +59,7 @@ class Version
      * @param string $version
      * @return bool
      */
-    public function matches($version)
+    public function matches(string $version): bool
     {
         return Semver::satisfies($version, $this->getConstraint());
     }
@@ -67,7 +67,7 @@ class Version
     /**
      * @return string
      */
-    public function getConstraint()
+    public function getConstraint(): string
     {
         return $this->constraint->getPrettyString();
     }
@@ -77,7 +77,7 @@ class Version
      *
      * @return bool
      */
-    public function isRange()
+    public function isRange(): bool
     {
         return $this->constraint instanceof MultiConstraint;
     }

--- a/src/Provider/Config.php
+++ b/src/Provider/Config.php
@@ -13,7 +13,7 @@ class Config implements \Pimple\ServiceProviderInterface
      */
     public function register(Container $container)
     {
-        $container['config'] = function (Container $c) {
+        $container['config'] = function (Container $c): \Mill\Config {
             return \Mill\Config::loadFromXML(
                 $c['filesystem'],
                 $c['config.path'],

--- a/src/Provider/Filesystem.php
+++ b/src/Provider/Filesystem.php
@@ -14,7 +14,7 @@ class Filesystem implements \Pimple\ServiceProviderInterface
      */
     public function register(Container $container)
     {
-        $container['filesystem'] = function (Container $c) {
+        $container['filesystem'] = function (Container $c): \League\Flysystem\Filesystem {
             $adapter = new Local('/');
 
             return new \League\Flysystem\Filesystem($adapter);

--- a/src/Provider/Reader.php
+++ b/src/Provider/Reader.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mill\Provider;
 
+use Closure;
 use Pimple\Container;
 
 class Reader implements \Pimple\ServiceProviderInterface
@@ -8,19 +9,20 @@ class Reader implements \Pimple\ServiceProviderInterface
     /**
      * Registers services on the given container.
      *
+     * @psalm-suppress MissingClosureReturnType Psalm has trouble with closures returning anonymous functions.
      * @param Container $container A Pimple container instance
      * @return void
      */
     public function register(Container $container)
     {
-        $container['reader.annotations'] = function (Container $c) {
-            return function ($class, $method = null) {
+        $container['reader.annotations'] = function (Container $c): Closure {
+            return function (string $class, string $method = null) {
                 return (new \Mill\Reader)->getAnnotations($class, $method);
             };
         };
 
-        $container['reader.annotations.representation'] = function (Container $c) {
-            return function ($class, $method) {
+        $container['reader.annotations.representation'] = function (Container $c): Closure {
+            return function (string $class, string $method): string {
                 return (new \Mill\Reader)->getRepresentationAnnotations($class, $method);
             };
         };

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -14,11 +14,11 @@ class Reader
      * Load, and pull, the annotations for a class or class method.
      *
      * @param string $class
-     * @param string|null $method
-     * @return string|false The found annotation docblock.
+     * @param null|string $method
+     * @return false|string
      * @throws MethodNotImplementedException If the supplied method does not exist on the supplied class.
      */
-    public function getAnnotations($class, $method = null)
+    public function getAnnotations(string $class, string $method = null)
     {
         $reflection = new ReflectionClass($class);
 
@@ -45,7 +45,7 @@ class Reader
      * @return string
      * @throws MethodNotImplementedException If the supplied method does not exist on the supplied class.
      */
-    public function getRepresentationAnnotations($class, $method)
+    public function getRepresentationAnnotations(string $class, string $method): string
     {
         $reflection = new ReflectionClass($class);
         if (!$reflection->hasMethod($method)) {

--- a/tests/Command/ChangelogTest.php
+++ b/tests/Command/ChangelogTest.php
@@ -7,22 +7,16 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class ChangelogTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var \Symfony\Component\Console\Command\Command
-     */
+    /** @var \Symfony\Component\Console\Command\Command */
     protected $command;
 
-    /**
-     * @var CommandTester
-     */
+    /** @var CommandTester */
     protected $tester;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $config_file;
 
-    public function setUp()
+    public function setUp(): void
     {
         $application = new Application();
         $application->add(new Changelog);
@@ -35,12 +29,11 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider providerTestChangelog
-     * @param boolean $private_objects
+     * @param bool $private_objects
      * @param array $capabilities
      * @param string $expected_file
-     * @return void
      */
-    public function testChangelog($private_objects, $capabilities, $expected_file)
+    public function testChangelog(bool $private_objects, array $capabilities, string $expected_file): void
     {
         /** @var string $output_dir */
         $output_dir = tempnam(sys_get_temp_dir(), 'mill-generate-test-');
@@ -78,7 +71,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The supplied Mill configuration file does not exist.
      */
-    public function testGenerateFailsOnInvalidConfigFile()
+    public function testGenerateFailsOnInvalidConfigFile(): void
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -86,10 +79,7 @@ class ChangelogTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    /**
-     * @return array
-     */
-    public function providerTestChangelog()
+    public function providerTestChangelog(): array
     {
         return [
             // Complete changelog. All documentation parsed.

--- a/tests/Command/ErrorMapTest.php
+++ b/tests/Command/ErrorMapTest.php
@@ -7,22 +7,16 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class ErrorMapTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var \Symfony\Component\Console\Command\Command
-     */
+    /** @var \Symfony\Component\Console\Command\Command */
     protected $command;
 
-    /**
-     * @var CommandTester
-     */
+    /** @var CommandTester */
     protected $tester;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $config_file;
 
-    public function setUp()
+    public function setUp(): void
     {
         $application = new Application();
         $application->add(new ErrorMap);
@@ -35,12 +29,11 @@ class ErrorMapTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider providerTestErrorMap
-     * @param boolean $private_objects
+     * @param bool $private_objects
      * @param array $capabilities
      * @param string $expected_file
-     * @return void
      */
-    public function testErrorMap($private_objects, $capabilities, $expected_file)
+    public function testErrorMap(bool $private_objects, array $capabilities, string $expected_file): void
     {
         /** @var string $output_dir */
         $output_dir = tempnam(sys_get_temp_dir(), 'mill-generate-test-');
@@ -89,7 +82,7 @@ class ErrorMapTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function testGenerateWithDryRun()
+    public function testGenerateWithDryRun(): void
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -105,7 +98,7 @@ class ErrorMapTest extends \PHPUnit\Framework\TestCase
         $this->assertNotContains('API version: 1.1.2', $output);
     }
 
-    public function testGenerateWithDefaultVersion()
+    public function testGenerateWithDefaultVersion(): void
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -123,7 +116,7 @@ class ErrorMapTest extends \PHPUnit\Framework\TestCase
         $this->assertNotContains('API version', $output);
     }
 
-    public function testGenerateWithSpecificConstraint()
+    public function testGenerateWithSpecificConstraint(): void
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -143,7 +136,7 @@ class ErrorMapTest extends \PHPUnit\Framework\TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The supplied Mill configuration file does not exist.
      */
-    public function testGenerateFailsOnInvalidConfigFile()
+    public function testGenerateFailsOnInvalidConfigFile(): void
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -151,7 +144,7 @@ class ErrorMapTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function testGenerateFailsOnInvalidVersionConstraint()
+    public function testGenerateFailsOnInvalidVersionConstraint(): void
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -166,10 +159,7 @@ class ErrorMapTest extends \PHPUnit\Framework\TestCase
         $this->assertContains('unrecognized schema', $output);
     }
 
-    /**
-     * @return array
-     */
-    public function providerTestErrorMap()
+    public function providerTestErrorMap(): array
     {
         return [
             // Complete error map. All documentation parsed.

--- a/tests/Command/GenerateTest.php
+++ b/tests/Command/GenerateTest.php
@@ -7,22 +7,16 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class GenerateTest extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var \Symfony\Component\Console\Command\Command
-     */
+    /** @var \Symfony\Component\Console\Command\Command */
     protected $command;
 
-    /**
-     * @var CommandTester
-     */
+    /** @var CommandTester */
     protected $tester;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $config_file;
 
-    public function setUp()
+    public function setUp(): void
     {
         $application = new Application();
         $application->add(new Generate);
@@ -33,7 +27,7 @@ class GenerateTest extends \PHPUnit\Framework\TestCase
         $this->config_file = __DIR__ . '/../../resources/examples/mill.xml';
     }
 
-    public function testGenerate()
+    public function testGenerate(): void
     {
         /** @var string $output_dir */
         $output_dir = tempnam(sys_get_temp_dir(), 'mill-generate-test-');
@@ -99,7 +93,7 @@ class GenerateTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function testGenerateWithDryRun()
+    public function testGenerateWithDryRun(): void
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -114,7 +108,7 @@ class GenerateTest extends \PHPUnit\Framework\TestCase
         $this->assertContains('API version: 1.1', $output);
     }
 
-    public function testGenerateWithDefaultVersion()
+    public function testGenerateWithDefaultVersion(): void
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -130,7 +124,7 @@ class GenerateTest extends \PHPUnit\Framework\TestCase
         $this->assertContains('API version: 1.1', $output);
     }
 
-    public function testGenerateWithSpecificConstraint()
+    public function testGenerateWithSpecificConstraint(): void
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -150,7 +144,7 @@ class GenerateTest extends \PHPUnit\Framework\TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage The supplied Mill configuration file does not exist.
      */
-    public function testGenerateFailsOnInvalidConfigFile()
+    public function testGenerateFailsOnInvalidConfigFile(): void
     {
         $this->tester->execute([
             'command' => $this->command->getName(),
@@ -158,7 +152,7 @@ class GenerateTest extends \PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function testGenerateFailsOnInvalidVersionConstraint()
+    public function testGenerateFailsOnInvalidVersionConstraint(): void
     {
         $this->tester->execute([
             'command' => $this->command->getName(),

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -5,7 +5,7 @@ use Mill\Config;
 
 class ConfigTest extends TestCase
 {
-    public function testLoadFromXML()
+    public function testLoadFromXML(): void
     {
         $config = $this->getConfig();
 
@@ -120,7 +120,7 @@ class ConfigTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessageRegExp /does not exist/
      */
-    public function testLoadFromXMLFailsIfConfigFileDoesNotExist()
+    public function testLoadFromXMLFailsIfConfigFileDoesNotExist(): void
     {
         $filesystem = $this->getContainer()->getFilesystem();
         Config::loadFromXML($filesystem, 'non-existent.xml');
@@ -130,7 +130,7 @@ class ConfigTest extends TestCase
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessageRegExp /is invalid/
      */
-    public function testLoadFromXMLFailsIfConfigFileIsInvalid()
+    public function testLoadFromXMLFailsIfConfigFileIsInvalid(): void
     {
         $filesystem = $this->getContainer()->getFilesystem();
         $filesystem->write('empty.xml', '');
@@ -141,7 +141,7 @@ class ConfigTest extends TestCase
     /**
      * @expectedException \Mill\Exceptions\Config\ValidationException
      */
-    public function testXSDValidation()
+    public function testXSDValidation(): void
     {
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -166,10 +166,12 @@ XML;
      * @param array $exception_details
      * @param string $xml
      * @throws \Exception
-     * @return void
      */
-    public function testLoadFromXMLFailuresOnVariousBadXMLFiles(array $includes, array $exception_details, $xml)
-    {
+    public function testLoadFromXMLFailuresOnVariousBadXMLFiles(
+        array $includes,
+        array $exception_details,
+        string $xml
+    ): void {
         if (isset($exception_details['exception'])) {
             $this->expectException($exception_details['exception']);
         } else {
@@ -219,7 +221,7 @@ XML;
 XML;
 
         $filesystem = $this->getContainer()->getFilesystem();
-        $filesystem->write('mill.bad.xml', $xml);
+        $filesystem->put('mill.bad.xml', $xml);
 
         try {
             Config::loadFromXML($filesystem, 'mill.bad.xml');
@@ -232,7 +234,7 @@ XML;
     /**
      * @expectedException \Mill\Exceptions\Config\UnconfiguredRepresentationException
      */
-    public function testDoesRepresentationExistFailsIfRepresentationIsNotConfigured()
+    public function testDoesRepresentationExistFailsIfRepresentationIsNotConfigured(): void
     {
         $this->getConfig()->doesRepresentationExist('UnconfiguredClass');
     }
@@ -240,7 +242,7 @@ XML;
     /**
      * @return array
      */
-    public function providerLoadFromXMLFailuresOnVariousBadXMLFiles()
+    public function providerLoadFromXMLFailuresOnVariousBadXMLFiles(): array
     {
         return [
             /**

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -5,7 +5,7 @@ use Mill\Container;
 
 class ContainerTest extends TestCase
 {
-    public function testContainer()
+    public function testContainer(): void
     {
         $container = $this->getContainer();
 
@@ -19,7 +19,7 @@ class ContainerTest extends TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testContainerFailsIfNoConfigPathWasSupplied()
+    public function testContainerFailsIfNoConfigPathWasSupplied(): void
     {
         new Container;
     }

--- a/tests/Generator/BlueprintTest.php
+++ b/tests/Generator/BlueprintTest.php
@@ -8,7 +8,7 @@ class BlueprintTest extends TestCase
 {
     const DS = DIRECTORY_SEPARATOR;
 
-    public function testGeneration()
+    public function testGeneration(): void
     {
         $dir = static::$resourcesDir . 'examples/Showtimes/blueprints/';
 
@@ -48,7 +48,7 @@ class BlueprintTest extends TestCase
         }
     }
 
-    public function testGenerationWithAnExcludedGroup()
+    public function testGenerationWithAnExcludedGroup(): void
     {
         $this->getConfig()->addBlueprintGroupExclude('Movies');
 

--- a/tests/Generator/Changelog/Formats/JsonTest.php
+++ b/tests/Generator/Changelog/Formats/JsonTest.php
@@ -7,11 +7,12 @@ use Mill\Tests\TestCase;
 
 class JsonTest extends TestCase
 {
-    public function testGenerate()
+    public function testGenerate(): void
     {
         $generator = new Json($this->getConfig());
         $generator->setChangelog((new Changelog($this->getConfig()))->generate());
         $generated = $generator->generate();
+        $generated = array_shift($generated);
         $generated = json_decode($generated, true);
 
         $this->assertSame([
@@ -396,22 +397,19 @@ class JsonTest extends TestCase
      * @dataProvider providerTestGenerateCases
      * @param array $changelog
      * @param array $expected
-     * @return void
      */
-    public function testGenerateCases(array $changelog, array $expected)
+    public function testGenerateCases(array $changelog, array $expected): void
     {
         $generator = new Json($this->getConfig());
         $generator->setChangelog($changelog);
         $generated = $generator->generate();
+        $generated = array_shift($generated);
         $generated = json_decode($generated, true);
 
         $this->assertSame($expected, $generated);
     }
 
-    /**
-     * @return array
-     */
-    public function providerTestGenerateCases()
+    public function providerTestGenerateCases(): array
     {
         return [
             'added-multiple-action-returns' => [

--- a/tests/Generator/ChangelogTest.php
+++ b/tests/Generator/ChangelogTest.php
@@ -8,12 +8,11 @@ class ChangelogTest extends TestCase
 {
     /**
      * @dataProvider providerTestGeneration
-     * @param boolean $private_objects
-     * @param array $capabilities
+     * @param bool $private_objects
+     * @param array|null $capabilities
      * @param array $expected
-     * @return void
      */
-    public function testGeneration($private_objects, $capabilities, $expected)
+    public function testGeneration(bool $private_objects, ?array $capabilities, array $expected): void
     {
         $generator = new Changelog($this->getConfig());
         $generator->setLoadPrivateDocs($private_objects);
@@ -39,7 +38,7 @@ class ChangelogTest extends TestCase
         }
     }
 
-    public function testJsonGeneration()
+    public function testJsonGeneration(): void
     {
         $generator = new Changelog($this->getConfig());
         $changelog = $generator->generateJson();
@@ -56,10 +55,7 @@ class ChangelogTest extends TestCase
         ], array_keys($changelog));
     }
 
-    /**
-     * @return array
-     */
-    public function providerTestGeneration()
+    public function providerTestGeneration(): array
     {
         // Save us the effort of copy and pasting the same base actions over and over.
         $actions = [
@@ -825,7 +821,7 @@ class ChangelogTest extends TestCase
                                     '/movies/{id}' => [
                                         Changelog::CHANGESET_TYPE_ACTION => [
                                             'd81e7058dd' => call_user_func(
-                                                function () use ($actions) {
+                                                function () use ($actions): array {
                                                     $actions = $actions['1.1']['/movies/{id}']['action']['d81e7058dd'];
 
                                                     // Remove the `DELETE` method from `/movies/{id}`, since that
@@ -1142,7 +1138,7 @@ class ChangelogTest extends TestCase
                                     '/movies/{id}' => [
                                         Changelog::CHANGESET_TYPE_ACTION => [
                                             'd81e7058dd' => call_user_func(
-                                                function () use ($actions) {
+                                                function () use ($actions): array {
                                                     $hash = 'd81e7058ddfce86beb09ddb2a2461ea16d949637';
                                                     $actions = $actions['1.1']['/movies/{id}']['action']['d81e7058dd'];
 

--- a/tests/Generator/ErrorMapTest.php
+++ b/tests/Generator/ErrorMapTest.php
@@ -8,12 +8,11 @@ class ErrorMapTestTest extends TestCase
 {
     /**
      * @dataProvider providerTestGeneration
-     * @param boolean $private_objects
-     * @param array $capabilities
+     * @param bool $private_objects
+     * @param array|null $capabilities
      * @param array $expected
-     * @return void
      */
-    public function testGeneration($private_objects, $capabilities, $expected)
+    public function testGeneration(bool $private_objects, ?array $capabilities, array $expected): void
     {
         $generator = new ErrorMap($this->getConfig());
         $generator->setLoadPrivateDocs($private_objects);
@@ -39,10 +38,7 @@ class ErrorMapTestTest extends TestCase
         }
     }
 
-    /**
-     * @return array
-     */
-    public function providerTestGeneration()
+    public function providerTestGeneration(): array
     {
         // Save us the effort of copy and pasting the same action data over and over.
         $errors = [

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -11,7 +11,7 @@ use Mill\Parser\Version;
  */
 class GeneratorTest extends TestCase
 {
-    public function testGeneratorParsesAllVersions()
+    public function testGeneratorParsesAllVersions(): void
     {
         $generator = new Generator($this->getConfig());
         $generator->generate();
@@ -25,7 +25,7 @@ class GeneratorTest extends TestCase
         ], array_keys($generator->getResources()));
     }
 
-    public function testGeneratorButExcludeARepresentation()
+    public function testGeneratorButExcludeARepresentation(): void
     {
         $config = $this->getConfig();
         $config->addExcludedRepresentation('\Mill\Examples\Showtimes\Representations\Movie');
@@ -48,19 +48,18 @@ class GeneratorTest extends TestCase
     /**
      * @dataProvider providerGeneratorWithVersion
      * @param string $version
-     * @param boolean $private_objects
-     * @param array $capabilities
+     * @param bool $private_objects
+     * @param array|null $capabilities
      * @param array $expected_representations
      * @param array $expected_resources
-     * @return void
      */
     public function testGeneratorWithVersion(
-        $version,
-        $private_objects,
-        $capabilities,
+        string $version,
+        bool $private_objects,
+        ?array $capabilities,
         array $expected_representations,
         array $expected_resources
-    ) {
+    ): void {
         $version_obj = new Version($version, __CLASS__, __METHOD__);
         $generator = new Generator($this->getConfig(), $version_obj);
         $generator->setLoadPrivateDocs($private_objects);
@@ -178,10 +177,7 @@ class GeneratorTest extends TestCase
         }
     }
 
-    /**
-     * @return array
-     */
-    public function providerGeneratorWithVersion()
+    public function providerGeneratorWithVersion(): array
     {
         // Save us the effort of copy and pasting the same base actions over and over.
         $actions = [
@@ -504,7 +500,7 @@ class GeneratorTest extends TestCase
                     '\Mill\Examples\Showtimes\Representations\Movie' => $representations['Movie'],
                     '\Mill\Examples\Showtimes\Representations\Person' => $representations['Person'],
                     '\Mill\Examples\Showtimes\Representations\Theater' => call_user_func(
-                        function () use ($representations) {
+                        function () use ($representations): array {
                             $representation = $representations['Theater'];
                             $representation['content.keys'] = array_merge($representation['content.keys'], [
                                 'website'
@@ -562,7 +558,7 @@ class GeneratorTest extends TestCase
                     '\Mill\Examples\Showtimes\Representations\Movie' => $representations['Movie'],
                     '\Mill\Examples\Showtimes\Representations\Person' => $representations['Person'],
                     '\Mill\Examples\Showtimes\Representations\Theater' => call_user_func(
-                        function () use ($representations) {
+                        function () use ($representations): array {
                             $representation = $representations['Theater'];
                             $representation['content.keys'] = array_merge($representation['content.keys'], [
                                 'website'
@@ -611,7 +607,7 @@ class GeneratorTest extends TestCase
                 'capabilities' => null,
                 'expected.representations' => array_merge($error_representations, [
                     '\Mill\Examples\Showtimes\Representations\Movie' => call_user_func(
-                        function () use ($representations) {
+                        function () use ($representations): array {
                             $representation = $representations['Movie'];
                             $representation['content.keys'] = array_merge($representation['content.keys'], [
                                 'external_urls',
@@ -638,14 +634,14 @@ class GeneratorTest extends TestCase
                                     '/movies/+id::GET' => $actions['/movies/+id::GET'],
                                     '/movies/+id::PATCH' => $actions['/movies/+id::PATCH'],
                                     '/movies/+id::DELETE' => $actions['/movies/+id::DELETE'],
-                                    '/movies::GET' => call_user_func(function () use ($actions) {
+                                    '/movies::GET' => call_user_func(function () use ($actions): array {
                                         $action = $actions['/movies::GET'];
                                         $action['params.keys'][] = 'page';
                                         $action['annotations.sum']['param']++;
 
                                         return $action;
                                     }),
-                                    '/movies::POST' => call_user_func(function () use ($actions) {
+                                    '/movies::POST' => call_user_func(function () use ($actions): array {
                                         $action = $actions['/movies::POST'];
                                         $action['params.keys'][] = 'imdb';
                                         $action['params.keys'][] = 'trailer';
@@ -689,7 +685,7 @@ class GeneratorTest extends TestCase
                 ],
                 'expected.representations' => array_merge($error_representations, [
                     '\Mill\Examples\Showtimes\Representations\Movie' => call_user_func(
-                        function () use ($representations) {
+                        function () use ($representations): array {
                             $representation = $representations['Movie'];
                             $representation['content.keys'] = array_merge($representation['content.keys'], [
                                 'external_urls',
@@ -714,14 +710,14 @@ class GeneratorTest extends TestCase
                                 'actions.data' => [
                                     '/movies/+id::GET' => $actions['/movies/+id::GET'],
                                     '/movies/+id::PATCH' => $actions['/movies/+id::PATCH'],
-                                    '/movies::GET' => call_user_func(function () use ($actions) {
+                                    '/movies::GET' => call_user_func(function () use ($actions): array {
                                         $action = $actions['/movies::GET'];
                                         $action['params.keys'][] = 'page';
                                         $action['annotations.sum']['param']++;
 
                                         return $action;
                                     }),
-                                    '/movies::POST' => call_user_func(function () use ($actions) {
+                                    '/movies::POST' => call_user_func(function () use ($actions): array {
                                         $action = $actions['/movies::POST'];
                                         $action['params.keys'][] = 'imdb';
                                         $action['params.keys'][] = 'trailer';
@@ -763,7 +759,7 @@ class GeneratorTest extends TestCase
                 ],
                 'expected.representations' => array_merge($error_representations, [
                     '\Mill\Examples\Showtimes\Representations\Movie' => call_user_func(
-                        function () use ($representations) {
+                        function () use ($representations): array {
                             $representation = $representations['Movie'];
                             $representation['content.keys'] = array_merge($representation['content.keys'], [
                                 'external_urls',
@@ -789,14 +785,14 @@ class GeneratorTest extends TestCase
                                     '/movies/+id::GET' => $actions['/movies/+id::GET'],
                                     '/movies/+id::PATCH' => $actions['/movies/+id::PATCH'],
                                     '/movies/+id::DELETE' => $actions['/movies/+id::DELETE'],
-                                    '/movies::GET' => call_user_func(function () use ($actions) {
+                                    '/movies::GET' => call_user_func(function () use ($actions): array {
                                         $action = $actions['/movies::GET'];
                                         $action['params.keys'][] = 'page';
                                         $action['annotations.sum']['param']++;
 
                                         return $action;
                                     }),
-                                    '/movies::POST' => call_user_func(function () use ($actions) {
+                                    '/movies::POST' => call_user_func(function () use ($actions): array {
                                         $action = $actions['/movies::POST'];
                                         $action['params.keys'][] = 'imdb';
                                         $action['params.keys'][] = 'trailer';
@@ -836,7 +832,7 @@ class GeneratorTest extends TestCase
                 'capabilities' => null,
                 'expected.representations' => array_merge($error_representations, [
                     '\Mill\Examples\Showtimes\Representations\Movie' => call_user_func(
-                        function () use ($representations) {
+                        function () use ($representations): array {
                             $representation = $representations['Movie'];
                             $representation['content.keys'] = array_merge($representation['content.keys'], [
                                 'external_urls',
@@ -861,7 +857,7 @@ class GeneratorTest extends TestCase
                                 'actions.data' => [
                                     '/movie/+id::GET' => $actions['/movie/+id::GET'],
                                     '/movies/+id::GET' => $actions['/movies/+id::GET'],
-                                    '/movies/+id::PATCH' => call_user_func(function () use ($actions) {
+                                    '/movies/+id::PATCH' => call_user_func(function () use ($actions): array {
                                         $action = $actions['/movies/+id::PATCH'];
                                         $action['params.keys'][] = 'imdb';
 
@@ -872,14 +868,14 @@ class GeneratorTest extends TestCase
                                         return $action;
                                     }),
                                     '/movies/+id::DELETE' => $actions['/movies/+id::DELETE'],
-                                    '/movies::GET' => call_user_func(function () use ($actions) {
+                                    '/movies::GET' => call_user_func(function () use ($actions): array {
                                         $action = $actions['/movies::GET'];
                                         $action['params.keys'][] = 'page';
                                         $action['annotations.sum']['param']++;
 
                                         return $action;
                                     }),
-                                    '/movies::POST' => call_user_func(function () use ($actions) {
+                                    '/movies::POST' => call_user_func(function () use ($actions): array {
                                         $action = $actions['/movies::POST'];
                                         $action['params.keys'][] = 'imdb';
                                         $action['params.keys'][] = 'trailer';
@@ -920,7 +916,7 @@ class GeneratorTest extends TestCase
                 'capabilities' => [],
                 'expected.representations' => array_merge($error_representations, [
                     '\Mill\Examples\Showtimes\Representations\Movie' => call_user_func(
-                        function () use ($representations) {
+                        function () use ($representations): array {
                             $representation = $representations['Movie'];
                             $representation['content.keys'] = array_merge($representation['content.keys'], [
                                 'external_urls',
@@ -945,7 +941,7 @@ class GeneratorTest extends TestCase
                                 'actions.data' => [
                                     '/movie/+id::GET' => $actions['/movie/+id::GET'],
                                     '/movies/+id::GET' => $actions['/movies/+id::GET'],
-                                    '/movies/+id::PATCH' => call_user_func(function () use ($actions) {
+                                    '/movies/+id::PATCH' => call_user_func(function () use ($actions): array {
                                         $action = $actions['/movies/+id::PATCH'];
                                         $action['params.keys'][] = 'imdb';
 
@@ -955,14 +951,14 @@ class GeneratorTest extends TestCase
 
                                         return $action;
                                     }),
-                                    '/movies::GET' => call_user_func(function () use ($actions) {
+                                    '/movies::GET' => call_user_func(function () use ($actions): array {
                                         $action = $actions['/movies::GET'];
                                         $action['params.keys'][] = 'page';
                                         $action['annotations.sum']['param']++;
 
                                         return $action;
                                     }),
-                                    '/movies::POST' => call_user_func(function () use ($actions) {
+                                    '/movies::POST' => call_user_func(function () use ($actions): array {
                                         $action = $actions['/movies::POST'];
                                         $action['params.keys'][] = 'imdb';
                                         $action['params.keys'][] = 'trailer';

--- a/tests/Parser/AnnotationTest.php
+++ b/tests/Parser/AnnotationTest.php
@@ -6,7 +6,7 @@ use Mill\Tests\Fixtures\AnnotationStub;
 
 class AnnotationTest extends \PHPUnit\Framework\TestCase
 {
-    public function testAnnotationFailsIfARequiredFieldWasNotSuppliedToRequired()
+    public function testAnnotationFailsIfARequiredFieldWasNotSuppliedToRequired(): void
     {
         $docblock = 'This is a test';
 

--- a/tests/Parser/Annotations/AnnotationTest.php
+++ b/tests/Parser/Annotations/AnnotationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mill\Tests\Parser\Annotations;
 
+use Mill\Exceptions\BaseException;
 use Mill\Parser\Annotations\DataAnnotation;
 use Mill\Tests\TestCase;
 
@@ -12,13 +13,12 @@ abstract class AnnotationTest extends TestCase
      * @param string $content
      * @param string $exception
      * @param array $asserts
-     * @throws \Exception
-     * @return void
+     * @throws BaseException
      */
     public function testAnnotationFailsOnInvalidContent(
         string $annotation,
         string $content,
-        $exception,
+        string $exception,
         array $asserts
     ): void {
         $this->expectException($exception);
@@ -29,7 +29,7 @@ abstract class AnnotationTest extends TestCase
             } else {
                 (new $annotation($content, __CLASS__, __METHOD__))->process();
             }
-        } catch (\Exception $e) {
+        } catch (BaseException $e) {
             if (get_class($e) !== $exception) {
                 $this->fail('Unrecognized exception (' . get_class($e) . ') thrown.');
             }
@@ -39,13 +39,7 @@ abstract class AnnotationTest extends TestCase
         }
     }
 
-    /**
-     * @return array
-     */
     abstract public function providerAnnotation(): array;
 
-    /**
-     * @return array
-     */
     abstract public function providerAnnotationFailsOnInvalidContent(): array;
 }

--- a/tests/Parser/Annotations/CapabilityAnnotationTest.php
+++ b/tests/Parser/Annotations/CapabilityAnnotationTest.php
@@ -11,11 +11,12 @@ class CapabilityAnnotationTest extends AnnotationTest
      * @dataProvider providerAnnotation
      * @param string $content
      * @param array $expected
-     * @return void
      */
     public function testAnnotation(string $content, array $expected): void
     {
-        $annotation = (new CapabilityAnnotation($content, __CLASS__, __METHOD__))->process();
+        $annotation = new CapabilityAnnotation($content, __CLASS__, __METHOD__);
+        $annotation->process();
+
         $this->assertAnnotation($annotation, $expected);
     }
 
@@ -23,7 +24,6 @@ class CapabilityAnnotationTest extends AnnotationTest
      * @dataProvider providerAnnotation
      * @param string $content
      * @param array $expected
-     * @return void
      */
     public function testHydrate(string $content, array $expected): void
     {
@@ -38,11 +38,6 @@ class CapabilityAnnotationTest extends AnnotationTest
         $this->assertAnnotation($annotation, $expected);
     }
 
-    /**
-     * @param CapabilityAnnotation $annotation
-     * @param array $expected
-     * @return void
-     */
     private function assertAnnotation(CapabilityAnnotation $annotation, array $expected): void
     {
         $this->assertFalse($annotation->requiresVisibilityDecorator());
@@ -56,9 +51,6 @@ class CapabilityAnnotationTest extends AnnotationTest
         $this->assertEmpty($annotation->getAliases());
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotation(): array
     {
         return [
@@ -71,9 +63,6 @@ class CapabilityAnnotationTest extends AnnotationTest
         ];
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [

--- a/tests/Parser/Annotations/ContentTypeAnnotationTest.php
+++ b/tests/Parser/Annotations/ContentTypeAnnotationTest.php
@@ -12,11 +12,12 @@ class ContentTypeAnnotationTest extends AnnotationTest
      * @param string $content
      * @param Version|null $version
      * @param array $expected
-     * @return void
      */
-    public function testAnnotation(string $content, $version, array $expected): void
+    public function testAnnotation(string $content, ?Version $version, array $expected): void
     {
-        $annotation = (new ContentTypeAnnotation($content, __CLASS__, __METHOD__, $version))->process();
+        $annotation = new ContentTypeAnnotation($content, __CLASS__, __METHOD__, $version);
+        $annotation->process();
+
         $this->assertAnnotation($annotation, $expected);
     }
 
@@ -25,9 +26,8 @@ class ContentTypeAnnotationTest extends AnnotationTest
      * @param string $content
      * @param Version|null $version
      * @param array $expected
-     * @return void
      */
-    public function testHydrate(string $content, $version, array $expected): void
+    public function testHydrate(string $content, ?Version $version, array $expected): void
     {
         $annotation = ContentTypeAnnotation::hydrate(array_merge(
             $expected,
@@ -40,11 +40,6 @@ class ContentTypeAnnotationTest extends AnnotationTest
         $this->assertAnnotation($annotation, $expected);
     }
 
-    /**
-     * @param ContentTypeAnnotation $annotation
-     * @param array $expected
-     * @return void
-     */
     private function assertAnnotation(ContentTypeAnnotation $annotation, array $expected): void
     {
         $this->assertFalse($annotation->requiresVisibilityDecorator());
@@ -65,9 +60,6 @@ class ContentTypeAnnotationTest extends AnnotationTest
         $this->assertEmpty($annotation->getAliases());
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotation(): array
     {
         return [
@@ -90,9 +82,6 @@ class ContentTypeAnnotationTest extends AnnotationTest
         ];
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [

--- a/tests/Parser/Annotations/DataAnnotationTest.php
+++ b/tests/Parser/Annotations/DataAnnotationTest.php
@@ -14,9 +14,8 @@ class DataAnnotationTest extends AnnotationTest
      * @param string $content
      * @param Version|null $version
      * @param array $expected
-     * @return void
      */
-    public function testAnnotation(string $content, $version, array $expected): void
+    public function testAnnotation(string $content, ?Version $version, array $expected): void
     {
         $annotation = $this->getDataAnnotationFromDocblock($content, __CLASS__);
         $this->assertAnnotation($annotation, $expected);
@@ -27,9 +26,8 @@ class DataAnnotationTest extends AnnotationTest
      * @param string $content
      * @param Version|null $version
      * @param array $expected
-     * @return void
      */
-    public function testHydrate(string $content, $version, array $expected): void
+    public function testHydrate(string $content, ?Version $version, array $expected): void
     {
         $annotation = DataAnnotation::hydrate(array_merge(
             $expected,
@@ -42,11 +40,6 @@ class DataAnnotationTest extends AnnotationTest
         $this->assertAnnotation($annotation, $expected);
     }
 
-    /**
-     * @param DataAnnotation $annotation
-     * @param array $expected
-     * @return void
-     */
     private function assertAnnotation(DataAnnotation $annotation, array $expected): void
     {
         $this->assertFalse($annotation->requiresVisibilityDecorator());
@@ -69,9 +62,6 @@ class DataAnnotationTest extends AnnotationTest
         }
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotation(): array
     {
         return [
@@ -254,9 +244,6 @@ class DataAnnotationTest extends AnnotationTest
         ];
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [

--- a/tests/Parser/Annotations/DescriptionAnnotationTest.php
+++ b/tests/Parser/Annotations/DescriptionAnnotationTest.php
@@ -10,11 +10,12 @@ class DescriptionAnnotationTest extends AnnotationTest
      * @dataProvider providerAnnotation
      * @param string $content
      * @param array $expected
-     * @return void
      */
     public function testAnnotation(string $content, array $expected): void
     {
-        $annotation = (new DescriptionAnnotation($content, __CLASS__, __METHOD__))->process();
+        $annotation = new DescriptionAnnotation($content, __CLASS__, __METHOD__);
+        $annotation->process();
+
         $this->assertAnnotation($annotation, $expected);
     }
 
@@ -22,7 +23,6 @@ class DescriptionAnnotationTest extends AnnotationTest
      * @dataProvider providerAnnotation
      * @param string $content
      * @param array $expected
-     * @return void
      */
     public function testHydrate(string $content, array $expected): void
     {
@@ -37,11 +37,6 @@ class DescriptionAnnotationTest extends AnnotationTest
         $this->assertAnnotation($annotation, $expected);
     }
 
-    /**
-     * @param DescriptionAnnotation $annotation
-     * @param array $expected
-     * @return void
-     */
     private function assertAnnotation(DescriptionAnnotation $annotation, array $expected): void
     {
         $this->assertFalse($annotation->requiresVisibilityDecorator());
@@ -55,9 +50,6 @@ class DescriptionAnnotationTest extends AnnotationTest
         $this->assertEmpty($annotation->getAliases());
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotation(): array
     {
         return [
@@ -70,9 +62,6 @@ class DescriptionAnnotationTest extends AnnotationTest
         ];
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [

--- a/tests/Parser/Annotations/LabelAnnotationTest.php
+++ b/tests/Parser/Annotations/LabelAnnotationTest.php
@@ -10,11 +10,12 @@ class LabelAnnotationTest extends AnnotationTest
      * @dataProvider providerAnnotation
      * @param string $content
      * @param array $expected
-     * @return void
      */
     public function testAnnotation(string $content, array $expected): void
     {
-        $annotation = (new LabelAnnotation($content, __CLASS__, __METHOD__))->process();
+        $annotation = new LabelAnnotation($content, __CLASS__, __METHOD__);
+        $annotation->process();
+
         $this->assertAnnotation($annotation, $expected);
     }
 
@@ -22,7 +23,6 @@ class LabelAnnotationTest extends AnnotationTest
      * @dataProvider providerAnnotation
      * @param string $content
      * @param array $expected
-     * @return void
      */
     public function testHydrate(string $content, array $expected): void
     {
@@ -37,11 +37,6 @@ class LabelAnnotationTest extends AnnotationTest
         $this->assertAnnotation($annotation, $expected);
     }
 
-    /**
-     * @param LabelAnnotation $annotation
-     * @param array $expected
-     * @return void
-     */
     private function assertAnnotation(LabelAnnotation $annotation, array $expected): void
     {
         $this->assertFalse($annotation->requiresVisibilityDecorator());
@@ -55,9 +50,6 @@ class LabelAnnotationTest extends AnnotationTest
         $this->assertEmpty($annotation->getAliases());
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotation(): array
     {
         return [
@@ -70,9 +62,6 @@ class LabelAnnotationTest extends AnnotationTest
         ];
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [

--- a/tests/Parser/Annotations/MinVersionAnnotationTest.php
+++ b/tests/Parser/Annotations/MinVersionAnnotationTest.php
@@ -11,11 +11,12 @@ class MinVersionAnnotationTest extends AnnotationTest
      * @dataProvider providerAnnotation
      * @param string $content
      * @param array $expected
-     * @return void
      */
     public function testAnnotation(string $content, array $expected): void
     {
-        $annotation = (new MinVersionAnnotation($content, __CLASS__, __METHOD__))->process();
+        $annotation = new MinVersionAnnotation($content, __CLASS__, __METHOD__);
+        $annotation->process();
+
         $this->assertAnnotation($annotation, $expected);
     }
 
@@ -23,7 +24,6 @@ class MinVersionAnnotationTest extends AnnotationTest
      * @dataProvider providerAnnotation
      * @param string $content
      * @param array $expected
-     * @return void
      */
     public function testHydrate(string $content, array $expected): void
     {
@@ -38,11 +38,6 @@ class MinVersionAnnotationTest extends AnnotationTest
         $this->assertAnnotation($annotation, $expected);
     }
 
-    /**
-     * @param MinVersionAnnotation $annotation
-     * @param array $expected
-     * @return void
-     */
     private function assertAnnotation(MinVersionAnnotation $annotation, array $expected): void
     {
         $this->assertFalse($annotation->requiresVisibilityDecorator());
@@ -56,9 +51,6 @@ class MinVersionAnnotationTest extends AnnotationTest
         $this->assertEmpty($annotation->getAliases());
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotation(): array
     {
         return [
@@ -71,9 +63,6 @@ class MinVersionAnnotationTest extends AnnotationTest
         ];
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [

--- a/tests/Parser/Annotations/ParamAnnotationTest.php
+++ b/tests/Parser/Annotations/ParamAnnotationTest.php
@@ -6,7 +6,6 @@ use Mill\Exceptions\Annotations\UnsupportedTypeException;
 use Mill\Parser\Annotations\CapabilityAnnotation;
 use Mill\Parser\Annotations\ParamAnnotation;
 use Mill\Parser\Version;
-use PhpParser\Node\Param;
 
 class ParamAnnotationTest extends AnnotationTest
 {
@@ -17,16 +16,16 @@ class ParamAnnotationTest extends AnnotationTest
      * @param bool $visible
      * @param bool $deprecated
      * @param array $expected
-     * @return void
      */
     public function testAnnotation(
         string $content,
-        $version,
+        ?Version $version,
         bool $visible,
         bool $deprecated,
         array $expected
     ): void {
-        $annotation = (new ParamAnnotation($content, __CLASS__, __METHOD__, $version))->process();
+        $annotation = new ParamAnnotation($content, __CLASS__, __METHOD__, $version);
+        $annotation->process();
         $annotation->setVisibility($visible);
         $annotation->setDeprecated($deprecated);
 
@@ -40,11 +39,10 @@ class ParamAnnotationTest extends AnnotationTest
      * @param bool $visible
      * @param bool $deprecated
      * @param array $expected
-     * @return void
      */
     public function testHydrate(
         string $content,
-        $version,
+        ?Version $version,
         bool $visible,
         bool $deprecated,
         array $expected
@@ -60,11 +58,6 @@ class ParamAnnotationTest extends AnnotationTest
         $this->assertAnnotation($annotation, $expected);
     }
 
-    /**
-     * @param ParamAnnotation $annotation
-     * @param array $expected
-     * @return void
-     */
     private function assertAnnotation(ParamAnnotation $annotation, array $expected): void
     {
         $this->assertTrue($annotation->requiresVisibilityDecorator());
@@ -94,9 +87,6 @@ class ParamAnnotationTest extends AnnotationTest
         $this->assertEmpty($annotation->getAliases());
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotation(): array
     {
         return [
@@ -439,9 +429,6 @@ class ParamAnnotationTest extends AnnotationTest
         ];
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [

--- a/tests/Parser/Annotations/ReturnAnnotationTest.php
+++ b/tests/Parser/Annotations/ReturnAnnotationTest.php
@@ -13,13 +13,13 @@ class ReturnAnnotationTest extends AnnotationTest
      * @dataProvider providerAnnotation
      * @param string $content
      * @param bool $visible
-     * @param Version|null $version
+     * @param $version
      * @param array $expected
-     * @return void
      */
     public function testAnnotation(string $content, bool $visible, $version, array $expected): void
     {
-        $annotation = (new ReturnAnnotation($content, __CLASS__, __METHOD__, $version))->process();
+        $annotation = new ReturnAnnotation($content, __CLASS__, __METHOD__, $version);
+        $annotation->process();
         $annotation->setVisibility($visible);
 
         $this->assertAnnotation($annotation, $expected);
@@ -29,9 +29,8 @@ class ReturnAnnotationTest extends AnnotationTest
      * @dataProvider providerAnnotation
      * @param string $content
      * @param bool $visible
-     * @param Version|null $version
+     * @param $version
      * @param array $expected
-     * @return void
      */
     public function testHydrate(string $content, bool $visible, $version, array $expected): void
     {
@@ -46,11 +45,6 @@ class ReturnAnnotationTest extends AnnotationTest
         $this->assertAnnotation($annotation, $expected);
     }
 
-    /**
-     * @param ReturnAnnotation $annotation
-     * @param array $expected
-     * @return void
-     */
     private function assertAnnotation(ReturnAnnotation $annotation, array $expected): void
     {
         $this->assertTrue($annotation->requiresVisibilityDecorator());
@@ -74,9 +68,6 @@ class ReturnAnnotationTest extends AnnotationTest
         $this->assertEmpty($annotation->getAliases());
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotation(): array
     {
         return [
@@ -289,9 +280,6 @@ class ReturnAnnotationTest extends AnnotationTest
         ];
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [

--- a/tests/Parser/Annotations/ScopeAnnotationTest.php
+++ b/tests/Parser/Annotations/ScopeAnnotationTest.php
@@ -11,11 +11,12 @@ class ScopeAnnotationTest extends AnnotationTest
      * @dataProvider providerAnnotation
      * @param string $content
      * @param array $expected
-     * @return void
      */
     public function testAnnotation(string $content, array $expected): void
     {
-        $annotation = (new ScopeAnnotation($content, __CLASS__, __METHOD__))->process();
+        $annotation = new ScopeAnnotation($content, __CLASS__, __METHOD__);
+        $annotation->process();
+
         $this->assertAnnotation($annotation, $expected);
     }
 
@@ -23,7 +24,6 @@ class ScopeAnnotationTest extends AnnotationTest
      * @dataProvider providerAnnotation
      * @param string $content
      * @param array $expected
-     * @return void
      */
     public function testHydrate(string $content, array $expected): void
     {
@@ -38,11 +38,6 @@ class ScopeAnnotationTest extends AnnotationTest
         $this->assertAnnotation($annotation, $expected);
     }
 
-    /**
-     * @param ScopeAnnotation $annotation
-     * @param array $expected
-     * @return void
-     */
     private function assertAnnotation(ScopeAnnotation $annotation, array $expected): void
     {
         $this->assertFalse($annotation->requiresVisibilityDecorator());
@@ -58,9 +53,6 @@ class ScopeAnnotationTest extends AnnotationTest
         $this->assertEmpty($annotation->getAliases());
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotation(): array
     {
         return [
@@ -81,9 +73,6 @@ class ScopeAnnotationTest extends AnnotationTest
         ];
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [

--- a/tests/Parser/Annotations/ThrowsAnnotationTest.php
+++ b/tests/Parser/Annotations/ThrowsAnnotationTest.php
@@ -15,14 +15,14 @@ class ThrowsAnnotationTest extends AnnotationTest
     /**
      * @dataProvider providerAnnotation
      * @param string $content
-     * @param Version|null $version
-     * @param boolean $visible
+     * @param $version
+     * @param bool $visible
      * @param array $expected
-     * @return void
      */
     public function testAnnotation(string $content, $version, bool $visible, array $expected): void
     {
-        $annotation = (new ThrowsAnnotation($content, __CLASS__, __METHOD__, $version))->process();
+        $annotation = new ThrowsAnnotation($content, __CLASS__, __METHOD__, $version);
+        $annotation->process();
         $annotation->setVisibility($visible);
 
         $this->assertAnnotation($annotation, $expected);
@@ -31,10 +31,9 @@ class ThrowsAnnotationTest extends AnnotationTest
     /**
      * @dataProvider providerAnnotation
      * @param string $content
-     * @param Version|null $version
-     * @param boolean $visible
+     * @param $version
+     * @param bool $visible
      * @param array $expected
-     * @return void
      */
     public function testHydrate(string $content, $version, bool $visible, array $expected): void
     {
@@ -49,11 +48,6 @@ class ThrowsAnnotationTest extends AnnotationTest
         $this->assertAnnotation($annotation, $expected);
     }
 
-    /**
-     * @param ThrowsAnnotation $annotation
-     * @param array $expected
-     * @return void
-     */
     private function assertAnnotation(ThrowsAnnotation $annotation, array $expected): void
     {
         $this->assertTrue($annotation->requiresVisibilityDecorator());
@@ -82,9 +76,6 @@ class ThrowsAnnotationTest extends AnnotationTest
         $this->assertEmpty($annotation->getAliases());
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotation(): array
     {
         return [
@@ -282,9 +273,6 @@ class ThrowsAnnotationTest extends AnnotationTest
         ];
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [

--- a/tests/Parser/Annotations/UriAnnotationTest.php
+++ b/tests/Parser/Annotations/UriAnnotationTest.php
@@ -12,11 +12,11 @@ class UriAnnotationTest extends AnnotationTest
      * @param bool $visible
      * @param bool $deprecated
      * @param array $expected
-     * @return void
      */
     public function testAnnotation(string $content, bool $visible, bool $deprecated, array $expected): void
     {
-        $annotation = (new UriAnnotation($content, __CLASS__, __METHOD__))->process();
+        $annotation = new UriAnnotation($content, __CLASS__, __METHOD__);
+        $annotation->process();
         $annotation->setVisibility($visible);
         $annotation->setDeprecated($deprecated);
 
@@ -29,7 +29,6 @@ class UriAnnotationTest extends AnnotationTest
      * @param bool $visible
      * @param bool $deprecated
      * @param array $expected
-     * @return void
      */
     public function testHydrate(string $content, bool $visible, bool $deprecated, array $expected): void
     {
@@ -44,11 +43,6 @@ class UriAnnotationTest extends AnnotationTest
         $this->assertAnnotation($annotation, $expected);
     }
 
-    /**
-     * @param UriAnnotation $annotation
-     * @param array $expected
-     * @return void
-     */
     private function assertAnnotation(UriAnnotation $annotation, array $expected): void
     {
         $this->assertTrue($annotation->requiresVisibilityDecorator());
@@ -63,26 +57,17 @@ class UriAnnotationTest extends AnnotationTest
         $this->assertEmpty($annotation->getAliases());
     }
 
-    /**
-     * @return void
-     */
     public function testConfiguredUriSegmentTranslations(): void
     {
         $this->getConfig()->addUriSegmentTranslation('movie_id', 'id');
 
-        $annotation = (new UriAnnotation(
-            '{Movies\Showtimes} /movies/+movie_id/showtimes',
-            __CLASS__,
-            __METHOD__
-        ))->process();
+        $annotation = new UriAnnotation('{Movies\Showtimes} /movies/+movie_id/showtimes', __CLASS__, __METHOD__);
+        $annotation->process();
 
         $this->assertSame('/movies/{id}/showtimes', $annotation->getCleanPath());
         $this->assertSame('/movies/+movie_id/showtimes', $annotation->toArray()['path']);
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotation(): array
     {
         return [
@@ -169,9 +154,6 @@ class UriAnnotationTest extends AnnotationTest
         ];
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [

--- a/tests/Parser/Annotations/UriSegmentAnnotationTest.php
+++ b/tests/Parser/Annotations/UriSegmentAnnotationTest.php
@@ -13,11 +13,12 @@ class UriSegmentAnnotationTest extends AnnotationTest
      * @param string $uri
      * @param string $segment
      * @param array $expected
-     * @return void
      */
     public function testAnnotation(string $uri, string $segment, array $expected): void
     {
-        $annotation = (new UriSegmentAnnotation($segment, __CLASS__, __METHOD__, null))->process();
+        $annotation = new UriSegmentAnnotation($segment, __CLASS__, __METHOD__, null);
+        $annotation->process();
+
         $this->assertAnnotation($annotation, $expected);
     }
 
@@ -26,7 +27,6 @@ class UriSegmentAnnotationTest extends AnnotationTest
      * @param string $uri
      * @param string $segment
      * @param array $expected
-     * @return void
      */
     public function testHydrate(string $uri, string $segment, array $expected): void
     {
@@ -41,11 +41,6 @@ class UriSegmentAnnotationTest extends AnnotationTest
         $this->assertAnnotation($annotation, $expected);
     }
 
-    /**
-     * @param UriSegmentAnnotation $annotation
-     * @param array $expected
-     * @return void
-     */
     private function assertAnnotation(UriSegmentAnnotation $annotation, array $expected): void
     {
         $this->assertFalse($annotation->requiresVisibilityDecorator());
@@ -63,9 +58,6 @@ class UriSegmentAnnotationTest extends AnnotationTest
         $this->assertEmpty($annotation->getAliases());
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotation(): array
     {
         return [
@@ -100,9 +92,6 @@ class UriSegmentAnnotationTest extends AnnotationTest
         ];
     }
 
-    /**
-     * @return array
-     */
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [

--- a/tests/Parser/MSONTest.php
+++ b/tests/Parser/MSONTest.php
@@ -10,15 +10,14 @@ class MSONTest extends TestCase
      * @dataProvider providerTestParse
      * @param string $content
      * @param array $expected
-     * @return void
      */
-    public function testParse($content, array $expected)
+    public function testParse(string $content, array $expected): void
     {
         $mson = (new MSON(__CLASS__, __METHOD__))->parse($content);
         $this->assertSame($expected, $mson->toArray());
     }
 
-    public function testEnumFailsWithoutValues()
+    public function testEnumFailsWithoutValues(): void
     {
         $this->expectException('Mill\Exceptions\MSON\MissingOptionsException');
 
@@ -29,18 +28,14 @@ class MSONTest extends TestCase
     /**
      * @dataProvider providerTestParseFailsOnInvalidTypes
      * @param string $content
-     * @return void
      */
-    public function testParseFailsOnInvalidTypes($content)
+    public function testParseFailsOnInvalidTypes(string $content): void
     {
         $this->expectException('Mill\Exceptions\Annotations\UnsupportedTypeException');
         (new MSON(__CLASS__, __METHOD__))->parse($content);
     }
 
-    /**
-     * @return array
-     */
-    public function providerTestParse()
+    public function providerTestParse(): array
     {
         return [
             '_complete' => [
@@ -282,10 +277,7 @@ class MSONTest extends TestCase
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function providerTestParseFailsOnInvalidTypes()
+    public function providerTestParseFailsOnInvalidTypes(): array
     {
         return [
             'type-unknown-representation' => [

--- a/tests/Parser/Representation/DocumentationTest.php
+++ b/tests/Parser/Representation/DocumentationTest.php
@@ -11,9 +11,8 @@ class DocumentationTest extends TestCase
      * @param string $class
      * @param string $method
      * @param array $expected
-     * @return void
      */
-    public function testParseDocumentationReturnsRepresentation($class, $method, array $expected)
+    public function testParseDocumentationReturnsRepresentation(string $class, string $method, array $expected): void
     {
         $parsed = (new Documentation($class, $method))->parse();
         $representation = $parsed->toArray();
@@ -46,19 +45,18 @@ class DocumentationTest extends TestCase
      * @param string $class
      * @param string $method
      * @param string $exception
-     * @return void
      */
-    public function testParseDocumentationFailsOnBadRepresentations($class, $method, $exception)
-    {
+    public function testParseDocumentationFailsOnBadRepresentations(
+        string $class,
+        string $method,
+        string $exception
+    ): void {
         $this->expectException($exception);
 
         (new Documentation($class, $method))->parse();
     }
 
-    /**
-     * @return array
-     */
-    public function providerParseDocumentationReturnsRepresentation()
+    public function providerParseDocumentationReturnsRepresentation(): array
     {
         return [
             'Movie' => [
@@ -584,10 +582,7 @@ class DocumentationTest extends TestCase
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function providerParseDocumentationFailsOnBadRepresentations()
+    public function providerParseDocumentationFailsOnBadRepresentations(): array
     {
         return [
             'no-annotations' => [

--- a/tests/Parser/Representation/RepresentationParserTest.php
+++ b/tests/Parser/Representation/RepresentationParserTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Mill\Tests\Parser\Representation;
 
+use Mill\Exceptions\BaseException;
+use Mill\Parser\Annotation;
 use Mill\Parser\Representation\RepresentationParser;
 use Mill\Tests\ReaderTestingTrait;
 use Mill\Tests\TestCase;
@@ -14,9 +16,8 @@ class RepresentationParserTest extends TestCase
      * @param string $class
      * @param string $method
      * @param array $expected
-     * @return void
      */
-    public function testParseAnnotations($class, $method, array $expected)
+    public function testParseAnnotations(string $class, string $method, array $expected): void
     {
         $parser = new RepresentationParser($class);
         $annotations = $parser->getAnnotations($method);
@@ -44,7 +45,7 @@ class RepresentationParserTest extends TestCase
         }
     }
 
-    public function testRepresentationWithUnknownAnnotations()
+    public function testRepresentationWithUnknownAnnotations(): void
     {
         $docblock = '/**
           * @deprecated
@@ -57,7 +58,7 @@ class RepresentationParserTest extends TestCase
         $this->assertEmpty($annotations);
     }
 
-    public function testRepresentationWithApiSee()
+    public function testRepresentationWithApiSee(): void
     {
         $parser = new RepresentationParser('\Mill\Tests\Fixtures\Representations\RepresentationWithOnlyApiSee');
         $annotations = $parser->getAnnotations('create');
@@ -91,17 +92,16 @@ class RepresentationParserTest extends TestCase
      * @param string $docblock
      * @param string $exception
      * @param array $asserts
-     * @throws \Exception
-     * @return void
+     * @throws BaseException
      */
-    public function testRepresentationsThatWillFailParsing($docblock, $exception, array $asserts)
+    public function testRepresentationsThatWillFailParsing(string $docblock, string $exception, array $asserts): void
     {
         $this->expectException($exception);
         $this->overrideReadersWithFakeDocblockReturn($docblock);
 
         try {
             (new RepresentationParser(__CLASS__))->getAnnotations(__METHOD__);
-        } catch (\Exception $e) {
+        } catch (BaseException $e) {
             if ('\\' . get_class($e) !== $exception) {
                 $this->fail('Unrecognized exception (' . get_class($e) . ') thrown.');
             }
@@ -114,18 +114,20 @@ class RepresentationParserTest extends TestCase
     /**
      * @dataProvider providerRepresentationMethodsThatWillFailParsing
      * @param string $class
-     * @param string $method
+     * @param null|string $method
      * @param string $exception
-     * @throws \Exception
-     * @return void
+     * @throws BaseException
      */
-    public function testRepresentationMethodsThatWillFailParsing($class, $method, $exception)
-    {
+    public function testRepresentationMethodsThatWillFailParsing(
+        string $class,
+        ?string $method,
+        string $exception
+    ): void {
         $this->expectException($exception);
 
         try {
             (new RepresentationParser($class))->getAnnotations($method);
-        } catch (\Exception $e) {
+        } catch (BaseException $e) {
             if ('\\' . get_class($e) !== $exception) {
                 $this->fail('Unrecognized exception (' . get_class($e) . ') thrown.');
             }
@@ -135,7 +137,7 @@ class RepresentationParserTest extends TestCase
         }
     }
 
-    public function testRepresentationThatHasVersioningAcrossMultipleAnnotations()
+    public function testRepresentationThatHasVersioningAcrossMultipleAnnotations(): void
     {
         $class = '\Mill\Tests\Fixtures\Representations\RepresentationWithVersioningAcrossMultipleAnnotations';
         $parser = new RepresentationParser($class);
@@ -149,7 +151,7 @@ class RepresentationParserTest extends TestCase
             'unrelated'
         ], array_keys($annotations));
 
-        $annotations = array_map(function ($annotation) {
+        $annotations = array_map(function (Annotation $annotation): array {
             return $annotation->toArray();
         }, $annotations);
 
@@ -172,10 +174,7 @@ class RepresentationParserTest extends TestCase
         $this->assertEmpty($annotations['unrelated']['scopes']);
     }
 
-    /**
-     * @return array
-     */
-    public function providerParseAnnotations()
+    public function providerParseAnnotations(): array
     {
         return [
             'movie' => [
@@ -424,10 +423,7 @@ class RepresentationParserTest extends TestCase
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function providerRepresentationsThatWillFailParsing()
+    public function providerRepresentationsThatWillFailParsing(): array
     {
         return [
             'docblock-unparseable-mson' => [
@@ -453,10 +449,7 @@ class RepresentationParserTest extends TestCase
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function providerRepresentationMethodsThatWillFailParsing()
+    public function providerRepresentationMethodsThatWillFailParsing(): array
     {
         return [
             'no-method-supplied' => [

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mill\Tests\Parser\Resource\Action;
 
+use Mill\Exceptions\BaseException;
 use Mill\Parser\Resource\Action\Documentation;
 use Mill\Parser\Version;
 use Mill\Tests\ReaderTestingTrait;
@@ -14,9 +15,8 @@ class DocumentationTest extends TestCase
      * @dataProvider providerParseMethodDocumentation
      * @param string $method
      * @param array $expected
-     * @return void
      */
-    public function testParseMethodDocumentation($method, array $expected)
+    public function testParseMethodDocumentation(string $method, array $expected): void
     {
         $class_stub = '\Mill\Examples\Showtimes\Controllers\Movie';
         $parser = (new Documentation($class_stub, $method))->parse();
@@ -28,7 +28,6 @@ class DocumentationTest extends TestCase
      * @dataProvider providerParseMethodDocumentation
      * @param string $method
      * @param array $expected
-     * @return void
      */
     public function testHydrate(string $method, array $expected): void
     {
@@ -41,12 +40,6 @@ class DocumentationTest extends TestCase
         $this->assertMethodDocumentation($hydrate, $class_stub, $method, $expected);
     }
 
-    /**
-     * @param Documentation $parser
-     * @param string $class
-     * @param string $method
-     * @param array $expected
-     */
     private function assertMethodDocumentation(
         Documentation $parser,
         string $class,
@@ -138,9 +131,8 @@ class DocumentationTest extends TestCase
      * @dataProvider providerParsingOfSpecificUseCases
      * @param string $docblock
      * @param array $asserts
-     * @return void
      */
-    public function testParsingOfSpecificUseCases($docblock, array $asserts)
+    public function testParsingOfSpecificUseCases(string $docblock, array $asserts): void
     {
         $this->overrideReadersWithFakeDocblockReturn($docblock);
 
@@ -160,16 +152,16 @@ class DocumentationTest extends TestCase
      * @param string $docblock
      * @param string $exception
      * @param array $asserts
-     * @throws \Exception
+     * @throws BaseException
      */
-    public function testMethodsThatWillFailParsing($docblock, $exception, array $asserts)
+    public function testMethodsThatWillFailParsing(string $docblock, string $exception, array $asserts): void
     {
         $this->expectException($exception);
         $this->overrideReadersWithFakeDocblockReturn($docblock);
 
         try {
             (new Documentation(__CLASS__, __METHOD__))->parse()->toArray();
-        } catch (\Exception $e) {
+        } catch (BaseException $e) {
             if ('\\' . get_class($e) !== $exception) {
                 $this->fail('Unrecognized exception (' . get_class($e) . ') thrown.');
             }
@@ -179,10 +171,7 @@ class DocumentationTest extends TestCase
         }
     }
 
-    /**
-     * @return array
-     */
-    public function providerParseMethodDocumentation()
+    public function providerParseMethodDocumentation(): array
     {
         $get_description = <<<DESCRIPTION
 Return information on a specific movie.
@@ -675,10 +664,7 @@ DESCRIPTION;
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function providerParsingOfSpecificUseCases()
+    public function providerParsingOfSpecificUseCases(): array
     {
         return [
             'with-aliased-uris' => [
@@ -791,10 +777,7 @@ DESCRIPTION;
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function providerMethodsThatWillFailParsing()
+    public function providerMethodsThatWillFailParsing(): array
     {
         return [
             'no-parsed-annotations' => [

--- a/tests/Parser/Resource/DocumentationTest.php
+++ b/tests/Parser/Resource/DocumentationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mill\Tests\Parser\Resource;
 
+use Mill\Exceptions\BaseException;
 use Mill\Exceptions\MethodNotImplementedException;
 use Mill\Parser\Resource\Documentation;
 use Mill\Tests\ReaderTestingTrait;
@@ -14,9 +15,8 @@ class DocumentationTest extends TestCase
      * @dataProvider providerDocumentation
      * @param string $class
      * @param array $expected
-     * @return void
      */
-    public function testDocumentation($class, array $expected)
+    public function testDocumentation(string $class, array $expected): void
     {
         $docs = (new Documentation($class))->parse();
 
@@ -56,17 +56,16 @@ class DocumentationTest extends TestCase
      * @param string $docblock
      * @param string $exception
      * @param array $asserts
-     * @throws \Exception
-     * @return void
+     * @throws BaseException
      */
-    public function testDocumentationFailsOnBadClasses($docblock, $exception, array $asserts)
+    public function testDocumentationFailsOnBadClasses(string $docblock, string $exception, array $asserts): void
     {
         $this->expectException($exception);
         $this->overrideReadersWithFakeDocblockReturn($docblock);
 
         try {
             (new Documentation(__CLASS__))->parse();
-        } catch (\Exception $e) {
+        } catch (BaseException $e) {
             if ('\\' . get_class($e) !== $exception) {
                 $this->fail('Unrecognized exception (' . get_class($e) . ') thrown.');
             }
@@ -81,7 +80,7 @@ class DocumentationTest extends TestCase
      * pulled off the current class.
      *
      */
-    public function testDocumentationAndGetSpecificMethod()
+    public function testDocumentationAndGetSpecificMethod(): void
     {
         $class = '\Mill\Examples\Showtimes\Controllers\Movie';
         $docs = (new Documentation($class))->parse();
@@ -90,10 +89,7 @@ class DocumentationTest extends TestCase
         $this->assertInstanceOf('\Mill\Parser\Resource\Action\Documentation', $docs->getMethod('GET'));
     }
 
-    /**
-     * @return array
-     */
-    public function providerDocumentation()
+    public function providerDocumentation(): array
     {
         return [
             'Movie' => [
@@ -115,10 +111,7 @@ These actions will allow you to pull information on a specific movie.',
         ];
     }
 
-    /**
-     * @return array
-     */
-    public function providerDocumentationFailsOnBadClasses()
+    public function providerDocumentationFailsOnBadClasses(): array
     {
         return [
             'missing-required-label-annotation' => [

--- a/tests/Parser/VersionTest.php
+++ b/tests/Parser/VersionTest.php
@@ -12,7 +12,7 @@ use Mill\Parser\Version;
  */
 class VersionTest extends \PHPUnit\Framework\TestCase
 {
-    public function testParse()
+    public function testParse(): void
     {
         $version = '>3.4';
         $parsed = new Version($version, __CLASS__, __METHOD__);
@@ -25,7 +25,7 @@ class VersionTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($parsed->isRange());
     }
 
-    public function testMatches()
+    public function testMatches(): void
     {
         $version = '3.*';
         $parsed = new Version($version, __CLASS__, __METHOD__);
@@ -39,7 +39,7 @@ class VersionTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function testParseFailsOnBadVersionSchemas()
+    public function testParseFailsOnBadVersionSchemas(): void
     {
         try {
             new Version('', __CLASS__, __METHOD__);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -8,7 +8,7 @@ class ParserTest extends TestCase
 {
     use ReaderTestingTrait;
 
-    public function testParseAnnotationsOnClassWithNoMethod()
+    public function testParseAnnotationsOnClassWithNoMethod(): void
     {
         $class = '\Mill\Examples\Showtimes\Controllers\Movie';
         $docs = (new Parser($class))->getAnnotations();
@@ -32,9 +32,8 @@ These actions will allow you to pull information on a specific movie.', $annotat
      * @dataProvider providerParseAnnotationsOnClassMethod
      * @param string $method
      * @param array $expected
-     * @return void
      */
-    public function testParseAnnotationsOnClassMethod($method, array $expected)
+    public function testParseAnnotationsOnClassMethod(string $method, array $expected): void
     {
         $class = '\Mill\Examples\Showtimes\Controllers\Movie';
         $annotations = (new Parser($class))->getAnnotations($method);
@@ -55,7 +54,7 @@ These actions will allow you to pull information on a specific movie.', $annotat
         }
     }
 
-    public function testParsingADeprecatedDecorator()
+    public function testParsingADeprecatedDecorator(): void
     {
         $this->overrideReadersWithFakeDocblockReturn('/**
           * @api-label Update a piece of content.
@@ -76,7 +75,7 @@ These actions will allow you to pull information on a specific movie.', $annotat
         $this->assertTrue($annotations['uri'][1]->isDeprecated());
     }
 
-    public function testParseAnnotationsOnClassMethodThatDoesntExist()
+    public function testParseAnnotationsOnClassMethodThatDoesntExist(): void
     {
         $class = '\Mill\Examples\Showtimes\Controllers\Movie';
 
@@ -88,10 +87,7 @@ These actions will allow you to pull information on a specific movie.', $annotat
         }
     }
 
-    /**
-     * @return array
-     */
-    public function providerParseAnnotationsOnClassMethod()
+    public function providerParseAnnotationsOnClassMethod(): array
     {
         return [
             'GET' => [

--- a/tests/Provider/ConfigTest.php
+++ b/tests/Provider/ConfigTest.php
@@ -8,7 +8,7 @@ use Pimple\Container;
 
 class ConfigTest extends \PHPUnit\Framework\TestCase
 {
-    public function testRegister()
+    public function testRegister(): void
     {
         $container = new Container;
 
@@ -16,9 +16,12 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $filesystem->register($container);
 
         // Overwrite the stock library local filesystem with an in-memory file system we'll use for testing.
-        $container->extend('filesystem', function ($filesystem, $c) {
-            return new \League\Flysystem\Filesystem(new MemoryAdapter);
-        });
+        $container->extend(
+            'filesystem',
+            function (\League\Flysystem\Filesystem $filesystem, Container $c): \League\Flysystem\Filesystem {
+                return new \League\Flysystem\Filesystem(new MemoryAdapter);
+            }
+        );
 
         $container['filesystem']->write(
             'mill.xml',

--- a/tests/Provider/FilesystemTest.php
+++ b/tests/Provider/FilesystemTest.php
@@ -6,7 +6,7 @@ use Pimple\Container;
 
 class FilesystemTest extends \PHPUnit\Framework\TestCase
 {
-    public function testRegister()
+    public function testRegister(): void
     {
         $container = new Container;
         $filesystem = new Filesystem;

--- a/tests/ReaderTestingTrait.php
+++ b/tests/ReaderTestingTrait.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mill\Tests;
 
+use Closure;
 use Mill\Container;
 use Mill\Provider\Reader;
 
@@ -24,22 +25,27 @@ trait ReaderTestingTrait
      * in order to test parser failures.
      *
      * @param string $docblock
-     * @return void
      */
-    protected function overrideReadersWithFakeDocblockReturn($docblock)
+    protected function overrideReadersWithFakeDocblockReturn(string $docblock): void
     {
         $container = Container::getInstance();
 
-        $container->extend('reader.annotations', function ($reader, Container $c) use ($docblock) {
-            return function () use ($docblock) {
-                return $docblock;
-            };
-        });
+        $container->extend(
+            'reader.annotations',
+            function (Closure $reader, Container $c) use ($docblock): Closure {
+                return function () use ($docblock): string {
+                    return $docblock;
+                };
+            }
+        );
 
-        $container->extend('reader.annotations.representation', function ($reader, Container $c) use ($docblock) {
-            return function () use ($docblock) {
-                return $docblock;
-            };
-        });
+        $container->extend(
+            'reader.annotations.representation',
+            function (Closure $reader, Container $c) use ($docblock): Closure {
+                return function () use ($docblock): string {
+                    return $docblock;
+                };
+            }
+        );
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,27 +5,25 @@ use League\Flysystem\Filesystem;
 use League\Flysystem\Memory\MemoryAdapter;
 use Mill\Config;
 use Mill\Container;
+use Mill\Exceptions\BaseException;
 use Mill\Parser;
 use Mill\Parser\Annotations\DataAnnotation;
 use Mill\Parser\Representation\RepresentationParser;
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-    /**
-     * @var Container
-     */
+    /** @var Container */
     protected static $container;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected static $fixturesDir = __DIR__ . '/../tests/_fixtures/';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected static $resourcesDir = __DIR__ . '/../resources/';
 
+    /**
+     * @psalm-suppress MissingReturnType
+     */
     public static function setUpBeforeClass()
     {
         parent::setUpBeforeClass();
@@ -35,9 +33,12 @@ class TestCase extends \PHPUnit\Framework\TestCase
         ]);
 
         // Overwrite the stock library local filesystem with an in-memory file system we'll use for testing.
-        $container->extend('filesystem', function ($filesystem, Container $c) {
-            return new Filesystem(new MemoryAdapter);
-        });
+        $container->extend(
+            'filesystem',
+            function (Filesystem $filesystem, Container $c): Filesystem {
+                return new Filesystem(new MemoryAdapter);
+            }
+        );
 
         $config = file_get_contents(static::$fixturesDir . 'mill.test.xml');
         $container->getFilesystem()->write('mill.xml', $config);
@@ -50,7 +51,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
      *
      * @return Container
      */
-    public function getContainer()
+    public function getContainer(): Container
     {
         return self::$container;
     }
@@ -60,7 +61,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
      *
      * @return Config
      */
-    public function getConfig()
+    public function getConfig(): Config
     {
         return $this->getContainer()->getConfig();
     }
@@ -70,7 +71,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
      *
      * @return Filesystem
      */
-    public function getFilesystem()
+    public function getFilesystem(): Filesystem
     {
         return $this->getContainer()->getFilesystem();
     }
@@ -82,25 +83,25 @@ class TestCase extends \PHPUnit\Framework\TestCase
      * @param string $class
      * @return DataAnnotation
      */
-    protected function getDataAnnotationFromDocblock($docblock, $class)
+    protected function getDataAnnotationFromDocblock(string $docblock, string $class): DataAnnotation
     {
         $tags = Parser::getAnnotationsFromDocblock($docblock)->getTags()->toArray();
-        $annotations = (new RepresentationParser($class))->parseAnnotations($tags, $docblock);
+
+        $parser = new RepresentationParser($class);
+        $parser->setMethod(__METHOD__);
+        $annotations = $parser->parseAnnotations($tags, $docblock);
 
         $this->assertCount(1, $annotations);
 
         return array_shift($annotations);
     }
 
-    /**
-     * @param mixed $exception
-     * @param string $class
-     * @param string|null $method
-     * @param array $asserts
-     * @return void
-     */
-    protected function assertExceptionAsserts($exception, $class, $method, $asserts = [])
-    {
+    protected function assertExceptionAsserts(
+        BaseException $exception,
+        string $class,
+        ?string $method,
+        array $asserts = []
+    ): void {
         $this->assertSame($class, $exception->getClass());
 
         // `@api-data` annotation tests don't set up a RepresentationParser with a method, so we don't need to worry

--- a/tests/_fixtures/AnnotationStub.php
+++ b/tests/_fixtures/AnnotationStub.php
@@ -9,24 +9,22 @@ class AnnotationStub extends Annotation
     const SUPPORTS_VERSIONING = false;
     const SUPPORTS_DEPRECATION = false;
 
-    /**
-     * @var null
-     */
+    /** @var null|string */
     protected $test = null;
 
-    protected function parser()
+    protected function parser(): array
     {
         return [
             'foo' => $this->docblock
         ];
     }
 
-    protected function interpreter()
+    protected function interpreter(): void
     {
         $this->test = $this->required('test');
     }
 
-    public function toArray()
+    public function toArray(): array
     {
         return [
             'test' => $this->test

--- a/tests/_fixtures/Representations/RepresentationWithMultipleLabelAnnotations.php
+++ b/tests/_fixtures/Representations/RepresentationWithMultipleLabelAnnotations.php
@@ -7,7 +7,7 @@ namespace Mill\Tests\Fixtures\Representations;
  */
 class RepresentationWithMultipleLabelAnnotations
 {
-    public function create()
+    public function create(): array
     {
         return [
             /**

--- a/tests/_fixtures/Representations/RepresentationWithNoAnnotations.php
+++ b/tests/_fixtures/Representations/RepresentationWithNoAnnotations.php
@@ -6,7 +6,7 @@ namespace Mill\Tests\Fixtures\Representations;
  */
 class RepresentationWithNoAnnotations
 {
-    public function create()
+    public function create(): void
     {
         //
     }

--- a/tests/_fixtures/Representations/RepresentationWithNoClassAnnotations.php
+++ b/tests/_fixtures/Representations/RepresentationWithNoClassAnnotations.php
@@ -6,7 +6,7 @@ namespace Mill\Tests\Fixtures\Representations;
  */
 class RepresentationWithNoClassAnnotations
 {
-    public function create()
+    public function create(): void
     {
         //
     }

--- a/tests/_fixtures/Representations/RepresentationWithOnlyApiSee.php
+++ b/tests/_fixtures/Representations/RepresentationWithOnlyApiSee.php
@@ -8,7 +8,7 @@ use Mill\Examples\Showtimes\Representations\Movie;
  */
 class RepresentationWithOnlyApiSee
 {
-    public function create()
+    public function create(): Movie
     {
         /**
          * @api-see \Mill\Examples\Showtimes\Representations\Movie::create

--- a/tests/_fixtures/Representations/RepresentationWithRequiredLabelAnnotationMissing.php
+++ b/tests/_fixtures/Representations/RepresentationWithRequiredLabelAnnotationMissing.php
@@ -7,7 +7,7 @@ namespace Mill\Tests\Fixtures\Representations;
  */
 class RepresentationWithRequiredLabelAnnotationMissing
 {
-    public function create()
+    public function create(): array
     {
         return [
             /**

--- a/tests/_fixtures/Representations/RepresentationWithVersioningAcrossMultipleAnnotations.php
+++ b/tests/_fixtures/Representations/RepresentationWithVersioningAcrossMultipleAnnotations.php
@@ -6,7 +6,7 @@ namespace Mill\Tests\Fixtures\Representations;
  */
 class RepresentationWithVersioningAcrossMultipleAnnotations
 {
-    public function create()
+    public function create(): void
     {
         /**
          * @api-data unrelated (string) - An piece of data unrelated to the connections.
@@ -24,7 +24,7 @@ class RepresentationWithVersioningAcrossMultipleAnnotations
          */
     }
 
-    public function someMethod()
+    public function someMethod(): void
     {
         /**
          * @api-data uri (uri) - URI that resolves to the connection data.


### PR DESCRIPTION
PHP 7 typehinting everything.

Also moved all Mill exceptions to extend off a `Mill\Exceptions\BaseException` object. Doing this now instead of including an exception trait on all exceptions so we can assert that Mill exceptions are Mill exceptions and not something else.