### PR TITLE
Renaming URI annotation "groups" to "namespaces".

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -53,7 +53,7 @@
                                 <xs:sequence>
                                     <xs:element name="exclude" minOccurs="1" maxOccurs="unbounded">
                                         <xs:complexType>
-                                            <xs:attribute name="group" type="xs:string" use="required" />
+                                            <xs:attribute name="namespace" type="xs:string" use="required" />
                                         </xs:complexType>
                                     </xs:element>
                                 </xs:sequence>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -178,9 +178,9 @@ These settings let you control the documentation generators that Mill supports f
 
 #### API Blueprint
 ##### Excludes
-* Use `<exclude>` elements to specify a resource group that should be excluded from API Blueprint generation and
+* Use `<exclude>` elements to specify a resource namespace that should be excluded from API Blueprint generation and
     compilation.
-    * Make sure to add a `group` attribute so Mill knows what group you're excluding..
+    * Make sure to add a `namespace` attribute so Mill knows what namespace you're excluding..
 
 Example:
 
@@ -188,8 +188,8 @@ Example:
 <generators>
     <blueprint>
         <excludes>
-            <exclude group="/" />
-            <exclude group="OAuth" />
+            <exclude namespace="/" />
+            <exclude namespace="OAuth" />
         </excludes>
     </blueprint>
 </generators>

--- a/docs/generate/changelogs.md
+++ b/docs/generate/changelogs.md
@@ -95,4 +95,4 @@ want to render it:
 | Resource action method | `mill-changelog_method` | `data-mill-method` |
 | Resource action parameter| `mill-changelog_parameter` | `data-mill-parameter` |
 | Resource action URI | `mill-changelog_uri` | `data-mill-uri` |
-| Resource group names | `mill-changelog_resource_group` | `data-mill-resource-group` |
+| Resource namespaces | `mill-changelog_resource_namespace` | `data-mill-resource-namespace` |

--- a/docs/reference/api-uri.md
+++ b/docs/reference/api-uri.md
@@ -11,7 +11,7 @@ This allows you to describe the URI(s) that a resource action services.
 
 ## Syntax
 ```php
-@api-uri:visibility {group} uri
+@api-uri:visibility {namespace} uri
 ```
 
 ## Requirements
@@ -24,7 +24,7 @@ This allows you to describe the URI(s) that a resource action services.
 
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
-| `{group}` | × | A group which this action lives under. This is used for grouping your documentation into like groups (like having your user actions grouped under `User`). It also allows you to do sub grouping with `Group\Subgroup`, if you wish. There is no limit to the amount of group depths a URI can be in. |
+| `{namespace}` | × | A namespace which this action lives under. This is used for grouping your documentation into like groups (like having your user actions grouped under `User`). It also allows you to do sub-grouping with `Namespace\Secondary Namespace`, if you wish. There is no limit to the amount of depths a URI can be in. |
 | `uri` | × | This is the URI that the resource action services. It's recommended that these conform to [RFC 3986](https://tools.ietf.org/html/rfc3986) and [RFC 6570](https://tools.ietf.org/html/rfc6570). |
 
 ## Examples

--- a/src/Command/Generate.php
+++ b/src/Command/Generate.php
@@ -114,18 +114,18 @@ class Generate extends Application
             // Process resource groups.
             if (isset($section['groups'])) {
                 $progress->setMessage('Processing resources…');
-                foreach ($section['groups'] as $group => $markdown) {
+                foreach ($section['groups'] as $namespace => $markdown) {
                     $progress->advance();
 
                     if ($dry_run) {
                         continue;
                     }
 
-                    // Convert any nested group names, like `Me\Videos`, into a proper directory structure: `Me/Videos`.
-                    $group = str_replace('\\', self::DS, $group);
+                    // Convert any nested namespaces, like `Me\Videos`, into a proper directory structure: `Me/Videos`.
+                    $namespace = str_replace('\\', self::DS, $namespace);
 
                     $filesystem->put(
-                        $version_dir . 'resources' . self::DS . $group . '.apib',
+                        $version_dir . 'resources' . self::DS . $namespace . '.apib',
                         trim($markdown)
                     );
                 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -121,11 +121,11 @@ class Config
     protected $parameter_tokens = [];
 
     /**
-     * Array of API Blueprint generator resource group excludes.
+     * Array of API Blueprint generator resource namespace excludes.
      *
      * @var array
      */
-    protected $blueprint_group_excludes = [];
+    protected $blueprint_namespace_excludes = [];
 
     /**
      * Create a new configuration object from a given config file.
@@ -338,45 +338,44 @@ class Config
             if (isset($generators->blueprint->excludes)) {
                 /** @var SimpleXMLElement $exclude */
                 foreach ($generators->blueprint->excludes->exclude as $exclude) {
-                    $group = trim((string) $exclude['group']);
+                    $namespace = trim((string) $exclude['namespace']);
 
-                    $this->addBlueprintGroupExclude($group);
+                    $this->addBlueprintNamespaceExclude($namespace);
                 }
             }
         }
     }
 
     /**
-     * Add a new API Blueprint resource group generator exclusion.
+     * Add a new API Blueprint resource namespace generator exclusion.
      *
-     * @param string $group
-     * @throws DomainException If an invalid Blueprint generator group exclude was detected.
+     * @param string $namespace
+     * @throws DomainException If an invalid Blueprint generator namespace exclude was detected.
      */
-    public function addBlueprintGroupExclude(string $group): void
+    public function addBlueprintNamespaceExclude(string $namespace): void
     {
-        if (empty($group)) {
+        if (empty($namespace)) {
             throw new DomainException(
-                'An invalid Blueprint generator group exclude was supplied in the Mill `generators` ' .
-                    'section.'
+                'An invalid Blueprint generator namespace exclude was supplied in the Mill `generators` section.'
             );
         }
 
-        $this->blueprint_group_excludes[] = $group;
+        $this->blueprint_namespace_excludes[] = $namespace;
     }
 
     /**
-     * Remove a currently configured API Blueprint resource group generator exclusion.
+     * Remove a currently configured API Blueprint resource namespace generator exclusion.
      *
-     * @param string $group
+     * @param string $namespace
      */
-    public function removeBlueprintGroupExclude(string $group): void
+    public function removeBlueprintNamespaceExclude(string $namespace): void
     {
-        $excludes = array_flip($this->blueprint_group_excludes);
-        if (isset($excludes[$group])) {
-            unset($excludes[$group]);
+        $excludes = array_flip($this->blueprint_namespace_excludes);
+        if (isset($excludes[$namespace])) {
+            unset($excludes[$namespace]);
         }
 
-        $this->blueprint_group_excludes = array_flip($excludes);
+        $this->blueprint_namespace_excludes = array_flip($excludes);
     }
 
     /**
@@ -825,13 +824,13 @@ class Config
     }
 
     /**
-     * Get the array of configured API Blueprint resource group excludes.
+     * Get the array of configured API Blueprint resource namespace excludes.
      *
      * @return array
      */
-    public function getBlueprintGroupExcludes(): array
+    public function getBlueprintNamespaceExcludes(): array
     {
-        return $this->blueprint_group_excludes;
+        return $this->blueprint_namespace_excludes;
     }
 
     /**

--- a/src/Generator/Blueprint.php
+++ b/src/Generator/Blueprint.php
@@ -31,24 +31,24 @@ class Blueprint extends Generator
     {
         parent::generate();
 
-        $group_excludes = $this->config->getBlueprintGroupExcludes();
+        $namespace_excludes = $this->config->getBlueprintNamespaceExcludes();
         $resources = $this->getResources();
 
         $blueprints = [];
 
         /** @var array $data */
-        foreach ($resources as $version => $groups) {
+        foreach ($resources as $version => $namespaces) {
             $this->version = $version;
             $this->representations = $this->getRepresentations($this->version);
 
             // Process resource groups.
-            foreach ($groups as $group_name => $data) {
-                // If this group has been designated in the config file to be excluded, then exclude it.
-                if (in_array($group_name, $group_excludes)) {
+            foreach ($namespaces as $namespace => $data) {
+                // If this namespace has been designated in the config file to be excluded, then exclude it.
+                if (in_array($namespace, $namespace_excludes)) {
                     continue;
                 }
 
-                $contents = sprintf('# Group %s', $group_name);
+                $contents = sprintf('# Group %s', $namespace);
                 $contents .= $this->line();
 
                 // Sort the resources so they're alphabetical.
@@ -124,7 +124,7 @@ class Blueprint extends Generator
                 }
 
                 $contents = trim($contents);
-                $blueprints[$this->version]['groups'][$group_name] = $contents;
+                $blueprints[$this->version]['groups'][$namespace] = $contents;
             }
 
             // Process representation data structures.

--- a/src/Generator/Changelog.php
+++ b/src/Generator/Changelog.php
@@ -162,7 +162,7 @@ class Changelog extends Generator
      */
     private function buildResourceChangelog(array $resources = []): void
     {
-        foreach ($resources as $group_name => $data) {
+        foreach ($resources as $namespace => $data) {
             foreach ($data['resources'] as $resource_name => $resource) {
                 /** @var Action\Documentation $action */
                 foreach ($resource['actions'] as $identifier => $action) {
@@ -174,9 +174,9 @@ class Changelog extends Generator
                             self::DEFINITION_ADDED,
                             $min_version,
                             self::CHANGESET_TYPE_ACTION,
-                            $group_name,
+                            $namespace,
                             [
-                                'resource_group' => $group_name,
+                                'resource_namespace' => $namespace,
                                 'method' => $action->getMethod(),
                                 'uri' => $action->getUri()->getCleanPath()
                             ]
@@ -192,9 +192,9 @@ class Changelog extends Generator
                                 self::DEFINITION_CHANGED,
                                 $introduced,
                                 self::CHANGESET_TYPE_CONTENT_TYPE,
-                                $group_name,
+                                $namespace,
                                 [
-                                    'resource_group' => $group_name,
+                                    'resource_namespace' => $namespace,
                                     'method' => $action->getMethod(),
                                     'uri' => $action->getUri()->getCleanPath(),
                                     'content_type' => $content_type->getContentType()
@@ -218,7 +218,7 @@ class Changelog extends Generator
                             }
 
                             $data = [
-                                'resource_group' => $group_name,
+                                'resource_namespace' => $namespace,
                                 'method' => $action->getMethod(),
                                 'uri' => $action->getUri()->getCleanPath()
                             ];
@@ -264,7 +264,7 @@ class Changelog extends Generator
                                     self::DEFINITION_ADDED,
                                     $introduced,
                                     $change_type,
-                                    $group_name,
+                                    $namespace,
                                     $data
                                 );
                             }
@@ -274,7 +274,7 @@ class Changelog extends Generator
                                     self::DEFINITION_REMOVED,
                                     $removed,
                                     $change_type,
-                                    $group_name,
+                                    $namespace,
                                     $data
                                 );
                             }
@@ -291,7 +291,7 @@ class Changelog extends Generator
      * @param string $definition
      * @param false|string $version
      * @param string $change_type
-     * @param null|string $group
+     * @param null|string $namespace
      * @param array $data
      * @return self
      */
@@ -299,21 +299,22 @@ class Changelog extends Generator
         string $definition,
         $version,
         string $change_type,
-        string $group = null,
+        string $namespace = null,
         array $data = []
     ): self {
-        // Since groups can be nested, let's throw changes under the top-level group.
-        if (!is_null($group)) {
-            $group = explode('\\', $group);
-            $group = array_shift($group);
+        // Since namespaces can be nested, let's throw changes under the top-level namespace.
+        if (!is_null($namespace)) {
+            $namespace = explode('\\', $namespace);
+            $namespace = array_shift($namespace);
         }
 
         $hash = $this->hashChangeset($change_type, $data);
 
         if ($change_type === self::CHANGESET_TYPE_REPRESENTATION_DATA) {
-            $this->changelog[$version][$definition]['representations'][$group][$change_type][$hash][] = $data;
+            $this->changelog[$version][$definition]['representations'][$namespace][$change_type][$hash][] = $data;
         } else {
-            $this->changelog[$version][$definition]['resources'][$group][$data['uri']][$change_type][$hash][] = $data;
+            $this->changelog[$version][$definition]['resources'][$namespace][$data['uri']][$change_type][$hash][] =
+                $data;
         }
 
         return $this;

--- a/src/Generator/Changelog/Changesets/Action.php
+++ b/src/Generator/Changelog/Changesets/Action.php
@@ -44,7 +44,7 @@ class Action extends Changeset
             [
                 // Changes are grouped by URIs so it's safe to just pull the first URI here.
                 $this->renderText($template, [
-                    'resource_group' => $changes[0]['resource_group'],
+                    'resource_namespace' => $changes[0]['resource_namespace'],
                     'uri' => $changes[0]['uri']
                 ]),
                 $methods

--- a/src/Generator/Changelog/Changesets/ActionParam.php
+++ b/src/Generator/Changelog/Changesets/ActionParam.php
@@ -56,7 +56,7 @@ class ActionParam extends Changeset
                 $template = $templates['plural'][$definition];
                 $entry[] = [
                     $this->renderText($template, [
-                        'resource_group' => $changes[0]['resource_group'],
+                        'resource_namespace' => $changes[0]['resource_namespace'],
                         'method' => $method,
                         'uri' => $changes[0]['uri']
                     ]),
@@ -68,7 +68,7 @@ class ActionParam extends Changeset
 
             $template = $templates['singular'][$definition];
             $entry[] = $this->renderText($template, [
-                'resource_group' => $changes[0]['resource_group'],
+                'resource_namespace' => $changes[0]['resource_namespace'],
                 'parameter' => array_shift($params),
                 'method' => $method,
                 'uri' => $changes[0]['uri']

--- a/src/Generator/Changelog/Changesets/ActionReturn.php
+++ b/src/Generator/Changelog/Changesets/ActionReturn.php
@@ -72,7 +72,7 @@ class ActionReturn extends Changeset
                 $template = $templates['plural'][$definition];
                 $entries[] = [
                     $this->renderText($template, [
-                        'resource_group' => $changes[0]['resource_group'],
+                        'resource_namespace' => $changes[0]['resource_namespace'],
                         'method' => $method,
                         'uri' => $changes[0]['uri']
                     ]),

--- a/src/Generator/Changelog/Changesets/ActionThrows.php
+++ b/src/Generator/Changelog/Changesets/ActionThrows.php
@@ -59,7 +59,7 @@ class ActionThrows extends Changeset
                 $template = $templates['plural'][$definition];
                 $entries[] = [
                     $this->renderText($template, [
-                        'resource_group' => $change['resource_group'],
+                        'resource_namespace' => $change['resource_namespace'],
                         'method' => $method,
                         'uri' => $change['uri']
                     ]),

--- a/src/Generator/Changelog/Formats/Json.php
+++ b/src/Generator/Changelog/Formats/Json.php
@@ -106,12 +106,12 @@ class Json extends Generator
     private function parseResourceChangesets(string $definition, array $changesets = []): array
     {
         $entries = [];
-        foreach ($changesets as $group => $data) {
-            $group_entry = [
-                $this->renderText('The following {resource_group} resources have ' . $definition . ':', [
-                    'resource_group' => $group
+        foreach ($changesets as $namespace => $data) {
+            $namespace_entry = [
+                $this->renderText('The following {resource_namespace} resources have ' . $definition . ':', [
+                    'resource_namespace' => $namespace
                 ]),
-                [] // Group-related entries will be nested here.
+                [] // Namespace-related entries will be nested here.
             ];
 
             foreach ($data as $uri => $change_types) {
@@ -131,12 +131,12 @@ class Json extends Generator
                             $entry = array_shift($entry);
                         }
 
-                        $group_entry[1][] = $entry;
+                        $namespace_entry[1][] = $entry;
                     }
                 }
             }
 
-            $entries[] = $group_entry;
+            $entries[] = $namespace_entry;
         }
 
         return $entries;

--- a/src/Generator/ErrorMap.php
+++ b/src/Generator/ErrorMap.php
@@ -28,12 +28,12 @@ class ErrorMap extends Generator
         parent::generate();
 
         foreach ($this->getResources() as $version => $resources) {
-            foreach ($resources as $group_name => $data) {
-                // Groups can have children via the `\` delimiter, but for the error map generator we only care about
-                // the top-level group name.
-                if (strpos($group_name, '\\') != false) {
-                    $parts = explode('\\', $group_name);
-                    $group_name = array_shift($parts);
+            foreach ($resources as $namespace => $data) {
+                // Namespaces can have children via the `\` delimiter, but for the error map generator we only care
+                // about the top-level namespace.
+                if (strpos($namespace, '\\') != false) {
+                    $parts = explode('\\', $namespace);
+                    $namespace = array_shift($parts);
                 }
 
                 foreach ($data['resources'] as $resource_name => $resource) {
@@ -51,7 +51,7 @@ class ErrorMap extends Generator
                             }
 
                             $uri = $action->getUri();
-                            $this->error_map[$version][$group_name][$error_code][] = [
+                            $this->error_map[$version][$namespace][$error_code][] = [
                                 'uri' => $uri->getCleanPath(),
                                 'method' => $action->getMethod(),
                                 'http_code' => $response->getHttpCode(),
@@ -65,10 +65,10 @@ class ErrorMap extends Generator
         }
 
         // Keep things tidy
-        foreach ($this->error_map as $version => $groups) {
-            foreach ($groups as $group => $resources) {
+        foreach ($this->error_map as $version => $namespaces) {
+            foreach ($namespaces as $namespace => $resources) {
                 foreach ($resources as $identifier => $errors) {
-                    usort($this->error_map[$version][$group][$identifier], function (array $a, array $b): int {
+                    usort($this->error_map[$version][$namespace][$identifier], function (array $a, array $b): int {
                         // If the error codes match, then fallback to sorting by the URI.
                         if ($a['error_code'] == $b['error_code']) {
                             // If the URIs match, then fallback to sorting by their methods.
@@ -83,7 +83,7 @@ class ErrorMap extends Generator
                     });
                 }
 
-                ksort($this->error_map[$version][$group]);
+                ksort($this->error_map[$version][$namespace]);
             }
         }
 

--- a/src/Generator/ErrorMap/Formats/Markdown.php
+++ b/src/Generator/ErrorMap/Formats/Markdown.php
@@ -42,7 +42,7 @@ class Markdown extends Generator
     {
         $markdown = [];
 
-        foreach ($this->error_map as $version => $groups) {
+        foreach ($this->error_map as $version => $namespaces) {
             $content = '';
 
             $api_name = $this->config->getName();
@@ -54,8 +54,8 @@ class Markdown extends Generator
                 $content .= $this->line(2);
             }
 
-            foreach ($groups as $group => $actions) {
-                $content .= sprintf('## %s', $group);
+            foreach ($namespaces as $namespace => $actions) {
+                $content .= sprintf('## %s', $namespace);
                 $content .= $this->line(1);
 
                 $content .= '| Error Code | URI | Method | HTTP Code | Description |';

--- a/src/Generator/Traits/ChangelogTemplate.php
+++ b/src/Generator/Traits/ChangelogTemplate.php
@@ -71,12 +71,11 @@ trait ChangelogTemplate
             switch ($key) {
                 case 'content_type':
                 case 'field':
-                case 'group':
                 case 'http_code':
                 case 'method':
                 case 'parameter':
                 case 'representation':
-                case 'resource_group':
+                case 'resource_namespace':
                 case 'uri':
                     $searches[] = '{' . $key . '}';
                     if (is_array($value)) {

--- a/src/Parser/Annotations/UriAnnotation.php
+++ b/src/Parser/Annotations/UriAnnotation.php
@@ -15,14 +15,14 @@ class UriAnnotation extends Annotation
     const SUPPORTS_ALIASING = true;
     const SUPPORTS_DEPRECATION = true;
 
-    const GROUP_REGEX = '/{([\w\/\\\ ]+)}/';
+    const NAMESPACE_REGEX = '/{([\w\/\\\ ]+)}/';
 
     /**
-     * Group that this URI belongs to.
+     * Namespace that this URI belongs to.
      *
      * @var string
      */
-    protected $group;
+    protected $namespace;
 
     /**
      * URI path that this annotation represents.
@@ -37,7 +37,7 @@ class UriAnnotation extends Annotation
      * @var array
      */
     protected $arrayable = [
-        'group',
+        'namespace',
         'path'
     ];
 
@@ -52,10 +52,10 @@ class UriAnnotation extends Annotation
         $parsed = [];
         $content = $this->docblock;
 
-        // Group is surrounded by `{curly braces}`.
-        if (preg_match(self::GROUP_REGEX, $content, $matches)) {
-            $parsed['group'] = $matches[1];
-            $content = trim(preg_replace(self::GROUP_REGEX, '', $content));
+        // Namespace is surrounded by `{curly braces}`.
+        if (preg_match(self::NAMESPACE_REGEX, $content, $matches)) {
+            $parsed['namespace'] = $matches[1];
+            $content = trim(preg_replace(self::NAMESPACE_REGEX, '', $content));
         }
 
         $parsed['path'] = trim($content);
@@ -73,7 +73,7 @@ class UriAnnotation extends Annotation
      */
     protected function interpreter(): void
     {
-        $this->group = $this->required('group');
+        $this->namespace = $this->required('namespace');
         $this->path = $this->required('path');
     }
 
@@ -88,31 +88,31 @@ class UriAnnotation extends Annotation
     {
         /** @var UriAnnotation $annotation */
         $annotation = parent::hydrate($data, $version);
-        $annotation->setGroup($data['group']);
+        $annotation->setNamespace($data['namespace']);
         $annotation->setPath($data['path']);
 
         return $annotation;
     }
 
     /**
-     * Get the group that this URI belongs to.
+     * Get the namespace that this URI belongs to.
      *
      * @return string
      */
-    public function getGroup(): string
+    public function getNamespace(): string
     {
-        return $this->group;
+        return $this->namespace;
     }
 
     /**
-     * Set the group that this URI belongs to.
+     * Set the namespace that this URI belongs to.
      *
-     * @param string $group
+     * @param string $namespace
      * @return self
      */
-    public function setGroup(string $group): self
+    public function setNamespace(string $namespace): self
     {
-        $this->group = $group;
+        $this->namespace = $namespace;
         return $this;
     }
 

--- a/src/Parser/Resource/Action/Documentation.php
+++ b/src/Parser/Resource/Action/Documentation.php
@@ -361,10 +361,10 @@ class Documentation
     }
 
     /**
-     * Set the lone URI that this action runs under for a specific group.
+     * Set the lone URI that this action runs under for a specific namespace.
      *
-     * This is used in the Compiler system when grouping actions under groups. If an action runs on the `Me\Videos`
-     * and `Users\Videos` groups, we don't want the action in the `Me\Videos` group to have actions with
+     * This is used in the Compiler system when grouping actions under namespaces. If an action runs on the `Me\Videos`
+     * and `Users\Videos` namespaces, we don't want the action in the `Me\Videos` namespace to have actions with
      * `Users\Videos` URIs.
      *
      * @param UriAnnotation $uri
@@ -387,7 +387,7 @@ class Documentation
     /**
      * Set the URI segments that this action has.
      *
-     * This is used in the Compiler system when grouping actions under groups. If an action broadcasts on
+     * This is used in the Compiler system when grouping actions under namespaces. If an action broadcasts on
      * `/me/videos` and `/users/:id/videos`, we don't want the URI segments for `/users/:id/videos` to be a part of the
      * compiled `/me/videos` action.
      *

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -44,8 +44,8 @@ class ConfigTest extends TestCase
         ], $config->getApiVersions());
 
         $this->assertSame([
-            'FakeExcludeGroup'
-        ], $config->getBlueprintGroupExcludes());
+            'FakeExcludeNamespace'
+        ], $config->getBlueprintNamespaceExcludes());
 
         $this->assertSame([
             'BUY_TICKETS',
@@ -282,13 +282,13 @@ XML
             'generators.blueprint.exclude.invalid' => [
                 'includes' => ['versions', 'controllers', 'representations'],
                 'exception' => [
-                    'regex' => '/invalid Blueprint generator group/'
+                    'regex' => '/invalid Blueprint generator namespace/'
                 ],
                 'xml' => <<<XML
 <generators>
     <blueprint>
         <excludes>
-            <exclude group="" />
+            <exclude namespace="" />
         </excludes>
     </blueprint>
 </generators>

--- a/tests/Generator/BlueprintTest.php
+++ b/tests/Generator/BlueprintTest.php
@@ -50,7 +50,7 @@ class BlueprintTest extends TestCase
 
     public function testGenerationWithAnExcludedGroup(): void
     {
-        $this->getConfig()->addBlueprintGroupExclude('Movies');
+        $this->getConfig()->addBlueprintNamespaceExclude('Movies');
 
         $blueprint = new Blueprint($this->getConfig());
         $generated = $blueprint->generate();
@@ -68,6 +68,6 @@ class BlueprintTest extends TestCase
             $this->assertArrayHasKey('Theaters', $section['groups']);
         }
 
-        $this->getConfig()->removeBlueprintGroupExclude('Movies');
+        $this->getConfig()->removeBlueprintNamespaceExclude('Movies');
     }
 }

--- a/tests/Generator/Changelog/Formats/JsonTest.php
+++ b/tests/Generator/Changelog/Formats/JsonTest.php
@@ -31,112 +31,113 @@ class JsonTest extends TestCase
             'added' => [
                 'resources' => [
                     [
-                        'The following <span class="mill-changelog_resource_group" ' .
-                            'data-mill-resource-group="Movies">Movies</span> resources have added:',
+                        'The following <span class="mill-changelog_resource_namespace" ' .
+                            'data-mill-resource-namespace="Movies">Movies</span> resources have added:',
                         [
                             [
-                                '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                '<span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                     'data-mill-method="GET" data-mill-uri="/movie/{id}">/movie/{id}</span> will now ' .
                                     'throw the following errors on <span class="mill-changelog_method" ' .
-                                    'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                    'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                     'data-mill-uri="/movie/{id}">GET</span> requests:',
                                 [
-                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
                                         'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
                                         'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                        'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                         'data-mill-uri="/movie/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: For no reason.',
-                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
                                         'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
                                         'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                        'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                         'data-mill-uri="/movie/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: For some ' .
                                         'other reason.'
                                 ]
                             ],
                             [
-                                '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                '<span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                     'data-mill-method="GET" data-mill-uri="/movies/{id}">/movies/{id}</span> will ' .
                                     'now throw the following errors on <span class="mill-changelog_method" ' .
-                                    'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                    'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                     'data-mill-uri="/movies/{id}">GET</span> requests:',
                                 [
-                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
                                         'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
                                         'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                        'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                         'data-mill-uri="/movies/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: For no reason.',
-                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
                                         'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
                                         'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                        'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                         'data-mill-uri="/movies/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: For some ' .
                                         'other reason.'
                                 ]
                             ],
                             [
-                                '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                '<span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                     'data-mill-method="PATCH" data-mill-uri="/movies/{id}">/movies/{id}</span> will ' .
                                     'now throw the following errors on <span class="mill-changelog_method" ' .
-                                    'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
+                                    'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
                                     'data-mill-uri="/movies/{id}">PATCH</span> requests:',
                                 [
-                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
                                         'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                         'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
+                                        'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
                                         'data-mill-uri="/movies/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: If the ' .
                                         'trailer URL could not be validated.',
-                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
                                         'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                         'data-mill-http-code="403 Forbidden" data-mill-representation="Coded error">' .
                                         '403 Forbidden</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
+                                        'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
                                         'data-mill-uri="/movies/{id}" data-mill-http-code="403 Forbidden" ' .
                                         'data-mill-representation="Coded error">Coded error</span> representation: ' .
                                         'If something cool happened.',
-                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
                                         'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                         'data-mill-http-code="403 Forbidden" data-mill-representation="Coded error">' .
                                         '403 Forbidden</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
+                                        'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
                                         'data-mill-uri="/movies/{id}" data-mill-http-code="403 Forbidden" ' .
                                         'data-mill-representation="Coded error">Coded error</span> representation: ' .
                                         'If the user is not allowed to edit that movie.'
                                 ]
                             ],
-                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-http-code="202 Accepted" data-mill-representation="Movie">/movies/{id}' .
-                                '</span>, <span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                '</span>, <span class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-http-code="202 Accepted" data-mill-representation="Movie">PATCH</span> ' .
                                 'requests now returns a <span class="mill-changelog_http_code" ' .
-                                'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
+                                'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/movies/{id}" data-mill-http-code="202 Accepted" ' .
                                 'data-mill-representation="Movie">202 Accepted</span> with a <span ' .
-                                'class="mill-changelog_representation" data-mill-resource-group="Movies" ' .
+                                'class="mill-changelog_representation" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-http-code="202 Accepted" data-mill-representation="Movie">Movie</span> ' .
                                 'representation.',
-                            '<span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                            '<span class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="POST" data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
                                 'data-mill-representation="">POST</span> on <span class="mill-changelog_uri" ' .
-                                'data-mill-resource-group="Movies" data-mill-method="POST" data-mill-uri="/movies" ' .
-                                'data-mill-http-code="201 Created" data-mill-representation="">/movies</span> now ' .
-                                'returns a <span class="mill-changelog_http_code" ' .
-                                'data-mill-resource-group="Movies" data-mill-method="POST" data-mill-uri="/movies" ' .
-                                'data-mill-http-code="201 Created" data-mill-representation="">201 Created</span>.'
+                                'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                'data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
+                                'data-mill-representation="">/movies</span> now returns a <span ' .
+                                'class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
+                                'data-mill-method="POST" data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
+                                'data-mill-representation="">201 Created</span>.'
                         ]
                     ]
                 ]
@@ -159,108 +160,108 @@ class JsonTest extends TestCase
             'changed' => [
                 'resources' => [
                     [
-                        'The following <span class="mill-changelog_resource_group" ' .
-                            'data-mill-resource-group="Movies">Movies</span> resources have changed:',
+                        'The following <span class="mill-changelog_resource_namespace" ' .
+                            'data-mill-resource-namespace="Movies">Movies</span> resources have changed:',
                         [
-                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">/movie/{id}</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">GET</span> requests will ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                 'data-mill-uri="/movie/{id}" data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">/movies/{id}</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">GET</span> requests will ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                 'data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">/movies/{id}</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">PATCH</span> requests will ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
+                                'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies" ' .
                                 'data-mill-content-type="application/mill.example.movie">/movies</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies" ' .
                                 'data-mill-content-type="application/mill.example.movie">GET</span> requests will ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-group="Movies" data-mill-method="GET" data-mill-uri="/movies" ' .
-                                'data-mill-content-type="application/mill.example.movie">' .
+                                'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                'data-mill-uri="/movies" data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="POST" data-mill-uri="/movies" ' .
                                 'data-mill-content-type="application/mill.example.movie">/movies</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                'class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="POST" data-mill-uri="/movies" ' .
                                 'data-mill-content-type="application/mill.example.movie">POST</span> requests will ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-group="Movies" data-mill-method="POST" data-mill-uri="/movies" ' .
-                                'data-mill-content-type="application/mill.example.movie">' .
+                                'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                'data-mill-uri="/movies" data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.'
                         ]
                     ],
                     [
-                        'The following <span class="mill-changelog_resource_group" ' .
-                            'data-mill-resource-group="Theaters">Theaters</span> resources have changed:',
+                        'The following <span class="mill-changelog_resource_namespace" ' .
+                            'data-mill-resource-namespace="Theaters">Theaters</span> resources have changed:',
                         [
-                            'On <span class="mill-changelog_uri" data-mill-resource-group="Theaters" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Theaters" ' .
                                 'data-mill-method="GET" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">/theaters/{id}</span>, ' .
-                                '<span class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
+                                '<span class="mill-changelog_method" data-mill-resource-namespace="Theaters" ' .
                                 'data-mill-method="GET" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">GET</span> requests will ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-group="Theaters" data-mill-method="GET" ' .
+                                'data-mill-resource-namespace="Theaters" data-mill-method="GET" ' .
                                 'data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">' .
                                 'application/mill.example.theater</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-group="Theaters" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Theaters" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">/theaters/{id}</span>, ' .
-                                '<span class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
+                                '<span class="mill-changelog_method" data-mill-resource-namespace="Theaters" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">PATCH</span> requests ' .
                                 'will return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-group="Theaters" data-mill-method="PATCH" ' .
+                                'data-mill-resource-namespace="Theaters" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">' .
                                 'application/mill.example.theater</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-group="Theaters" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Theaters" ' .
                                 'data-mill-method="GET" data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">/theaters</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
+                                'class="mill-changelog_method" data-mill-resource-namespace="Theaters" ' .
                                 'data-mill-method="GET" data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">GET</span> requests will ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-group="Theaters" data-mill-method="GET" ' .
+                                'data-mill-resource-namespace="Theaters" data-mill-method="GET" ' .
                                 'data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">' .
                                 'application/mill.example.theater</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-group="Theaters" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Theaters" ' .
                                 'data-mill-method="POST" data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">/theaters</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
+                                'class="mill-changelog_method" data-mill-resource-namespace="Theaters" ' .
                                 'data-mill-method="POST" data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">POST</span> requests ' .
                                 'will return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-group="Theaters" data-mill-method="POST" ' .
+                                'data-mill-resource-namespace="Theaters" data-mill-method="POST" ' .
                                 'data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">' .
                                 'application/mill.example.theater</span> Content-Type header.'
@@ -271,21 +272,21 @@ class JsonTest extends TestCase
             'removed' => [
                 'resources' => [
                     [
-                        'The following <span class="mill-changelog_resource_group" ' .
-                            'data-mill-resource-group="Theaters">Theaters</span> resources have removed:',
+                        'The following <span class="mill-changelog_resource_namespace" ' .
+                            'data-mill-resource-namespace="Theaters">Theaters</span> resources have removed:',
                         [
-                            '<span class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
+                            '<span class="mill-changelog_method" data-mill-resource-namespace="Theaters" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-http-code="403 Forbidden" data-mill-representation="Coded error">PATCH' .
                                 '</span> requests to <span class="mill-changelog_uri" ' .
-                                'data-mill-resource-group="Theaters" data-mill-method="PATCH" ' .
+                                'data-mill-resource-namespace="Theaters" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/theaters/{id}" data-mill-http-code="403 Forbidden" ' .
                                 'data-mill-representation="Coded error">/theaters/{id}</span> longer will return a ' .
-                                '<span class="mill-changelog_http_code" data-mill-resource-group="Theaters" ' .
+                                '<span class="mill-changelog_http_code" data-mill-resource-namespace="Theaters" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-http-code="403 Forbidden" data-mill-representation="Coded error">403 ' .
                                 'Forbidden</span> with a <span class="mill-changelog_representation" ' .
-                                'data-mill-resource-group="Theaters" data-mill-method="PATCH" ' .
+                                'data-mill-resource-namespace="Theaters" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/theaters/{id}" data-mill-http-code="403 Forbidden" ' .
                                 'data-mill-representation="Coded error">Coded error</span> representation: If ' .
                                 'something cool happened.'
@@ -303,15 +304,15 @@ class JsonTest extends TestCase
             'added' => [
                 'resources' => [
                     [
-                        'The following <span class="mill-changelog_resource_group" ' .
-                            'data-mill-resource-group="Movies">Movies</span> resources have added:',
+                        'The following <span class="mill-changelog_resource_namespace" ' .
+                            'data-mill-resource-namespace="Movies">Movies</span> resources have added:',
                         [
-                            'A <span class="mill-changelog_parameter" data-mill-resource-group="Movies" ' .
+                            'A <span class="mill-changelog_parameter" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" data-mill-parameter="imdb">' .
                                 'imdb</span> request parameter was added to <span class="mill-changelog_method" ' .
-                                'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
+                                'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/movies/{id}" data-mill-parameter="imdb">PATCH</span> on <span ' .
-                                'class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                'class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" data-mill-parameter="imdb">' .
                                 '/movies/{id}</span>.'
                         ]
@@ -345,32 +346,33 @@ class JsonTest extends TestCase
                 ],
                 'resources' => [
                     [
-                        'The following <span class="mill-changelog_resource_group" ' .
-                            'data-mill-resource-group="Movies">Movies</span> resources have added:',
+                        'The following <span class="mill-changelog_resource_namespace" ' .
+                            'data-mill-resource-namespace="Movies">Movies</span> resources have added:',
                         [
                             [
-                                '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                '<span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                     'data-mill-uri="/movies/{id}">/movies/{id}</span> has been added with support ' .
                                     'for the following HTTP methods:',
                                 [
-                                    '<span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                    '<span class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
                                         'data-mill-method="PATCH" data-mill-uri="/movies/{id}">PATCH</span>',
-                                    '<span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
+                                    '<span class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
                                         'data-mill-method="DELETE" data-mill-uri="/movies/{id}">DELETE</span>'
                                 ]
                             ],
-                            'A <span class="mill-changelog_parameter" data-mill-resource-group="Movies" ' .
+                            'A <span class="mill-changelog_parameter" data-mill-resource-namespace="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies" data-mill-parameter="page">page' .
                                 '</span> request parameter was added to <span class="mill-changelog_method" ' .
-                                'data-mill-resource-group="Movies" data-mill-method="GET" data-mill-uri="/movies" ' .
-                                'data-mill-parameter="page">GET</span> on <span class="mill-changelog_uri" ' .
-                                'data-mill-resource-group="Movies" data-mill-method="GET" data-mill-uri="/movies" ' .
-                                'data-mill-parameter="page">/movies</span>.',
+                                'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                'data-mill-uri="/movies" data-mill-parameter="page">GET</span> on <span ' .
+                                'class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                                'data-mill-method="GET" data-mill-uri="/movies" data-mill-parameter="page">' .
+                                '/movies</span>.',
                             [
                                 'The following parameters have been added to <span class="mill-changelog_method" ' .
-                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
                                     'data-mill-uri="/movies">POST</span> on <span class="mill-changelog_uri" ' .
-                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
                                     'data-mill-uri="/movies">/movies</span>:',
                                 [
                                     '<span class="mill-changelog_parameter" data-mill-parameter="imdb">imdb</span>',
@@ -422,14 +424,14 @@ class JsonTest extends TestCase
                                         Changelog::CHANGESET_TYPE_ACTION_RETURN => [
                                             'hashed-set.1' => [
                                                 [
-                                                    'resource_group' => 'Movies',
+                                                    'resource_namespace' => 'Movies',
                                                     'method' => 'POST',
                                                     'uri' => '/movies',
                                                     'http_code' => '201 Created',
                                                     'representation' => false
                                                 ],
                                                 [
-                                                    'resource_group' => 'Movies',
+                                                    'resource_namespace' => 'Movies',
                                                     'method' => 'POST',
                                                     'uri' => '/movies',
                                                     'http_code' => '200 OK',
@@ -438,7 +440,7 @@ class JsonTest extends TestCase
                                             ],
                                             'hashed-set.2' => [
                                                 [
-                                                    'resource_group' => 'Movies',
+                                                    'resource_namespace' => 'Movies',
                                                     'method' => 'GET',
                                                     'uri' => '/movies',
                                                     'http_code' => '200 OK',
@@ -457,44 +459,44 @@ class JsonTest extends TestCase
                         'added' => [
                             'resources' => [
                                 [
-                                    'The following <span class="mill-changelog_resource_group" ' .
-                                        'data-mill-resource-group="Movies">Movies</span> resources have added:',
+                                    'The following <span class="mill-changelog_resource_namespace" ' .
+                                        'data-mill-resource-namespace="Movies">Movies</span> resources have added:',
                                     [
                                         [
                                             'The <span class="mill-changelog_method" ' .
-                                                'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
                                                 'data-mill-uri="/movies">POST</span> on <span ' .
-                                                'class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                                'class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                                 'data-mill-method="POST" data-mill-uri="/movies">/movies</span> will ' .
                                                 'now return the following responses:',
                                             [
                                                 '<span class="mill-changelog_http_code" ' .
-                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
                                                     'data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
                                                     'data-mill-representation="">201 Created</span>',
                                                 '<span class="mill-changelog_http_code" ' .
-                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
                                                     'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                                     'data-mill-representation="Movie">200 OK</span> with a <span ' .
                                                     'class="mill-changelog_representation" ' .
-                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
                                                     'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                                     'data-mill-representation="Movie">Movie</span> representation'
                                             ]
                                         ],
-                                        'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                        'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                             'data-mill-method="GET" data-mill-uri="/movies" ' .
                                             'data-mill-http-code="200 OK" data-mill-representation="Movie">/movies' .
                                             '</span>, <span class="mill-changelog_method" ' .
-                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                            'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                             'data-mill-representation="Movie">GET</span> requests now returns a ' .
                                             '<span class="mill-changelog_http_code" ' .
-                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                            'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                             'data-mill-representation="Movie">200 OK</span> with a <span ' .
                                             'class="mill-changelog_representation" ' .
-                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                            'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                             'data-mill-representation="Movie">Movie</span> representation.'
                                     ]
@@ -514,14 +516,14 @@ class JsonTest extends TestCase
                                         Changelog::CHANGESET_TYPE_ACTION_RETURN => [
                                             'hashed-set.1' => [
                                                 [
-                                                    'resource_group' => 'Movies',
+                                                    'resource_namespace' => 'Movies',
                                                     'method' => 'POST',
                                                     'uri' => '/movies',
                                                     'http_code' => '201 Created',
                                                     'representation' => false
                                                 ],
                                                 [
-                                                    'resource_group' => 'Movies',
+                                                    'resource_namespace' => 'Movies',
                                                     'method' => 'POST',
                                                     'uri' => '/movies',
                                                     'http_code' => '200 OK',
@@ -530,7 +532,7 @@ class JsonTest extends TestCase
                                             ],
                                             'hashed-set.2' => [
                                                 [
-                                                    'resource_group' => 'Movies',
+                                                    'resource_namespace' => 'Movies',
                                                     'method' => 'GET',
                                                     'uri' => '/movies',
                                                     'http_code' => '200 OK',
@@ -549,44 +551,44 @@ class JsonTest extends TestCase
                         'removed' => [
                             'resources' => [
                                 [
-                                    'The following <span class="mill-changelog_resource_group" ' .
-                                        'data-mill-resource-group="Movies">Movies</span> resources have removed:',
+                                    'The following <span class="mill-changelog_resource_namespace" ' .
+                                        'data-mill-resource-namespace="Movies">Movies</span> resources have removed:',
                                     [
                                         [
                                             'The <span class="mill-changelog_method" ' .
-                                                'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
                                                 'data-mill-uri="/movies">POST</span> on <span ' .
-                                                'class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                                'class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                                 'data-mill-method="POST" data-mill-uri="/movies">/movies</span> no ' .
                                                 'longer returns the following responses:',
                                             [
                                                 '<span class="mill-changelog_http_code" ' .
-                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
                                                     'data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
                                                     'data-mill-representation="">201 Created</span>',
                                                 '<span class="mill-changelog_http_code" ' .
-                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
                                                     'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                                     'data-mill-representation="Movie">200 OK</span> with a <span ' .
                                                     'class="mill-changelog_representation" ' .
-                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
                                                     'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                                     'data-mill-representation="Movie">Movie</span> representation'
                                             ]
                                         ],
-                                        'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
+                                        'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
                                             'data-mill-method="GET" data-mill-uri="/movies" ' .
                                             'data-mill-http-code="200 OK" data-mill-representation="Movie">/movies' .
                                             '</span>, <span class="mill-changelog_method" ' .
-                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                            'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                             'data-mill-representation="Movie">GET</span> requests no longer returns ' .
                                             'a <span class="mill-changelog_http_code" ' .
-                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                            'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                             'data-mill-representation="Movie">200 OK</span> with a <span ' .
                                             'class="mill-changelog_representation" ' .
-                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
+                                            'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                             'data-mill-representation="Movie">Movie</span> representation.'
                                     ]

--- a/tests/Generator/ChangelogTest.php
+++ b/tests/Generator/ChangelogTest.php
@@ -64,7 +64,7 @@ class ChangelogTest extends TestCase
                     'throws' => [
                         '2e302f7f79' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movie/{id}',
                                 'http_code' => '404 Not Found',
@@ -72,7 +72,7 @@ class ChangelogTest extends TestCase
                                 'description' => 'For no reason.'
                             ],
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movie/{id}',
                                 'http_code' => '404 Not Found',
@@ -86,7 +86,7 @@ class ChangelogTest extends TestCase
                     'return' => [
                         '3781891d58' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'POST',
                                 'uri' => '/movies',
                                 'http_code' => '201 Created',
@@ -99,7 +99,7 @@ class ChangelogTest extends TestCase
                     'return' => [
                         '162944fa14' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '202 Accepted',
@@ -110,7 +110,7 @@ class ChangelogTest extends TestCase
                     'throws' => [
                         'e7dc298139' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '404 Not Found',
@@ -118,7 +118,7 @@ class ChangelogTest extends TestCase
                                 'description' => 'For no reason.'
                             ],
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '404 Not Found',
@@ -128,7 +128,7 @@ class ChangelogTest extends TestCase
                         ],
                         '162944fa14' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '404 Not Found',
@@ -136,7 +136,7 @@ class ChangelogTest extends TestCase
                                 'description' => 'If the trailer URL could not be validated.'
                             ],
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '403 Forbidden',
@@ -144,7 +144,7 @@ class ChangelogTest extends TestCase
                                 'description' => 'If something cool happened.'
                             ],
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '403 Forbidden',
@@ -160,7 +160,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movie/{id}',
                                 'content_type' => 'application/mill.example.movie'
@@ -172,7 +172,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies',
                                 'content_type' => 'application/mill.example.movie'
@@ -180,7 +180,7 @@ class ChangelogTest extends TestCase
                         ],
                         '066564ef49' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'POST',
                                 'uri' => '/movies',
                                 'content_type' => 'application/mill.example.movie'
@@ -192,7 +192,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies/{id}',
                                 'content_type' => 'application/mill.example.movie'
@@ -200,7 +200,7 @@ class ChangelogTest extends TestCase
                         ],
                         'f4628f751a' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'content_type' => 'application/mill.example.movie'
@@ -212,7 +212,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
-                                'resource_group' => 'Theaters',
+                                'resource_namespace' => 'Theaters',
                                 'method' => 'GET',
                                 'uri' => '/theaters',
                                 'content_type' => 'application/mill.example.theater'
@@ -220,7 +220,7 @@ class ChangelogTest extends TestCase
                         ],
                         '066564ef49' => [
                             [
-                                'resource_group' => 'Theaters',
+                                'resource_namespace' => 'Theaters',
                                 'method' => 'POST',
                                 'uri' => '/theaters',
                                 'content_type' => 'application/mill.example.theater'
@@ -232,7 +232,7 @@ class ChangelogTest extends TestCase
                     'action_throws' => [
                         'b3a16c4d74' => [
                             [
-                                'resource_group' => 'Theaters',
+                                'resource_namespace' => 'Theaters',
                                 'method' => 'PATCH',
                                 'uri' => '/theaters/{id}',
                                 'http_code' => '403 Forbidden',
@@ -244,7 +244,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
-                                'resource_group' => 'Theaters',
+                                'resource_namespace' => 'Theaters',
                                 'method' => 'GET',
                                 'uri' => '/theaters/{id}',
                                 'content_type' => 'application/mill.example.theater'
@@ -252,7 +252,7 @@ class ChangelogTest extends TestCase
                         ],
                         'f4628f751a' => [
                             [
-                                'resource_group' => 'Theaters',
+                                'resource_namespace' => 'Theaters',
                                 'method' => 'PATCH',
                                 'uri' => '/theaters/{id}',
                                 'content_type' => 'application/mill.example.theater'
@@ -266,7 +266,7 @@ class ChangelogTest extends TestCase
                     'param' => [
                         '162944fa14' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'parameter' => 'imdb',
@@ -281,7 +281,7 @@ class ChangelogTest extends TestCase
                     'param' => [
                         '776d02bb83' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies',
                                 'parameter' => 'page',
@@ -290,14 +290,14 @@ class ChangelogTest extends TestCase
                         ],
                         '3781891d58' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'POST',
                                 'uri' => '/movies',
                                 'parameter' => 'imdb',
                                 'description' => 'IMDB URL'
                             ],
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'POST',
                                 'uri' => '/movies',
                                 'parameter' => 'trailer',
@@ -310,12 +310,12 @@ class ChangelogTest extends TestCase
                     'action' => [
                         'd81e7058dd' => [
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}'
                             ],
                             [
-                                'resource_group' => 'Movies',
+                                'resource_namespace' => 'Movies',
                                 'method' => 'DELETE',
                                 'uri' => '/movies/{id}'
                             ]

--- a/tests/Parser/Annotations/UriAnnotationTest.php
+++ b/tests/Parser/Annotations/UriAnnotationTest.php
@@ -81,13 +81,13 @@ class UriAnnotationTest extends AnnotationTest
                         'aliased' => false,
                         'aliases' => [],
                         'deprecated' => false,
-                        'group' => 'Movies\Showtimes',
+                        'namespace' => 'Movies\Showtimes',
                         'path' => '/movies/+id/showtimes',
                         'visible' => false
                     ]
                 ]
             ],
-            'private.group_with_no_depth' => [
+            'private.namespace_with_no_depth' => [
                 'content' => '{Movies} /movies',
                 'visible' => false,
                 'deprecated' => false,
@@ -97,7 +97,7 @@ class UriAnnotationTest extends AnnotationTest
                         'aliased' => false,
                         'aliases' => [],
                         'deprecated' => false,
-                        'group' => 'Movies',
+                        'namespace' => 'Movies',
                         'path' => '/movies',
                         'visible' => false
                     ]
@@ -113,7 +113,7 @@ class UriAnnotationTest extends AnnotationTest
                         'aliased' => false,
                         'aliases' => [],
                         'deprecated' => false,
-                        'group' => 'Movies\Showtimes',
+                        'namespace' => 'Movies\Showtimes',
                         'path' => '/movies/+id/showtimes',
                         'visible' => true
                     ]
@@ -129,13 +129,13 @@ class UriAnnotationTest extends AnnotationTest
                         'aliased' => false,
                         'aliases' => [],
                         'deprecated' => true,
-                        'group' => 'Movies\Showtimes',
+                        'namespace' => 'Movies\Showtimes',
                         'path' => '/movies/+id/showtimes',
                         'visible' => true
                     ]
                 ]
             ],
-            'public.non-alphanumeric_group' => [
+            'public.non-alphanumeric_namespace' => [
                 'content' => '{/} /',
                 'visible' => true,
                 'deprecated' => false,
@@ -145,7 +145,7 @@ class UriAnnotationTest extends AnnotationTest
                         'aliased' => false,
                         'aliases' => [],
                         'deprecated' => false,
-                        'group' => '/',
+                        'namespace' => '/',
                         'path' => '/',
                         'visible' => true
                     ]
@@ -157,12 +157,12 @@ class UriAnnotationTest extends AnnotationTest
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [
-            'missing-group' => [
+            'missing-namespace' => [
                 'annotation' => UriAnnotation::class,
                 'content' => '',
                 'expected.exception' => MissingRequiredFieldException::class,
                 'expected.exception.asserts' => [
-                    'getRequiredField' => 'group',
+                    'getRequiredField' => 'namespace',
                     'getAnnotation' => 'uri',
                     'getDocblock' => '',
                     'getValues' => []

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -214,7 +214,7 @@ DESCRIPTION;
                                 'aliased' => true,
                                 'aliases' => [],
                                 'deprecated' => false,
-                                'group' => 'Movies',
+                                'namespace' => 'Movies',
                                 'path' => '/movie/+id',
                                 'visible' => false
                             ],
@@ -225,13 +225,13 @@ DESCRIPTION;
                                         'aliased' => true,
                                         'aliases' => [],
                                         'deprecated' => false,
-                                        'group' => 'Movies',
+                                        'namespace' => 'Movies',
                                         'path' => '/movie/+id',
                                         'visible' => false
                                     ]
                                 ],
                                 'deprecated' => false,
-                                'group' => 'Movies',
+                                'namespace' => 'Movies',
                                 'path' => '/movies/+id',
                                 'visible' => true
                             ]
@@ -329,7 +329,7 @@ DESCRIPTION;
                                 'aliased' => false,
                                 'aliases' => [],
                                 'deprecated' => false,
-                                'group' => 'Movies',
+                                'namespace' => 'Movies',
                                 'path' => '/movies/+id',
                                 'visible' => true
                             ]
@@ -612,7 +612,7 @@ DESCRIPTION;
                                 'aliased' => false,
                                 'aliases' => [],
                                 'deprecated' => false,
-                                'group' => 'Movies',
+                                'namespace' => 'Movies',
                                 'path' => '/movies/+id',
                                 'visible' => false
                             ]
@@ -691,13 +691,13 @@ DESCRIPTION;
                                         'aliased' => true,
                                         'aliases' => [],
                                         'deprecated' => false,
-                                        'group' => 'Foo\Bar',
+                                        'namespace' => 'Foo\Bar',
                                         'path' => '/bar',
                                         'visible' => false
                                     ]
                                 ],
                                 'deprecated' => false,
-                                'group' => 'Foo\Bar',
+                                'namespace' => 'Foo\Bar',
                                 'path' => '/foo',
                                 'visible' => true
                             ],
@@ -705,7 +705,7 @@ DESCRIPTION;
                                 'aliased' => true,
                                 'aliases' => [],
                                 'deprecated' => false,
-                                'group' => 'Foo\Bar',
+                                'namespace' => 'Foo\Bar',
                                 'path' => '/bar',
                                 'visible' => false
                             ]
@@ -734,7 +734,7 @@ DESCRIPTION;
                                 'aliased' => false,
                                 'aliases' => [],
                                 'deprecated' => false,
-                                'group' => 'Foo\Bar',
+                                'namespace' => 'Foo\Bar',
                                 'path' => '/foo',
                                 'visible' => true
                             ],
@@ -742,7 +742,7 @@ DESCRIPTION;
                                 'aliased' => false,
                                 'aliases' => [],
                                 'deprecated' => false,
-                                'group' => 'Foo\Bar',
+                                'namespace' => 'Foo\Bar',
                                 'path' => '/bar',
                                 'visible' => false
                             ]

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -17,8 +17,8 @@
         <blueprint>
             <excludes>
                 <!-- This is here just for code coverage purposes, and to verify that we're able to exclude resource
-                    groups when loading a config XML file. -->
-                <exclude group="FakeExcludeGroup" />
+                    namespaces when loading a config XML file. -->
+                <exclude namespace="FakeExcludeNamespace" />
             </excludes>
         </blueprint>
     </generators>


### PR DESCRIPTION
This renames `@api-uri` annotation "group" arguments to "namespaces". Referring to them as namespaces makes their purpose a lot clearer and easier to explain.

With this change, there are a few breaking config and changelog changes:

* [x] The `group` attribute in `<exclude>` elements has been renamed to `namespace`.
* [x] `resource-group` CSS classes on JSON-formatted changelog entries have been renamed to `resource-namespace`.

Resolves #128 