### PR TITLE
Minor updates to the changelog generator string templates.

### DIFF
--- a/resources/examples/Showtimes/blueprints/changelog-public-only-all-capabilities.md
+++ b/resources/examples/Showtimes/blueprints/changelog-public-only-all-capabilities.md
@@ -7,14 +7,14 @@ Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
 #### Added
 ##### Resources
 - The following Movies resources have added:
-    - `/movies/{id}` will now throw the following errors on `GET` requests:
+    - `/movies/{id}` now throws the following errors on `GET` requests:
         - `404 Not Found` with a `Error` representation: For no reason.
         - `404 Not Found` with a `Error` representation: For some other reason.
-    - `/movies/{id}` will now throw the following errors on `PATCH` requests:
+    - `/movies/{id}` now throws the following errors on `PATCH` requests:
         - `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
         - `403 Forbidden` with a `Coded error` representation: If something cool happened.
         - `403 Forbidden` with a `Coded error` representation: If the user is not allowed to edit that movie.
-    - On `/movies/{id}`, `PATCH` requests now returns a `202 Accepted` with a `Movie` representation.
+    - On `/movies/{id}`, `PATCH` requests now return a `202 Accepted` with a `Movie` representation.
     - `POST` on `/movies` now returns a `201 Created`.
 
 #### Removed
@@ -26,20 +26,20 @@ Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
 #### Changed
 ##### Resources
 - The following Movies resources have changed:
-    - On `/movies/{id}`, `GET` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies/{id}`, `PATCH` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies`, `GET` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies`, `POST` requests will return a `application/mill.example.movie` Content-Type header.
+    - On `/movies/{id}`, `GET` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies/{id}`, `PATCH` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies`, `GET` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies`, `POST` requests now return a `application/mill.example.movie` Content-Type header.
 - The following Theaters resources have changed:
-    - On `/theaters/{id}`, `GET` requests will return a `application/mill.example.theater` Content-Type header.
-    - On `/theaters/{id}`, `PATCH` requests will return a `application/mill.example.theater` Content-Type header.
-    - On `/theaters`, `GET` requests will return a `application/mill.example.theater` Content-Type header.
-    - On `/theaters`, `POST` requests will return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters/{id}`, `GET` requests now return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters/{id}`, `PATCH` requests now return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters`, `GET` requests now return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters`, `POST` requests now return a `application/mill.example.theater` Content-Type header.
 
 #### Removed
 ##### Resources
 - The following Theaters resources have removed:
-    - `PATCH` requests to `/theaters/{id}` longer will return a `403 Forbidden` with a `Coded error` representation: If something cool happened.
+    - `PATCH` requests to `/theaters/{id}` no longer returns a `403 Forbidden` with a `Coded error` representation: If something cool happened.
 
 ## 1.1.1 (2017-03-01)
 ### Reference

--- a/resources/examples/Showtimes/blueprints/changelog-public-only-matched-capabilities.md
+++ b/resources/examples/Showtimes/blueprints/changelog-public-only-matched-capabilities.md
@@ -7,14 +7,14 @@ Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
 #### Added
 ##### Resources
 - The following Movies resources have added:
-    - `/movies/{id}` will now throw the following errors on `GET` requests:
+    - `/movies/{id}` now throws the following errors on `GET` requests:
         - `404 Not Found` with a `Error` representation: For no reason.
         - `404 Not Found` with a `Error` representation: For some other reason.
-    - `/movies/{id}` will now throw the following errors on `PATCH` requests:
+    - `/movies/{id}` now throws the following errors on `PATCH` requests:
         - `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
         - `403 Forbidden` with a `Coded error` representation: If something cool happened.
         - `403 Forbidden` with a `Coded error` representation: If the user is not allowed to edit that movie.
-    - On `/movies/{id}`, `PATCH` requests now returns a `202 Accepted` with a `Movie` representation.
+    - On `/movies/{id}`, `PATCH` requests now return a `202 Accepted` with a `Movie` representation.
     - `POST` on `/movies` now returns a `201 Created`.
 
 #### Removed
@@ -26,20 +26,20 @@ Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
 #### Changed
 ##### Resources
 - The following Movies resources have changed:
-    - On `/movies/{id}`, `GET` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies/{id}`, `PATCH` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies`, `GET` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies`, `POST` requests will return a `application/mill.example.movie` Content-Type header.
+    - On `/movies/{id}`, `GET` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies/{id}`, `PATCH` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies`, `GET` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies`, `POST` requests now return a `application/mill.example.movie` Content-Type header.
 - The following Theaters resources have changed:
-    - On `/theaters/{id}`, `GET` requests will return a `application/mill.example.theater` Content-Type header.
-    - On `/theaters/{id}`, `PATCH` requests will return a `application/mill.example.theater` Content-Type header.
-    - On `/theaters`, `GET` requests will return a `application/mill.example.theater` Content-Type header.
-    - On `/theaters`, `POST` requests will return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters/{id}`, `GET` requests now return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters/{id}`, `PATCH` requests now return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters`, `GET` requests now return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters`, `POST` requests now return a `application/mill.example.theater` Content-Type header.
 
 #### Removed
 ##### Resources
 - The following Theaters resources have removed:
-    - `PATCH` requests to `/theaters/{id}` longer will return a `403 Forbidden` with a `Coded error` representation: If something cool happened.
+    - `PATCH` requests to `/theaters/{id}` no longer returns a `403 Forbidden` with a `Coded error` representation: If something cool happened.
 
 ## 1.1.1 (2017-03-01)
 ### Reference

--- a/resources/examples/Showtimes/blueprints/changelog-public-only-unmatched-capabilities.md
+++ b/resources/examples/Showtimes/blueprints/changelog-public-only-unmatched-capabilities.md
@@ -7,14 +7,14 @@ Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
 #### Added
 ##### Resources
 - The following Movies resources have added:
-    - `/movies/{id}` will now throw the following errors on `GET` requests:
+    - `/movies/{id}` now throws the following errors on `GET` requests:
         - `404 Not Found` with a `Error` representation: For no reason.
         - `404 Not Found` with a `Error` representation: For some other reason.
-    - `/movies/{id}` will now throw the following errors on `PATCH` requests:
+    - `/movies/{id}` now throws the following errors on `PATCH` requests:
         - `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
         - `403 Forbidden` with a `Coded error` representation: If something cool happened.
         - `403 Forbidden` with a `Coded error` representation: If the user is not allowed to edit that movie.
-    - On `/movies/{id}`, `PATCH` requests now returns a `202 Accepted` with a `Movie` representation.
+    - On `/movies/{id}`, `PATCH` requests now return a `202 Accepted` with a `Movie` representation.
     - `POST` on `/movies` now returns a `201 Created`.
 
 #### Removed
@@ -26,20 +26,20 @@ Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
 #### Changed
 ##### Resources
 - The following Movies resources have changed:
-    - On `/movies/{id}`, `GET` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies/{id}`, `PATCH` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies`, `GET` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies`, `POST` requests will return a `application/mill.example.movie` Content-Type header.
+    - On `/movies/{id}`, `GET` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies/{id}`, `PATCH` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies`, `GET` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies`, `POST` requests now return a `application/mill.example.movie` Content-Type header.
 - The following Theaters resources have changed:
-    - On `/theaters/{id}`, `GET` requests will return a `application/mill.example.theater` Content-Type header.
-    - On `/theaters/{id}`, `PATCH` requests will return a `application/mill.example.theater` Content-Type header.
-    - On `/theaters`, `GET` requests will return a `application/mill.example.theater` Content-Type header.
-    - On `/theaters`, `POST` requests will return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters/{id}`, `GET` requests now return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters/{id}`, `PATCH` requests now return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters`, `GET` requests now return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters`, `POST` requests now return a `application/mill.example.theater` Content-Type header.
 
 #### Removed
 ##### Resources
 - The following Theaters resources have removed:
-    - `PATCH` requests to `/theaters/{id}` longer will return a `403 Forbidden` with a `Coded error` representation: If something cool happened.
+    - `PATCH` requests to `/theaters/{id}` no longer returns a `403 Forbidden` with a `Coded error` representation: If something cool happened.
 
 ## 1.1.1 (2017-03-01)
 ### Reference

--- a/resources/examples/Showtimes/blueprints/changelog.md
+++ b/resources/examples/Showtimes/blueprints/changelog.md
@@ -7,17 +7,17 @@ Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
 #### Added
 ##### Resources
 - The following Movies resources have added:
-    - `/movie/{id}` will now throw the following errors on `GET` requests:
+    - `/movie/{id}` now throws the following errors on `GET` requests:
         - `404 Not Found` with a `Error` representation: For no reason.
         - `404 Not Found` with a `Error` representation: For some other reason.
-    - `/movies/{id}` will now throw the following errors on `GET` requests:
+    - `/movies/{id}` now throws the following errors on `GET` requests:
         - `404 Not Found` with a `Error` representation: For no reason.
         - `404 Not Found` with a `Error` representation: For some other reason.
-    - `/movies/{id}` will now throw the following errors on `PATCH` requests:
+    - `/movies/{id}` now throws the following errors on `PATCH` requests:
         - `404 Not Found` with a `Error` representation: If the trailer URL could not be validated.
         - `403 Forbidden` with a `Coded error` representation: If something cool happened.
         - `403 Forbidden` with a `Coded error` representation: If the user is not allowed to edit that movie.
-    - On `/movies/{id}`, `PATCH` requests now returns a `202 Accepted` with a `Movie` representation.
+    - On `/movies/{id}`, `PATCH` requests now return a `202 Accepted` with a `Movie` representation.
     - `POST` on `/movies` now returns a `201 Created`.
 
 #### Removed
@@ -29,21 +29,21 @@ Changed up the responses for `/movie/{id}`, `/movies/{id}` and `/movies`.
 #### Changed
 ##### Resources
 - The following Movies resources have changed:
-    - On `/movie/{id}`, `GET` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies/{id}`, `GET` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies/{id}`, `PATCH` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies`, `GET` requests will return a `application/mill.example.movie` Content-Type header.
-    - On `/movies`, `POST` requests will return a `application/mill.example.movie` Content-Type header.
+    - On `/movie/{id}`, `GET` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies/{id}`, `GET` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies/{id}`, `PATCH` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies`, `GET` requests now return a `application/mill.example.movie` Content-Type header.
+    - On `/movies`, `POST` requests now return a `application/mill.example.movie` Content-Type header.
 - The following Theaters resources have changed:
-    - On `/theaters/{id}`, `GET` requests will return a `application/mill.example.theater` Content-Type header.
-    - On `/theaters/{id}`, `PATCH` requests will return a `application/mill.example.theater` Content-Type header.
-    - On `/theaters`, `GET` requests will return a `application/mill.example.theater` Content-Type header.
-    - On `/theaters`, `POST` requests will return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters/{id}`, `GET` requests now return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters/{id}`, `PATCH` requests now return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters`, `GET` requests now return a `application/mill.example.theater` Content-Type header.
+    - On `/theaters`, `POST` requests now return a `application/mill.example.theater` Content-Type header.
 
 #### Removed
 ##### Resources
 - The following Theaters resources have removed:
-    - `PATCH` requests to `/theaters/{id}` longer will return a `403 Forbidden` with a `Coded error` representation: If something cool happened.
+    - `PATCH` requests to `/theaters/{id}` no longer returns a `403 Forbidden` with a `Coded error` representation: If something cool happened.
 
 ## 1.1.1 (2017-03-01)
 ### Reference

--- a/src/Generator/Changelog/Changesets/ActionParam.php
+++ b/src/Generator/Changelog/Changesets/ActionParam.php
@@ -14,7 +14,7 @@ class ActionParam extends Changeset
         return [
             'plural' => [
                 Changelog::DEFINITION_ADDED => 'The following parameters have been added to {method} on {uri}:',
-                Changelog::DEFINITION_REMOVED => 'The following parameters have been removed to {method} on {uri}:'
+                Changelog::DEFINITION_REMOVED => 'The following parameters have been removed from {method} on {uri}:'
             ],
             'singular' => [
                 Changelog::DEFINITION_ADDED => 'A {parameter} request parameter was added to {method} on {uri}.',

--- a/src/Generator/Changelog/Changesets/ActionReturn.php
+++ b/src/Generator/Changelog/Changesets/ActionReturn.php
@@ -13,19 +13,19 @@ class ActionReturn extends Changeset
     {
         return [
             'plural' => [
-                Changelog::DEFINITION_ADDED => 'The {method} on {uri} will now return the following responses:',
+                Changelog::DEFINITION_ADDED => 'The {method} on {uri} now returns the following responses:',
                 Changelog::DEFINITION_REMOVED => 'The {method} on {uri} no longer returns the following responses:'
             ],
             'singular' => [
-                Changelog::DEFINITION_ADDED => 'On {uri}, {method} requests now returns a {http_code} with a ' .
+                Changelog::DEFINITION_ADDED => 'On {uri}, {method} requests now return a {http_code} with a ' .
                     '{representation} representation.',
-                Changelog::DEFINITION_REMOVED => 'On {uri}, {method} requests no longer returns a {http_code} with a ' .
+                Changelog::DEFINITION_REMOVED => 'On {uri}, {method} requests no longer return a {http_code} with a ' .
                     '{representation} representation.',
 
                 // Representations are optional on returns, so we need special strings for those cases.
                 'no_representation' => [
                     Changelog::DEFINITION_ADDED => '{method} on {uri} now returns a {http_code}.',
-                    Changelog::DEFINITION_REMOVED => '{method} on {uri} no longer will return a {http_code}.'
+                    Changelog::DEFINITION_REMOVED => '{method} on {uri} no longer returns a {http_code}.'
                 ]
             ]
         ];

--- a/src/Generator/Changelog/Changesets/ActionThrows.php
+++ b/src/Generator/Changelog/Changesets/ActionThrows.php
@@ -13,13 +13,13 @@ class ActionThrows extends Changeset
     {
         return [
             'plural' => [
-                Changelog::DEFINITION_ADDED => '{uri} will now throw the following errors on {method} requests:',
-                Changelog::DEFINITION_REMOVED => '{uri} will no longer throw the following errors on {method} requests:'
+                Changelog::DEFINITION_ADDED => '{uri} now throws the following errors on {method} requests:',
+                Changelog::DEFINITION_REMOVED => '{uri} no longer throws the following errors on {method} requests:'
             ],
             'singular' => [
                 Changelog::DEFINITION_ADDED => 'On {method} requests to {uri}, a {http_code} with a {representation} ' .
-                    'representation will now be returned: {description}',
-                Changelog::DEFINITION_REMOVED => '{method} requests to {uri} longer will return a {http_code} with a ' .
+                    'representation is now returned: {description}',
+                Changelog::DEFINITION_REMOVED => '{method} requests to {uri} no longer returns a {http_code} with a ' .
                     '{representation} representation: {description}'
             ]
         ];

--- a/src/Generator/Changelog/Changesets/ContentType.php
+++ b/src/Generator/Changelog/Changesets/ContentType.php
@@ -13,7 +13,7 @@ class ContentType extends Changeset
     {
         return [
             'singular' => [
-                Changelog::DEFINITION_CHANGED => 'On {uri}, {method} requests will return a {content_type} ' .
+                Changelog::DEFINITION_CHANGED => 'On {uri}, {method} requests now return a {content_type} ' .
                     'Content-Type header.'
             ]
         ];

--- a/tests/Generator/Changelog/Formats/JsonTest.php
+++ b/tests/Generator/Changelog/Formats/JsonTest.php
@@ -35,8 +35,8 @@ class JsonTest extends TestCase
                         [
                             [
                                 '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
-                                    'data-mill-method="GET" data-mill-uri="/movie/{id}">/movie/{id}</span> will now ' .
-                                    'throw the following errors on <span class="mill-changelog_method" ' .
+                                    'data-mill-method="GET" data-mill-uri="/movie/{id}">/movie/{id}</span> now ' .
+                                    'throws the following errors on <span class="mill-changelog_method" ' .
                                     'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                     'data-mill-uri="/movie/{id}">GET</span> requests:',
                                 [
@@ -59,8 +59,8 @@ class JsonTest extends TestCase
                             ],
                             [
                                 '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
-                                    'data-mill-method="GET" data-mill-uri="/movies/{id}">/movies/{id}</span> will ' .
-                                    'now throw the following errors on <span class="mill-changelog_method" ' .
+                                    'data-mill-method="GET" data-mill-uri="/movies/{id}">/movies/{id}</span> now ' .
+                                    'throws the following errors on <span class="mill-changelog_method" ' .
                                     'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                     'data-mill-uri="/movies/{id}">GET</span> requests:',
                                 [
@@ -83,8 +83,8 @@ class JsonTest extends TestCase
                             ],
                             [
                                 '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
-                                    'data-mill-method="PATCH" data-mill-uri="/movies/{id}">/movies/{id}</span> will ' .
-                                    'now throw the following errors on <span class="mill-changelog_method" ' .
+                                    'data-mill-method="PATCH" data-mill-uri="/movies/{id}">/movies/{id}</span> now ' .
+                                    'throws the following errors on <span class="mill-changelog_method" ' .
                                     'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
                                     'data-mill-uri="/movies/{id}">PATCH</span> requests:',
                                 [
@@ -120,7 +120,7 @@ class JsonTest extends TestCase
                                 '</span>, <span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-http-code="202 Accepted" data-mill-representation="Movie">PATCH</span> ' .
-                                'requests now returns a <span class="mill-changelog_http_code" ' .
+                                'requests now return a <span class="mill-changelog_http_code" ' .
                                 'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/movies/{id}" data-mill-http-code="202 Accepted" ' .
                                 'data-mill-representation="Movie">202 Accepted</span> with a <span ' .
@@ -133,9 +133,9 @@ class JsonTest extends TestCase
                                 'data-mill-representation="">POST</span> on <span class="mill-changelog_uri" ' .
                                 'data-mill-resource-group="Movies" data-mill-method="POST" data-mill-uri="/movies" ' .
                                 'data-mill-http-code="201 Created" data-mill-representation="">/movies</span> now ' .
-                                'returns a <span class="mill-changelog_http_code" ' .
-                                'data-mill-resource-group="Movies" data-mill-method="POST" data-mill-uri="/movies" ' .
-                                'data-mill-http-code="201 Created" data-mill-representation="">201 Created</span>.'
+                                'returns a <span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
+                                'data-mill-method="POST" data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
+                                'data-mill-representation="">201 Created</span>.'
                         ]
                     ]
                 ]
@@ -166,17 +166,18 @@ class JsonTest extends TestCase
                                 'data-mill-content-type="application/mill.example.movie">/movie/{id}</span>, <span ' .
                                 'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
-                                'data-mill-content-type="application/mill.example.movie">GET</span> requests will ' .
+                                'data-mill-content-type="application/mill.example.movie">GET</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
                                 'data-mill-resource-group="Movies" data-mill-method="GET" ' .
-                                'data-mill-uri="/movie/{id}" data-mill-content-type="application/mill.example.movie">' .
+                                'data-mill-uri="/movie/{id}" ' .
+                                'data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.',
                             'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">/movies/{id}</span>, <span ' .
                                 'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
-                                'data-mill-content-type="application/mill.example.movie">GET</span> requests will ' .
+                                'data-mill-content-type="application/mill.example.movie">GET</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
                                 'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                 'data-mill-uri="/movies/{id}" ' .
@@ -187,7 +188,7 @@ class JsonTest extends TestCase
                                 'data-mill-content-type="application/mill.example.movie">/movies/{id}</span>, <span ' .
                                 'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
-                                'data-mill-content-type="application/mill.example.movie">PATCH</span> requests will ' .
+                                'data-mill-content-type="application/mill.example.movie">PATCH</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
                                 'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/movies/{id}" ' .
@@ -198,7 +199,7 @@ class JsonTest extends TestCase
                                 'data-mill-content-type="application/mill.example.movie">/movies</span>, <span ' .
                                 'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies" ' .
-                                'data-mill-content-type="application/mill.example.movie">GET</span> requests will ' .
+                                'data-mill-content-type="application/mill.example.movie">GET</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
                                 'data-mill-resource-group="Movies" data-mill-method="GET" data-mill-uri="/movies" ' .
                                 'data-mill-content-type="application/mill.example.movie">' .
@@ -208,7 +209,7 @@ class JsonTest extends TestCase
                                 'data-mill-content-type="application/mill.example.movie">/movies</span>, <span ' .
                                 'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="POST" data-mill-uri="/movies" ' .
-                                'data-mill-content-type="application/mill.example.movie">POST</span> requests will ' .
+                                'data-mill-content-type="application/mill.example.movie">POST</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
                                 'data-mill-resource-group="Movies" data-mill-method="POST" data-mill-uri="/movies" ' .
                                 'data-mill-content-type="application/mill.example.movie">' .
@@ -224,7 +225,7 @@ class JsonTest extends TestCase
                                 'data-mill-content-type="application/mill.example.theater">/theaters/{id}</span>, ' .
                                 '<span class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="GET" data-mill-uri="/theaters/{id}" ' .
-                                'data-mill-content-type="application/mill.example.theater">GET</span> requests will ' .
+                                'data-mill-content-type="application/mill.example.theater">GET</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
                                 'data-mill-resource-group="Theaters" data-mill-method="GET" ' .
                                 'data-mill-uri="/theaters/{id}" ' .
@@ -235,8 +236,8 @@ class JsonTest extends TestCase
                                 'data-mill-content-type="application/mill.example.theater">/theaters/{id}</span>, ' .
                                 '<span class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/theaters/{id}" ' .
-                                'data-mill-content-type="application/mill.example.theater">PATCH</span> requests ' .
-                                'will return a <span class="mill-changelog_content_type" ' .
+                                'data-mill-content-type="application/mill.example.theater">PATCH</span> requests now ' .
+                                'return a <span class="mill-changelog_content_type" ' .
                                 'data-mill-resource-group="Theaters" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">' .
@@ -246,7 +247,7 @@ class JsonTest extends TestCase
                                 'data-mill-content-type="application/mill.example.theater">/theaters</span>, <span ' .
                                 'class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="GET" data-mill-uri="/theaters" ' .
-                                'data-mill-content-type="application/mill.example.theater">GET</span> requests will ' .
+                                'data-mill-content-type="application/mill.example.theater">GET</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
                                 'data-mill-resource-group="Theaters" data-mill-method="GET" ' .
                                 'data-mill-uri="/theaters" ' .
@@ -257,8 +258,8 @@ class JsonTest extends TestCase
                                 'data-mill-content-type="application/mill.example.theater">/theaters</span>, <span ' .
                                 'class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="POST" data-mill-uri="/theaters" ' .
-                                'data-mill-content-type="application/mill.example.theater">POST</span> requests ' .
-                                'will return a <span class="mill-changelog_content_type" ' .
+                                'data-mill-content-type="application/mill.example.theater">POST</span> requests now ' .
+                                'return a <span class="mill-changelog_content_type" ' .
                                 'data-mill-resource-group="Theaters" data-mill-method="POST" ' .
                                 'data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">' .
@@ -279,7 +280,7 @@ class JsonTest extends TestCase
                                 '</span> requests to <span class="mill-changelog_uri" ' .
                                 'data-mill-resource-group="Theaters" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/theaters/{id}" data-mill-http-code="403 Forbidden" ' .
-                                'data-mill-representation="Coded error">/theaters/{id}</span> longer will return a ' .
+                                'data-mill-representation="Coded error">/theaters/{id}</span> no longer returns a ' .
                                 '<span class="mill-changelog_http_code" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-http-code="403 Forbidden" data-mill-representation="Coded error">403 ' .
@@ -467,8 +468,8 @@ class JsonTest extends TestCase
                                                 'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                                 'data-mill-uri="/movies">POST</span> on <span ' .
                                                 'class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
-                                                'data-mill-method="POST" data-mill-uri="/movies">/movies</span> will ' .
-                                                'now return the following responses:',
+                                                'data-mill-method="POST" data-mill-uri="/movies">/movies</span> now ' .
+                                                'returns the following responses:',
                                             [
                                                 '<span class="mill-changelog_http_code" ' .
                                                     'data-mill-resource-group="Movies" data-mill-method="POST" ' .
@@ -490,7 +491,7 @@ class JsonTest extends TestCase
                                             '</span>, <span class="mill-changelog_method" ' .
                                             'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
-                                            'data-mill-representation="Movie">GET</span> requests now returns a ' .
+                                            'data-mill-representation="Movie">GET</span> requests now return a ' .
                                             '<span class="mill-changelog_http_code" ' .
                                             'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
@@ -582,7 +583,7 @@ class JsonTest extends TestCase
                                             '</span>, <span class="mill-changelog_method" ' .
                                             'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
-                                            'data-mill-representation="Movie">GET</span> requests no longer returns ' .
+                                            'data-mill-representation="Movie">GET</span> requests no longer return ' .
                                             'a <span class="mill-changelog_http_code" ' .
                                             'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .


### PR DESCRIPTION
Suggested by @campbellmarc:

> Parameters > Removed > Plural = Y
> The following parameters have been removed from {method} on {uri}:
> 
> Responses > Addition > Plural = Y
> The {method} on {uri} now returns the following responses:
> 
> Responses > Addition > Plural = N
> On {uri}, {method} requests now return a {http_code} with a {representation} representation.
> 
> Responses > Removal > Plural = N
> On {uri}, {method} requests no longer return a {http_code} with a {representation} representation.
> 
> Responses > Removal > Plural = N > Without data representation
> {method} on {uri} no longer returns a {http_code}.
> 
> Errors > Addition > Plural = Y
> {uri} now throws the following errors on {method} requests:
> 
> Errors > Removal > Plural = Y
> {uri} no longer throws the following errors on {method} requests:
> 
> Errors > Addition > Plural = N
> On {method} requests to {uri}, a {http_code} with a {representation} representation is now returned: {description}
> 
> Errors > Removal > Plural = N
> {method} requests to {uri} no longer returns a {http_code} with a {representation} representation: {description}
> 
> Content type
> On {uri}, {method} requests now return a {content_type} Content-Type header.