### PR TITLE
Simplified URI grouping

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -53,7 +53,7 @@
                                 <xs:sequence>
                                     <xs:element name="exclude" minOccurs="1" maxOccurs="unbounded">
                                         <xs:complexType>
-                                            <xs:attribute name="namespace" type="xs:string" use="required" />
+                                            <xs:attribute name="group" type="xs:string" use="required" />
                                         </xs:complexType>
                                     </xs:element>
                                 </xs:sequence>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -38,6 +38,7 @@
                             <ul>
                                 <li><a href="{{ site.github.url }}/reference/api-contenttype">&middot; <small>@api-contenttype</small></a></li>
                                 <li><a href="{{ site.github.url }}/reference/api-error">&middot; <small>@api-error</small></a></li>
+                                <li><a href="{{ site.github.url }}/reference/api-group">&middot; <small>@api-group</small></a></li>
                                 <li><a href="{{ site.github.url }}/reference/api-label">&middot; <small>@api-label</small></a></li>
                                 <li><a href="{{ site.github.url }}/reference/api-minversion">&middot; <small>@api-minversion</small></a></li>
                                 <li><a href="{{ site.github.url }}/reference/api-param">&middot; <small>@api-param</small></a></li>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,8 +186,8 @@ from the `./bin/mill generate` command.
 
 #### API Blueprint
 ##### Excludes
-* Use `<exclude>` elements to specify a resource namespace that should be excluded from API Blueprint generation and compilation.
-    * Make sure to add a `namespace` attribute so Mill knows what namespace you're excluding.
+* Use `<exclude>` elements to specify a resource group that should be excluded from API Blueprint generation and compilation.
+    * Make sure to add a `group` attribute so Mill knows what group you're excluding.
 
 Example:
 
@@ -195,8 +195,8 @@ Example:
 <generators>
     <blueprint>
         <excludes>
-            <exclude namespace="/" />
-            <exclude namespace="OAuth" />
+            <exclude group="/" />
+            <exclude group="OAuth" />
         </excludes>
     </blueprint>
 </generators>

--- a/docs/generate/changelogs.md
+++ b/docs/generate/changelogs.md
@@ -96,4 +96,4 @@ then be styled according to however you want to render it:
 | Resource action method | `mill-changelog_method` | `data-mill-method` |
 | Resource action parameter| `mill-changelog_parameter` | `data-mill-parameter` |
 | Resource action URI | `mill-changelog_uri` | `data-mill-uri` |
-| Resource namespaces | `mill-changelog_resource_namespace` | `data-mill-resource-namespace` |
+| Resource groups | `mill-changelog_resource_group` | `data-mill-resource-group` |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,8 +81,9 @@ class UsersController extends \MyApplication\Controller
      * Search for users.
      *
      * @api-label Search
+     * @api-group Users
      *
-     * @api-uri:public {Users} /users
+     * @api-uri:public /users
      *
      * @api-contentType application/json
      *

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -22,6 +22,7 @@ title: "Reference"
 | :--- | :--- |
 | [`@api-contenttype`]({{ site.github.url }}/reference/api-contenttype) | Denotes the `Content-Type` returned. |
 | [`@api-error`]({{ site.github.url }}/reference/api-error) | An exception or error that may be thrown in the action. |
+| [`@api-group`]({{ site.github.url }}/reference/api-label) | Name of the group that this action should be grouped under when generating documentation. |
 | [`@api-label`]({{ site.github.url }}/reference/api-label) | Short description of what the resource action handles. |
 | [`@api-minversion`]({{ site.github.url }}/reference/api-minversion) | Minimum version required for this action. |
 | [`@api-param`]({{ site.github.url }}/reference/api-param) | A request parameter for this action. |

--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -11,6 +11,7 @@ permalink: /reference/resource-actions
 | :--- | :--- |
 | [`@api-contenttype`]({{ site.github.url }}/reference/api-contenttype) | Denotes the `Content-Type` returned. |
 | [`@api-error`]({{ site.github.url }}/reference/api-error) | An exception or error that may be thrown in the action. |
+| [`@api-group`]({{ site.github.url }}/reference/api-group) | Name of the group that this action should be grouped under when generating documentation. |
 | [`@api-label`]({{ site.github.url }}/reference/api-label) | Short description of what the resource action handles. |
 | [`@api-minversion`]({{ site.github.url }}/reference/api-minversion) | Minimum version required for this action. |
 | [`@api-param`]({{ site.github.url }}/reference/api-param) | A request parameter for this action. |

--- a/docs/reference/api-group.md
+++ b/docs/reference/api-group.md
@@ -1,0 +1,45 @@
+---
+layout: default
+title: "@api-group"
+permalink: /reference/api-group
+---
+
+# @api-group
+---
+
+Name of the group that this action should be grouped under when generating documentation.
+
+## Syntax
+```php
+@api-group groupName
+```
+
+## Requirements
+
+| Required? | Needs a visibility | Supports versioning | Supports deprecation |
+| :--- | :--- | :--- | :--- |
+| ✓ | × | × | × |
+
+## Breakdown
+
+| Tag | Optional | Description |
+| :--- | :--- | :--- |
+| `groupName` | × | Group name |
+
+## Examples
+On a resource action:
+
+```php
+/**
+ * @api-label Update data on a group of videos.
+ * @api-group Users
+ *
+ * @api-uri:public /users
+ *
+ * …
+ */
+public function PATCH()
+{
+    …
+}
+```

--- a/docs/reference/api-minversion.md
+++ b/docs/reference/api-minversion.md
@@ -30,7 +30,10 @@ action.
 ## Examples
 ```php
 /**
- * @api-uri:public {Movies} /movies/+id
+ * @api-label Update a movie.
+ * @api-group Movies
+ *
+ * @api-uri:public /movies/+id
  * @api-urisegment {/movies/+id} id (integer) - Movie ID
  *
  * @api-minversion 3.2

--- a/docs/reference/api-scope.md
+++ b/docs/reference/api-scope.md
@@ -32,7 +32,10 @@ representation data point.
 ## Examples
 ```php
 /**
- * @api-uri:public {Movies} /movies/+id
+ * @api-label Update a movie
+ * @api-group Movies
+ *
+ * @api-uri:public /movies/+id
  * @api-urisegment {/movies/+id} id (integer) - Movie ID
  *
  * @api-scope edit

--- a/docs/reference/api-uri.md
+++ b/docs/reference/api-uri.md
@@ -11,7 +11,7 @@ This allows you to describe the URI(s) that a resource action services.
 
 ## Syntax
 ```php
-@api-uri:visibility {namespace} uri
+@api-uri:visibility uri
 ```
 
 ## Requirements
@@ -24,16 +24,15 @@ This allows you to describe the URI(s) that a resource action services.
 
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
-| `{namespace}` | × | A namespace which this action lives under. This is used for grouping your documentation into like groups (like having your user actions grouped under `User`). It also allows you to do sub-grouping with `Namespace\Secondary Namespace`, if you wish. There is no limit to the amount of depths a URI can be in. |
 | `uri` | × | This is the URI that the resource action services. It's recommended that these conform to [RFC 3986](https://tools.ietf.org/html/rfc3986) and [RFC 6570](https://tools.ietf.org/html/rfc6570). |
 
 ## Examples
 ```php
 /**
  * …
- * @api-uri:private {Movies} /movies
+ * @api-uri:private /movies
  *
- * @api-uri:private:deprecated {Theaters\Movies} /theaters/+id/movies
+ * @api-uri:private:deprecated /theaters/+id/movies
  * …
  */
 public function PATCH()

--- a/docs/reference/deprecation.md
+++ b/docs/reference/deprecation.md
@@ -20,11 +20,12 @@ parameter or URI, you can use the `:deprecated` "decorator".
  * Return information on a specific movie.
  *
  * @api-label Get a single movie.
+ * @api-group Movies
  *
- * @api-uri:public {Movies} /movies/+id
+ * @api-uri:public /movies/+id
  * @api-urisegment {/movies/+id} id (integer) - Movie ID
  *
- * @api-uri:private:deprecated {Films} /films/+id
+ * @api-uri:private:deprecated /films/+id
  * @api-urisegment {/films/+id} id (integer) - Film ID
  *
  * @api-contenttype application/json

--- a/docs/reference/uri-segment.md
+++ b/docs/reference/uri-segment.md
@@ -55,7 +55,7 @@ resource action URI.
 /**
  * …
  *
- * @api-uri:private:deprecated {Movies} /movies/+id
+ * @api-uri:private:deprecated /movies/+id
  * @api-urisegment {/movies/+id} id (integer) - Movie ID
  *
  * …

--- a/docs/reference/visibility.md
+++ b/docs/reference/visibility.md
@@ -21,10 +21,13 @@ with either `:public` or `:private`.
 
 ```php
 /**
- * @api-uri:public {Movies} /movies/+id
+ * @api-label Update a movie.
+ * @api-group Movies
+ *
+ * @api-uri:public /movies/+id
  * @api-urisegment {/movies/+id} id (integer) - Movie ID
  *
- * @api-uri:private {Films} /films/+id
+ * @api-uri:private /films/+id
  * @api-urisegment {/films/+id} id (integer) - Film ID
  *
  * @api-error:private 403 (\Some\ErrorErrorRepresentation) - If the user isn't

--- a/resources/examples/Showtimes/Controllers/Movie.php
+++ b/resources/examples/Showtimes/Controllers/Movie.php
@@ -25,11 +25,12 @@ class Movie
      * ```
      *
      * @api-label Get a single movie.
+     * @api-group Movies
      *
-     * @api-uri:private:alias {Movies} /movie/+id
+     * @api-uri:private:alias /movie/+id
      * @api-uriSegment {/movie/+id} id (integer) - Movie ID
      *
-     * @api-uri:public {Movies} /movies/+id
+     * @api-uri:public /movies/+id
      * @api-uriSegment {/movies/+id} id (integer) - Movie ID
      *
      * @api-return:public {object} \Mill\Examples\Showtimes\Representations\Movie
@@ -56,8 +57,9 @@ class Movie
      * Update a movies data.
      *
      * @api-label Update a movie.
+     * @api-group Movies
      *
-     * @api-uri:public {Movies} /movies/+id
+     * @api-uri:public /movies/+id
      * @api-uriSegment {/movies/+id} id (integer) - Movie ID
      *
      * @api-scope edit
@@ -115,8 +117,9 @@ class Movie
      * Delete a movie.
      *
      * @api-label Delete a movie.
+     * @api-group Movies
      *
-     * @api-uri:private {Movies} /movies/+id
+     * @api-uri:private /movies/+id
      * @api-uriSegment {/movies/+id} id (integer) - Movie ID
      *
      * @api-contentType application/json

--- a/resources/examples/Showtimes/Controllers/Movies.php
+++ b/resources/examples/Showtimes/Controllers/Movies.php
@@ -10,8 +10,9 @@ class Movies
      * Returns all movies for a specific location.
      *
      * @api-label Get movies.
+     * @api-group Movies
      *
-     * @api-uri:public {Movies} /movies
+     * @api-uri:public /movies
      *
      * @api-param:public location (string, required) - Location you want movies for.
      *
@@ -37,8 +38,9 @@ class Movies
      * Create a new movie.
      *
      * @api-label Create a movie.
+     * @api-group Movies
      *
-     * @api-uri:public {Movies} /movies
+     * @api-uri:public /movies
      *
      * @api-scope create
      *

--- a/resources/examples/Showtimes/Controllers/Theater.php
+++ b/resources/examples/Showtimes/Controllers/Theater.php
@@ -14,8 +14,9 @@ class Theater
      * Return information on a specific movie theater.
      *
      * @api-label Get a single movie theater.
+     * @api-group Theaters
      *
-     * @api-uri:public {Theaters} /theaters/+id
+     * @api-uri:public /theaters/+id
      * @api-uriSegment {/theaters/+id} id (integer) - Theater ID
      *
      * @api-return:public {object} \Mill\Examples\Showtimes\Representations\Theater
@@ -38,8 +39,9 @@ class Theater
      * Update a movie theaters' data.
      *
      * @api-label Update a movie theater.
+     * @api-group Theaters
      *
-     * @api-uri:public {Theaters} /theaters/+id
+     * @api-uri:public /theaters/+id
      * @api-uriSegment {/theaters/+id} id (integer) - Theater ID
      *
      * @api-scope create
@@ -69,8 +71,9 @@ class Theater
      * Delete a movie theater.
      *
      * @api-label Delete a movie theater.
+     * @api-group Theaters
      *
-     * @api-uri:private {Theaters} /theaters/+id
+     * @api-uri:private /theaters/+id
      * @api-uriSegment {/theaters/+id} id (integer) - Theater ID
      *
      * @api-contentType application/json

--- a/resources/examples/Showtimes/Controllers/Theaters.php
+++ b/resources/examples/Showtimes/Controllers/Theaters.php
@@ -10,8 +10,9 @@ class Theaters
      * Returns all movie theatres for a specific location.
      *
      * @api-label Get movie theaters.
+     * @api-group Theaters
      *
-     * @api-uri:public {Theaters} /theaters
+     * @api-uri:public /theaters
      *
      * @api-param:public location (string, required) - Location you want theaters in.
      *
@@ -34,8 +35,9 @@ class Theaters
      * Create a new movie theater.
      *
      * @api-label Create a movie theater.
+     * @api-group Theaters
      *
-     * @api-uri:public {Theaters} /theaters
+     * @api-uri:public /theaters
      *
      * @api-scope create
      *

--- a/src/Command/Generate.php
+++ b/src/Command/Generate.php
@@ -114,18 +114,18 @@ class Generate extends Application
             // Process resource groups.
             if (isset($section['groups'])) {
                 $progress->setMessage('Processing resources…');
-                foreach ($section['groups'] as $namespace => $markdown) {
+                foreach ($section['groups'] as $group => $markdown) {
                     $progress->advance();
 
                     if ($dry_run) {
                         continue;
                     }
 
-                    // Convert any nested namespaces, like `Me\Videos`, into a proper directory structure: `Me/Videos`.
-                    $namespace = str_replace('\\', self::DS, $namespace);
+                    // Convert any nested groups, like `Me\Videos`, into a proper directory structure: `Me/Videos`.
+                    $group = str_replace('\\', self::DS, $group);
 
                     $filesystem->put(
-                        $version_dir . 'resources' . self::DS . $namespace . '.apib',
+                        $version_dir . 'resources' . self::DS . $group . '.apib',
                         trim($markdown)
                     );
                 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -121,11 +121,11 @@ class Config
     protected $parameter_tokens = [];
 
     /**
-     * Array of API Blueprint generator resource namespace excludes.
+     * Array of API Blueprint generator resource group excludes.
      *
      * @var array
      */
-    protected $blueprint_namespace_excludes = [];
+    protected $blueprint_group_excludes = [];
 
     /**
      * Create a new configuration object from a given config file.
@@ -348,44 +348,44 @@ class Config
             if (isset($generators->blueprint->excludes)) {
                 /** @var SimpleXMLElement $exclude */
                 foreach ($generators->blueprint->excludes->exclude as $exclude) {
-                    $namespace = trim((string) $exclude['namespace']);
+                    $group = trim((string) $exclude['group']);
 
-                    $this->addBlueprintNamespaceExclude($namespace);
+                    $this->addBlueprintGroupExclude($group);
                 }
             }
         }
     }
 
     /**
-     * Add a new API Blueprint resource namespace generator exclusion.
+     * Add a new API Blueprint resource group generator exclusion.
      *
-     * @param string $namespace
-     * @throws DomainException If an invalid Blueprint generator namespace exclude was detected.
+     * @param string $group
+     * @throws DomainException If an invalid Blueprint generator group exclude was detected.
      */
-    public function addBlueprintNamespaceExclude(string $namespace): void
+    public function addBlueprintGroupExclude(string $group): void
     {
-        if (empty($namespace)) {
+        if (empty($group)) {
             throw new DomainException(
-                'An invalid Blueprint generator namespace exclude was supplied in the Mill `generators` section.'
+                'An invalid Blueprint generator group exclude was supplied in the Mill `generators` section.'
             );
         }
 
-        $this->blueprint_namespace_excludes[] = $namespace;
+        $this->blueprint_group_excludes[] = $group;
     }
 
     /**
-     * Remove a currently configured API Blueprint resource namespace generator exclusion.
+     * Remove a currently configured API Blueprint resource group generator exclusion.
      *
-     * @param string $namespace
+     * @param string $group
      */
-    public function removeBlueprintNamespaceExclude(string $namespace): void
+    public function removeBlueprintGroupExclude(string $group): void
     {
-        $excludes = array_flip($this->blueprint_namespace_excludes);
-        if (isset($excludes[$namespace])) {
-            unset($excludes[$namespace]);
+        $excludes = array_flip($this->blueprint_group_excludes);
+        if (isset($excludes[$group])) {
+            unset($excludes[$group]);
         }
 
-        $this->blueprint_namespace_excludes = array_flip($excludes);
+        $this->blueprint_group_excludes = array_flip($excludes);
     }
 
     /**
@@ -834,13 +834,13 @@ class Config
     }
 
     /**
-     * Get the array of configured API Blueprint resource namespace excludes.
+     * Get the array of configured API Blueprint resource group excludes.
      *
      * @return array
      */
-    public function getBlueprintNamespaceExcludes(): array
+    public function getBlueprintGroupExcludes(): array
     {
-        return $this->blueprint_namespace_excludes;
+        return $this->blueprint_group_excludes;
     }
 
     /**

--- a/src/Generator/Blueprint.php
+++ b/src/Generator/Blueprint.php
@@ -32,24 +32,24 @@ class Blueprint extends Generator
     {
         parent::generate();
 
-        $namespace_excludes = $this->config->getBlueprintNamespaceExcludes();
+        $group_excludes = $this->config->getBlueprintGroupExcludes();
         $resources = $this->getResources();
 
         $blueprints = [];
 
         /** @var array $data */
-        foreach ($resources as $version => $namespaces) {
+        foreach ($resources as $version => $groups) {
             $this->version = $version;
             $this->representations = $this->getRepresentations($this->version);
 
             // Process resource groups.
-            foreach ($namespaces as $namespace => $data) {
-                // If this namespace has been designated in the config file to be excluded, then exclude it.
-                if (in_array($namespace, $namespace_excludes)) {
+            foreach ($groups as $group => $data) {
+                // If this group has been designated in the config file to be excluded, then exclude it.
+                if (in_array($group, $group_excludes)) {
                     continue;
                 }
 
-                $contents = sprintf('# Group %s', $namespace);
+                $contents = sprintf('# Group %s', $group);
                 $contents .= $this->line();
 
                 // Sort the resources so they're alphabetical.
@@ -125,7 +125,7 @@ class Blueprint extends Generator
                 }
 
                 $contents = trim($contents);
-                $blueprints[$this->version]['groups'][$namespace] = $contents;
+                $blueprints[$this->version]['groups'][$group] = $contents;
             }
 
             // Process representation data structures.

--- a/src/Generator/Changelog.php
+++ b/src/Generator/Changelog.php
@@ -162,7 +162,7 @@ class Changelog extends Generator
      */
     private function buildResourceChangelog(array $resources = []): void
     {
-        foreach ($resources as $namespace => $data) {
+        foreach ($resources as $group => $data) {
             foreach ($data['resources'] as $resource_name => $resource) {
                 /** @var Action\Documentation $action */
                 foreach ($resource['actions'] as $identifier => $action) {
@@ -174,9 +174,9 @@ class Changelog extends Generator
                             self::DEFINITION_ADDED,
                             $min_version,
                             self::CHANGESET_TYPE_ACTION,
-                            $namespace,
+                            $group,
                             [
-                                'resource_namespace' => $namespace,
+                                'resource_group' => $group,
                                 'method' => $action->getMethod(),
                                 'uri' => $action->getUri()->getCleanPath()
                             ]
@@ -192,9 +192,9 @@ class Changelog extends Generator
                                 self::DEFINITION_CHANGED,
                                 $introduced,
                                 self::CHANGESET_TYPE_CONTENT_TYPE,
-                                $namespace,
+                                $group,
                                 [
-                                    'resource_namespace' => $namespace,
+                                    'resource_group' => $group,
                                     'method' => $action->getMethod(),
                                     'uri' => $action->getUri()->getCleanPath(),
                                     'content_type' => $content_type->getContentType()
@@ -218,7 +218,7 @@ class Changelog extends Generator
                             }
 
                             $data = [
-                                'resource_namespace' => $namespace,
+                                'resource_group' => $group,
                                 'method' => $action->getMethod(),
                                 'uri' => $action->getUri()->getCleanPath()
                             ];
@@ -260,23 +260,11 @@ class Changelog extends Generator
                             }
 
                             if ($introduced) {
-                                $this->record(
-                                    self::DEFINITION_ADDED,
-                                    $introduced,
-                                    $change_type,
-                                    $namespace,
-                                    $data
-                                );
+                                $this->record(self::DEFINITION_ADDED, $introduced, $change_type, $group, $data);
                             }
 
                             if ($removed) {
-                                $this->record(
-                                    self::DEFINITION_REMOVED,
-                                    $removed,
-                                    $change_type,
-                                    $namespace,
-                                    $data
-                                );
+                                $this->record(self::DEFINITION_REMOVED, $removed, $change_type, $group, $data);
                             }
                         }
                     }
@@ -291,7 +279,7 @@ class Changelog extends Generator
      * @param string $definition
      * @param false|string $version
      * @param string $change_type
-     * @param null|string $namespace
+     * @param null|string $group
      * @param array $data
      * @return self
      */
@@ -299,22 +287,21 @@ class Changelog extends Generator
         string $definition,
         $version,
         string $change_type,
-        string $namespace = null,
+        string $group = null,
         array $data = []
     ): self {
-        // Since namespaces can be nested, let's throw changes under the top-level namespace.
-        if (!is_null($namespace)) {
-            $namespace = explode('\\', $namespace);
-            $namespace = array_shift($namespace);
+        // Since groups can be nested, let's throw changes under the top-level group.
+        if (!is_null($group)) {
+            $group = explode('\\', $group);
+            $group = array_shift($group);
         }
 
         $hash = $this->hashChangeset($change_type, $data);
 
         if ($change_type === self::CHANGESET_TYPE_REPRESENTATION_DATA) {
-            $this->changelog[$version][$definition]['representations'][$namespace][$change_type][$hash][] = $data;
+            $this->changelog[$version][$definition]['representations'][$group][$change_type][$hash][] = $data;
         } else {
-            $this->changelog[$version][$definition]['resources'][$namespace][$data['uri']][$change_type][$hash][] =
-                $data;
+            $this->changelog[$version][$definition]['resources'][$group][$data['uri']][$change_type][$hash][] = $data;
         }
 
         return $this;

--- a/src/Generator/Changelog/Changesets/Action.php
+++ b/src/Generator/Changelog/Changesets/Action.php
@@ -44,7 +44,7 @@ class Action extends Changeset
             [
                 // Changes are grouped by URIs so it's safe to just pull the first URI here.
                 $this->renderText($template, [
-                    'resource_namespace' => $changes[0]['resource_namespace'],
+                    'resource_group' => $changes[0]['resource_group'],
                     'uri' => $changes[0]['uri']
                 ]),
                 $methods

--- a/src/Generator/Changelog/Changesets/ActionError.php
+++ b/src/Generator/Changelog/Changesets/ActionError.php
@@ -59,7 +59,7 @@ class ActionError extends Changeset
                 $template = $templates['plural'][$definition];
                 $entries[] = [
                     $this->renderText($template, [
-                        'resource_namespace' => $change['resource_namespace'],
+                        'resource_group' => $change['resource_group'],
                         'method' => $method,
                         'uri' => $change['uri']
                     ]),

--- a/src/Generator/Changelog/Changesets/ActionParam.php
+++ b/src/Generator/Changelog/Changesets/ActionParam.php
@@ -56,7 +56,7 @@ class ActionParam extends Changeset
                 $template = $templates['plural'][$definition];
                 $entry[] = [
                     $this->renderText($template, [
-                        'resource_namespace' => $changes[0]['resource_namespace'],
+                        'resource_group' => $changes[0]['resource_group'],
                         'method' => $method,
                         'uri' => $changes[0]['uri']
                     ]),
@@ -68,7 +68,7 @@ class ActionParam extends Changeset
 
             $template = $templates['singular'][$definition];
             $entry[] = $this->renderText($template, [
-                'resource_namespace' => $changes[0]['resource_namespace'],
+                'resource_group' => $changes[0]['resource_group'],
                 'parameter' => array_shift($params),
                 'method' => $method,
                 'uri' => $changes[0]['uri']

--- a/src/Generator/Changelog/Changesets/ActionReturn.php
+++ b/src/Generator/Changelog/Changesets/ActionReturn.php
@@ -72,7 +72,7 @@ class ActionReturn extends Changeset
                 $template = $templates['plural'][$definition];
                 $entries[] = [
                     $this->renderText($template, [
-                        'resource_namespace' => $changes[0]['resource_namespace'],
+                        'resource_group' => $changes[0]['resource_group'],
                         'method' => $method,
                         'uri' => $changes[0]['uri']
                     ]),

--- a/src/Generator/Changelog/Formats/Json.php
+++ b/src/Generator/Changelog/Formats/Json.php
@@ -106,12 +106,12 @@ class Json extends Generator
     private function parseResourceChangesets(string $definition, array $changesets = []): array
     {
         $entries = [];
-        foreach ($changesets as $namespace => $data) {
-            $namespace_entry = [
-                $this->renderText('The following {resource_namespace} resources have ' . $definition . ':', [
-                    'resource_namespace' => $namespace
+        foreach ($changesets as $group => $data) {
+            $group_entry = [
+                $this->renderText('The following {resource_group} resources have ' . $definition . ':', [
+                    'resource_group' => $group
                 ]),
-                [] // Namespace-related entries will be nested here.
+                [] // Group-related entries will be nested here.
             ];
 
             foreach ($data as $uri => $change_types) {
@@ -131,12 +131,12 @@ class Json extends Generator
                             $entry = array_shift($entry);
                         }
 
-                        $namespace_entry[1][] = $entry;
+                        $group_entry[1][] = $entry;
                     }
                 }
             }
 
-            $entries[] = $namespace_entry;
+            $entries[] = $group_entry;
         }
 
         return $entries;

--- a/src/Generator/ErrorMap.php
+++ b/src/Generator/ErrorMap.php
@@ -28,12 +28,12 @@ class ErrorMap extends Generator
         parent::generate();
 
         foreach ($this->getResources() as $version => $resources) {
-            foreach ($resources as $namespace => $data) {
-                // Namespaces can have children via the `\` delimiter, but for the error map generator we only care
-                // about the top-level namespace.
-                if (strpos($namespace, '\\') != false) {
-                    $parts = explode('\\', $namespace);
-                    $namespace = array_shift($parts);
+            foreach ($resources as $group => $data) {
+                // Groups can have children via the `\` delimiter, but for the error map generator we only care about
+                // the top-level group.
+                if (strpos($group, '\\') != false) {
+                    $parts = explode('\\', $group);
+                    $group = array_shift($parts);
                 }
 
                 foreach ($data['resources'] as $resource_name => $resource) {
@@ -51,7 +51,7 @@ class ErrorMap extends Generator
                             }
 
                             $uri = $action->getUri();
-                            $this->error_map[$version][$namespace][$error_code][] = [
+                            $this->error_map[$version][$group][$error_code][] = [
                                 'uri' => $uri->getCleanPath(),
                                 'method' => $action->getMethod(),
                                 'http_code' => $response->getHttpCode(),
@@ -65,10 +65,10 @@ class ErrorMap extends Generator
         }
 
         // Keep things tidy
-        foreach ($this->error_map as $version => $namespaces) {
-            foreach ($namespaces as $namespace => $resources) {
+        foreach ($this->error_map as $version => $groups) {
+            foreach ($groups as $group => $resources) {
                 foreach ($resources as $identifier => $errors) {
-                    usort($this->error_map[$version][$namespace][$identifier], function (array $a, array $b): int {
+                    usort($this->error_map[$version][$group][$identifier], function (array $a, array $b): int {
                         // If the error codes match, then fallback to sorting by the URI.
                         if ($a['error_code'] == $b['error_code']) {
                             // If the URIs match, then fallback to sorting by their methods.
@@ -83,7 +83,7 @@ class ErrorMap extends Generator
                     });
                 }
 
-                ksort($this->error_map[$version][$namespace]);
+                ksort($this->error_map[$version][$group]);
             }
         }
 

--- a/src/Generator/ErrorMap/Formats/Markdown.php
+++ b/src/Generator/ErrorMap/Formats/Markdown.php
@@ -42,7 +42,7 @@ class Markdown extends Generator
     {
         $markdown = [];
 
-        foreach ($this->error_map as $version => $namespaces) {
+        foreach ($this->error_map as $version => $groups) {
             $content = '';
 
             $api_name = $this->config->getName();
@@ -54,8 +54,8 @@ class Markdown extends Generator
                 $content .= $this->line(2);
             }
 
-            foreach ($namespaces as $namespace => $actions) {
-                $content .= sprintf('## %s', $namespace);
+            foreach ($groups as $group => $actions) {
+                $content .= sprintf('## %s', $group);
                 $content .= $this->line(1);
 
                 $content .= '| Error Code | URI | Method | HTTP Code | Description |';

--- a/src/Generator/Traits/ChangelogTemplate.php
+++ b/src/Generator/Traits/ChangelogTemplate.php
@@ -75,7 +75,7 @@ trait ChangelogTemplate
                 case 'method':
                 case 'parameter':
                 case 'representation':
-                case 'resource_namespace':
+                case 'resource_group':
                 case 'uri':
                     $searches[] = '{' . $key . '}';
                     if (is_array($value)) {

--- a/src/Parser/Annotation.php
+++ b/src/Parser/Annotation.php
@@ -63,6 +63,13 @@ abstract class Annotation
     const SUPPORTS_VERSIONING = false;
 
     /**
+     * An array of items that should be included in an array representation of this annotation.
+     *
+     * @var array
+     */
+    const ARRAYABLE = [];
+
+    /**
      * The raw annotation from the docblock.
      *
      * @var string
@@ -138,13 +145,6 @@ abstract class Annotation
      * @var array
      */
     protected $parsed_data = [];
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [];
 
     /**
      * @param string $doc
@@ -409,7 +409,7 @@ abstract class Annotation
     public function toArray(): array
     {
         $arr = [];
-        foreach ($this->arrayable as $var) {
+        foreach (static::ARRAYABLE as $var) {
             if ($this->{$var} instanceof Annotation) {
                 $arr += $this->{$var}->toArray();
             } else {

--- a/src/Parser/Annotations/ContentTypeAnnotation.php
+++ b/src/Parser/Annotations/ContentTypeAnnotation.php
@@ -12,17 +12,12 @@ class ContentTypeAnnotation extends Annotation
 {
     const SUPPORTS_VERSIONING = true;
 
-    /** @var string */
-    protected $content_type;
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [
+    const ARRAYABLE = [
         'content_type'
     ];
+
+    /** @var string */
+    protected $content_type;
 
     /**
      * {@inheritdoc}

--- a/src/Parser/Annotations/DataAnnotation.php
+++ b/src/Parser/Annotations/DataAnnotation.php
@@ -18,6 +18,16 @@ class DataAnnotation extends Annotation
     const SUPPORTS_VENDOR_TAGS = true;
     const SUPPORTS_VERSIONING = true;
 
+    const ARRAYABLE = [
+        'description',
+        'identifier',
+        'nullable',
+        'sample_data',
+        'subtype',
+        'type',
+        'values'
+    ];
+
     /**
      * Identifier for this data.
      *
@@ -66,21 +76,6 @@ class DataAnnotation extends Annotation
      * @var string
      */
     protected $description;
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [
-        'description',
-        'identifier',
-        'nullable',
-        'sample_data',
-        'subtype',
-        'type',
-        'values'
-    ];
 
     /**
      * {@inheritdoc}

--- a/src/Parser/Annotations/DescriptionAnnotation.php
+++ b/src/Parser/Annotations/DescriptionAnnotation.php
@@ -10,17 +10,12 @@ use Mill\Parser\Version;
  */
 class DescriptionAnnotation extends Annotation
 {
-    /** @var string */
-    protected $description;
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [
+    const ARRAYABLE = [
         'description'
     ];
+
+    /** @var string */
+    protected $description;
 
     /**
      * {@inheritdoc}

--- a/src/Parser/Annotations/ErrorAnnotation.php
+++ b/src/Parser/Annotations/ErrorAnnotation.php
@@ -27,6 +27,13 @@ class ErrorAnnotation extends Annotation
     const REGEX_ERROR_TYPE = '/{([\w\s]+)}/';
     const REGEX_ERROR_SUB_TYPE = '/{([\w\s]+),([\w\s]+)}/';
 
+    const ARRAYABLE = [
+        'description',
+        'error_code',
+        'http_code',
+        'representation'
+    ];
+
     /**
      * Optional unique error code for the error that this exception handles.
      *
@@ -40,18 +47,6 @@ class ErrorAnnotation extends Annotation
      * @var string
      */
     protected $description;
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [
-        'description',
-        'error_code',
-        'http_code',
-        'representation'
-    ];
 
     /**
      * {@inheritdoc}

--- a/src/Parser/Annotations/GroupAnnotation.php
+++ b/src/Parser/Annotations/GroupAnnotation.php
@@ -1,0 +1,67 @@
+<?php
+namespace Mill\Parser\Annotations;
+
+use Mill\Parser\Annotation;
+use Mill\Parser\Version;
+
+/**
+ * Handler for the `@api-group` annotation.
+ *
+ */
+class GroupAnnotation extends Annotation
+{
+    const ARRAYABLE = [
+        'group'
+    ];
+
+    /** @var string */
+    protected $group;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parser(): array
+    {
+        return [
+            'group' => $this->docblock
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interpreter(): void
+    {
+        $this->group = $this->required('group');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function hydrate(array $data = [], Version $version = null): self
+    {
+        /** @var GroupAnnotation $annotation */
+        $annotation = parent::hydrate($data, $version);
+        $annotation->setGroup($data['group']);
+
+        return $annotation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGroup(): string
+    {
+        return $this->group;
+    }
+
+    /**
+     * @param string $group
+     * @return self
+     */
+    public function setGroup(string $group): self
+    {
+        $this->group = $group;
+        return $this;
+    }
+}

--- a/src/Parser/Annotations/LabelAnnotation.php
+++ b/src/Parser/Annotations/LabelAnnotation.php
@@ -10,17 +10,12 @@ use Mill\Parser\Version;
  */
 class LabelAnnotation extends Annotation
 {
-    /** @var string */
-    protected $label;
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [
+    const ARRAYABLE = [
         'label'
     ];
+
+    /** @var string */
+    protected $label;
 
     /**
      * {@inheritdoc}

--- a/src/Parser/Annotations/MinVersionAnnotation.php
+++ b/src/Parser/Annotations/MinVersionAnnotation.php
@@ -17,17 +17,12 @@ use Mill\Parser\Version;
  */
 class MinVersionAnnotation extends Annotation
 {
-    /** @var string */
-    protected $minimum_version;
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [
+    const ARRAYABLE = [
         'minimum_version'
     ];
+
+    /** @var string */
+    protected $minimum_version;
 
     /**
      * {@inheritdoc}

--- a/src/Parser/Annotations/ParamAnnotation.php
+++ b/src/Parser/Annotations/ParamAnnotation.php
@@ -19,6 +19,17 @@ class ParamAnnotation extends Annotation
     const SUPPORTS_VENDOR_TAGS = true;
     const SUPPORTS_VERSIONING = true;
 
+    const ARRAYABLE = [
+        'description',
+        'field',
+        'nullable',
+        'required',
+        'sample_data',
+        'type',
+        'values',
+        'visible'
+    ];
+
     /**
      * Name of this parameter's field.
      *
@@ -67,22 +78,6 @@ class ParamAnnotation extends Annotation
      * @var array|null
      */
     protected $values = [];
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [
-        'description',
-        'field',
-        'nullable',
-        'required',
-        'sample_data',
-        'type',
-        'values',
-        'visible'
-    ];
 
     /**
      * {@inheritdoc}

--- a/src/Parser/Annotations/ReturnAnnotation.php
+++ b/src/Parser/Annotations/ReturnAnnotation.php
@@ -22,6 +22,14 @@ class ReturnAnnotation extends Annotation
 
     const REGEX_TYPE = '/^({[^}]*})/';
 
+    const ARRAYABLE = [
+        'description',
+        'http_code',
+        'representation',
+        'type',
+        'visible'
+    ];
+
     /**
      * Description for what this annotations' action return is.
      *
@@ -35,19 +43,6 @@ class ReturnAnnotation extends Annotation
      * @var string
      */
     protected $type;
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [
-        'description',
-        'http_code',
-        'representation',
-        'type',
-        'visible'
-    ];
 
     /**
      * {@inheritdoc}

--- a/src/Parser/Annotations/ScopeAnnotation.php
+++ b/src/Parser/Annotations/ScopeAnnotation.php
@@ -12,6 +12,11 @@ use Mill\Parser\Version;
  */
 class ScopeAnnotation extends Annotation
 {
+    const ARRAYABLE = [
+        'description',
+        'scope'
+    ];
+
     /** @var string */
     protected $scope;
 
@@ -21,16 +26,6 @@ class ScopeAnnotation extends Annotation
      * @var false|null|string
      */
     protected $description = null;
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [
-        'description',
-        'scope'
-    ];
 
     /**
      * {@inheritdoc}

--- a/src/Parser/Annotations/UriAnnotation.php
+++ b/src/Parser/Annotations/UriAnnotation.php
@@ -15,19 +15,9 @@ class UriAnnotation extends Annotation
     const SUPPORTS_ALIASING = true;
     const SUPPORTS_DEPRECATION = true;
 
-    const NAMESPACE_REGEX = '/{([\w\/\\\ ]+)}/';
-
     const ARRAYABLE = [
-        'namespace',
         'path'
     ];
-
-    /**
-     * Namespace that this URI belongs to.
-     *
-     * @var string
-     */
-    protected $namespace;
 
     /**
      * URI path that this annotation represents.
@@ -41,18 +31,9 @@ class UriAnnotation extends Annotation
      */
     protected function parser(): array
     {
-        $parsed = [];
-        $content = $this->docblock;
-
-        // Namespace is surrounded by `{curly braces}`.
-        if (preg_match(self::NAMESPACE_REGEX, $content, $matches)) {
-            $parsed['namespace'] = $matches[1];
-            $content = trim(preg_replace(self::NAMESPACE_REGEX, '', $content));
-        }
-
-        $parsed['path'] = trim($content);
-
-        return $parsed;
+        return [
+            'path' => trim($this->docblock)
+        ];
     }
 
     /**
@@ -60,7 +41,6 @@ class UriAnnotation extends Annotation
      */
     protected function interpreter(): void
     {
-        $this->namespace = $this->required('namespace');
         $this->path = $this->required('path');
     }
 
@@ -71,28 +51,9 @@ class UriAnnotation extends Annotation
     {
         /** @var UriAnnotation $annotation */
         $annotation = parent::hydrate($data, $version);
-        $annotation->setNamespace($data['namespace']);
         $annotation->setPath($data['path']);
 
         return $annotation;
-    }
-
-    /**
-     * @return string
-     */
-    public function getNamespace(): string
-    {
-        return $this->namespace;
-    }
-
-    /**
-     * @param string $namespace
-     * @return self
-     */
-    public function setNamespace(string $namespace): self
-    {
-        $this->namespace = $namespace;
-        return $this;
     }
 
     /**

--- a/src/Parser/Annotations/UriAnnotation.php
+++ b/src/Parser/Annotations/UriAnnotation.php
@@ -17,6 +17,11 @@ class UriAnnotation extends Annotation
 
     const NAMESPACE_REGEX = '/{([\w\/\\\ ]+)}/';
 
+    const ARRAYABLE = [
+        'namespace',
+        'path'
+    ];
+
     /**
      * Namespace that this URI belongs to.
      *
@@ -30,16 +35,6 @@ class UriAnnotation extends Annotation
      * @var string
      */
     protected $path;
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [
-        'namespace',
-        'path'
-    ];
 
     /**
      * {@inheritdoc}

--- a/src/Parser/Annotations/UriSegmentAnnotation.php
+++ b/src/Parser/Annotations/UriSegmentAnnotation.php
@@ -15,6 +15,14 @@ class UriSegmentAnnotation extends Annotation
 
     const REGEX_URI = '/^({[^}]*})/';
 
+    const ARRAYABLE = [
+        'description',
+        'field',
+        'type',
+        'uri',
+        'values'
+    ];
+
     /**
      * URI that this segment is for.
      *
@@ -49,19 +57,6 @@ class UriSegmentAnnotation extends Annotation
      * @var array|false|null
      */
     protected $values = [];
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [
-        'description',
-        'field',
-        'type',
-        'uri',
-        'values'
-    ];
 
     /**
      * {@inheritdoc}

--- a/src/Parser/Annotations/VendorTagAnnotation.php
+++ b/src/Parser/Annotations/VendorTagAnnotation.php
@@ -12,21 +12,16 @@ use Mill\Parser\Version;
  */
 class VendorTagAnnotation extends Annotation
 {
+    const ARRAYABLE = [
+        'vendor_tag'
+    ];
+
     /**
      * Name of this vendor tag.
      *
      * @var string
      */
     protected $vendor_tag;
-
-    /**
-     * An array of items that should be included in an array representation of this annotation.
-     *
-     * @var array
-     */
-    protected $arrayable = [
-        'vendor_tag'
-    ];
 
     /**
      * {@inheritdoc}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -46,8 +46,8 @@ class ConfigTest extends TestCase
         ], $config->getApiVersions());
 
         $this->assertSame([
-            'FakeExcludeNamespace'
-        ], $config->getBlueprintNamespaceExcludes());
+            'FakeExcludeGroup'
+        ], $config->getBlueprintGroupExcludes());
 
         $this->assertSame([
             'tag:BUY_TICKETS',
@@ -284,13 +284,13 @@ XML
             'generators.blueprint.exclude.invalid' => [
                 'includes' => ['versions', 'controllers', 'representations'],
                 'exception' => [
-                    'regex' => '/invalid Blueprint generator namespace/'
+                    'regex' => '/invalid Blueprint generator group/'
                 ],
                 'xml' => <<<XML
 <generators>
     <blueprint>
         <excludes>
-            <exclude namespace="" />
+            <exclude group="" />
         </excludes>
     </blueprint>
 </generators>

--- a/tests/Generator/BlueprintTest.php
+++ b/tests/Generator/BlueprintTest.php
@@ -50,7 +50,7 @@ class BlueprintTest extends TestCase
 
     public function testGenerationWithAnExcludedGroup(): void
     {
-        $this->getConfig()->addBlueprintNamespaceExclude('Movies');
+        $this->getConfig()->addBlueprintGroupExclude('Movies');
 
         $blueprint = new Blueprint($this->getConfig());
         $generated = $blueprint->generate();
@@ -68,6 +68,6 @@ class BlueprintTest extends TestCase
             $this->assertArrayHasKey('Theaters', $section['groups']);
         }
 
-        $this->getConfig()->removeBlueprintNamespaceExclude('Movies');
+        $this->getConfig()->removeBlueprintGroupExclude('Movies');
     }
 }

--- a/tests/Generator/Changelog/Formats/JsonTest.php
+++ b/tests/Generator/Changelog/Formats/JsonTest.php
@@ -31,111 +31,111 @@ class JsonTest extends TestCase
             'added' => [
                 'resources' => [
                     [
-                        'The following <span class="mill-changelog_resource_namespace" ' .
-                            'data-mill-resource-namespace="Movies">Movies</span> resources have added:',
+                        'The following <span class="mill-changelog_resource_group" ' .
+                            'data-mill-resource-group="Movies">Movies</span> resources have added:',
                         [
                             [
-                                '<span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                                '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                     'data-mill-method="GET" data-mill-uri="/movie/{id}">/movie/{id}</span> now ' .
                                     'returns the following errors on <span class="mill-changelog_method" ' .
-                                    'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                    'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                     'data-mill-uri="/movie/{id}">GET</span> requests:',
                                 [
-                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
                                         'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
                                         'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                        'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                         'data-mill-uri="/movie/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: For no reason.',
-                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
                                         'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
                                         'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                        'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                         'data-mill-uri="/movie/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: For some ' .
                                         'other reason.'
                                 ]
                             ],
                             [
-                                '<span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                                '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                     'data-mill-method="GET" data-mill-uri="/movies/{id}">/movies/{id}</span> now ' .
                                     'returns the following errors on <span class="mill-changelog_method" ' .
-                                    'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                    'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                     'data-mill-uri="/movies/{id}">GET</span> requests:',
                                 [
-                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
                                         'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
                                         'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                        'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                         'data-mill-uri="/movies/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: For no reason.',
-                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
                                         'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
                                         'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                        'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                         'data-mill-uri="/movies/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: For some ' .
                                         'other reason.'
                                 ]
                             ],
                             [
-                                '<span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                                '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                     'data-mill-method="PATCH" data-mill-uri="/movies/{id}">/movies/{id}</span> now ' .
                                     'returns the following errors on <span class="mill-changelog_method" ' .
-                                    'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
+                                    'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
                                     'data-mill-uri="/movies/{id}">PATCH</span> requests:',
                                 [
-                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
                                         'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                         'data-mill-http-code="404 Not Found" data-mill-representation="Error">404 ' .
                                         'Not Found</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
+                                        'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
                                         'data-mill-uri="/movies/{id}" data-mill-http-code="404 Not Found" ' .
                                         'data-mill-representation="Error">Error</span> representation: If the ' .
                                         'trailer URL could not be validated.',
-                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
                                         'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                         'data-mill-http-code="403 Forbidden" data-mill-representation="Coded error">' .
                                         '403 Forbidden</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
+                                        'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
                                         'data-mill-uri="/movies/{id}" data-mill-http-code="403 Forbidden" ' .
                                         'data-mill-representation="Coded error">Coded error</span> representation: ' .
                                         'If something cool happened.',
-                                    '<span class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
+                                    '<span class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
                                         'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                         'data-mill-http-code="403 Forbidden" data-mill-representation="Coded error">' .
                                         '403 Forbidden</span> with a <span class="mill-changelog_representation" ' .
-                                        'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
+                                        'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
                                         'data-mill-uri="/movies/{id}" data-mill-http-code="403 Forbidden" ' .
                                         'data-mill-representation="Coded error">Coded error</span> representation: ' .
                                         'If the user is not allowed to edit that movie.'
                                 ]
                             ],
-                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-http-code="202 Accepted" data-mill-representation="Movie">/movies/{id}' .
-                                '</span>, <span class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
+                                '</span>, <span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-http-code="202 Accepted" data-mill-representation="Movie">PATCH</span> ' .
                                 'requests now return a <span class="mill-changelog_http_code" ' .
-                                'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/movies/{id}" data-mill-http-code="202 Accepted" ' .
                                 'data-mill-representation="Movie">202 Accepted</span> with a <span ' .
-                                'class="mill-changelog_representation" data-mill-resource-namespace="Movies" ' .
+                                'class="mill-changelog_representation" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-http-code="202 Accepted" data-mill-representation="Movie">Movie</span> ' .
                                 'representation.',
-                            '<span class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
+                            '<span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="POST" data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
                                 'data-mill-representation="">POST</span> on <span class="mill-changelog_uri" ' .
-                                'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                 'data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
                                 'data-mill-representation="">/movies</span> now returns a <span ' .
-                                'class="mill-changelog_http_code" data-mill-resource-namespace="Movies" ' .
+                                'class="mill-changelog_http_code" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="POST" data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
                                 'data-mill-representation="">201 Created</span>.'
                         ]
@@ -160,109 +160,109 @@ class JsonTest extends TestCase
             'changed' => [
                 'resources' => [
                     [
-                        'The following <span class="mill-changelog_resource_namespace" ' .
-                            'data-mill-resource-namespace="Movies">Movies</span> resources have changed:',
+                        'The following <span class="mill-changelog_resource_group" ' .
+                            'data-mill-resource-group="Movies">Movies</span> resources have changed:',
                         [
-                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">/movie/{id}</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movie/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">GET</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                 'data-mill-uri="/movie/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">/movies/{id}</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">GET</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                 'data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">/movies/{id}</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">PATCH</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/movies/{id}" ' .
                                 'data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies" ' .
                                 'data-mill-content-type="application/mill.example.movie">/movies</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies" ' .
                                 'data-mill-content-type="application/mill.example.movie">GET</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                 'data-mill-uri="/movies" data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="POST" data-mill-uri="/movies" ' .
                                 'data-mill-content-type="application/mill.example.movie">/movies</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="POST" data-mill-uri="/movies" ' .
                                 'data-mill-content-type="application/mill.example.movie">POST</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                 'data-mill-uri="/movies" data-mill-content-type="application/mill.example.movie">' .
                                 'application/mill.example.movie</span> Content-Type header.'
                         ]
                     ],
                     [
-                        'The following <span class="mill-changelog_resource_namespace" ' .
-                            'data-mill-resource-namespace="Theaters">Theaters</span> resources have changed:',
+                        'The following <span class="mill-changelog_resource_group" ' .
+                            'data-mill-resource-group="Theaters">Theaters</span> resources have changed:',
                         [
-                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Theaters" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="GET" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">/theaters/{id}</span>, ' .
-                                '<span class="mill-changelog_method" data-mill-resource-namespace="Theaters" ' .
+                                '<span class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="GET" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">GET</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-namespace="Theaters" data-mill-method="GET" ' .
+                                'data-mill-resource-group="Theaters" data-mill-method="GET" ' .
                                 'data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">' .
                                 'application/mill.example.theater</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Theaters" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">/theaters/{id}</span>, ' .
-                                '<span class="mill-changelog_method" data-mill-resource-namespace="Theaters" ' .
+                                '<span class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">PATCH</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-namespace="Theaters" data-mill-method="PATCH" ' .
+                                'data-mill-resource-group="Theaters" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-content-type="application/mill.example.theater">' .
                                 'application/mill.example.theater</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Theaters" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="GET" data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">/theaters</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-namespace="Theaters" ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="GET" data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">GET</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-namespace="Theaters" data-mill-method="GET" ' .
+                                'data-mill-resource-group="Theaters" data-mill-method="GET" ' .
                                 'data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">' .
                                 'application/mill.example.theater</span> Content-Type header.',
-                            'On <span class="mill-changelog_uri" data-mill-resource-namespace="Theaters" ' .
+                            'On <span class="mill-changelog_uri" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="POST" data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">/theaters</span>, <span ' .
-                                'class="mill-changelog_method" data-mill-resource-namespace="Theaters" ' .
+                                'class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="POST" data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">POST</span> requests now ' .
                                 'return a <span class="mill-changelog_content_type" ' .
-                                'data-mill-resource-namespace="Theaters" data-mill-method="POST" ' .
+                                'data-mill-resource-group="Theaters" data-mill-method="POST" ' .
                                 'data-mill-uri="/theaters" ' .
                                 'data-mill-content-type="application/mill.example.theater">' .
                                 'application/mill.example.theater</span> Content-Type header.'
@@ -273,21 +273,21 @@ class JsonTest extends TestCase
             'removed' => [
                 'resources' => [
                     [
-                        'The following <span class="mill-changelog_resource_namespace" ' .
-                            'data-mill-resource-namespace="Theaters">Theaters</span> resources have removed:',
+                        'The following <span class="mill-changelog_resource_group" ' .
+                            'data-mill-resource-group="Theaters">Theaters</span> resources have removed:',
                         [
-                            '<span class="mill-changelog_method" data-mill-resource-namespace="Theaters" ' .
+                            '<span class="mill-changelog_method" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-http-code="403 Forbidden" data-mill-representation="Coded error">PATCH' .
                                 '</span> requests to <span class="mill-changelog_uri" ' .
-                                'data-mill-resource-namespace="Theaters" data-mill-method="PATCH" ' .
+                                'data-mill-resource-group="Theaters" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/theaters/{id}" data-mill-http-code="403 Forbidden" ' .
                                 'data-mill-representation="Coded error">/theaters/{id}</span> no longer returns a ' .
-                                '<span class="mill-changelog_http_code" data-mill-resource-namespace="Theaters" ' .
+                                '<span class="mill-changelog_http_code" data-mill-resource-group="Theaters" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/theaters/{id}" ' .
                                 'data-mill-http-code="403 Forbidden" data-mill-representation="Coded error">403 ' .
                                 'Forbidden</span> with a <span class="mill-changelog_representation" ' .
-                                'data-mill-resource-namespace="Theaters" data-mill-method="PATCH" ' .
+                                'data-mill-resource-group="Theaters" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/theaters/{id}" data-mill-http-code="403 Forbidden" ' .
                                 'data-mill-representation="Coded error">Coded error</span> representation: If ' .
                                 'something cool happened.'
@@ -305,15 +305,15 @@ class JsonTest extends TestCase
             'added' => [
                 'resources' => [
                     [
-                        'The following <span class="mill-changelog_resource_namespace" ' .
-                            'data-mill-resource-namespace="Movies">Movies</span> resources have added:',
+                        'The following <span class="mill-changelog_resource_group" ' .
+                            'data-mill-resource-group="Movies">Movies</span> resources have added:',
                         [
-                            'A <span class="mill-changelog_parameter" data-mill-resource-namespace="Movies" ' .
+                            'A <span class="mill-changelog_parameter" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" data-mill-parameter="imdb">' .
                                 'imdb</span> request parameter was added to <span class="mill-changelog_method" ' .
-                                'data-mill-resource-namespace="Movies" data-mill-method="PATCH" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="PATCH" ' .
                                 'data-mill-uri="/movies/{id}" data-mill-parameter="imdb">PATCH</span> on <span ' .
-                                'class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                                'class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="PATCH" data-mill-uri="/movies/{id}" data-mill-parameter="imdb">' .
                                 '/movies/{id}</span>.'
                         ]
@@ -347,33 +347,33 @@ class JsonTest extends TestCase
                 ],
                 'resources' => [
                     [
-                        'The following <span class="mill-changelog_resource_namespace" ' .
-                            'data-mill-resource-namespace="Movies">Movies</span> resources have added:',
+                        'The following <span class="mill-changelog_resource_group" ' .
+                            'data-mill-resource-group="Movies">Movies</span> resources have added:',
                         [
                             [
-                                '<span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                                '<span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                     'data-mill-uri="/movies/{id}">/movies/{id}</span> has been added with support ' .
                                     'for the following HTTP methods:',
                                 [
-                                    '<span class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
+                                    '<span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                         'data-mill-method="PATCH" data-mill-uri="/movies/{id}">PATCH</span>',
-                                    '<span class="mill-changelog_method" data-mill-resource-namespace="Movies" ' .
+                                    '<span class="mill-changelog_method" data-mill-resource-group="Movies" ' .
                                         'data-mill-method="DELETE" data-mill-uri="/movies/{id}">DELETE</span>'
                                 ]
                             ],
-                            'A <span class="mill-changelog_parameter" data-mill-resource-namespace="Movies" ' .
+                            'A <span class="mill-changelog_parameter" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies" data-mill-parameter="page">page' .
                                 '</span> request parameter was added to <span class="mill-changelog_method" ' .
-                                'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                 'data-mill-uri="/movies" data-mill-parameter="page">GET</span> on <span ' .
-                                'class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                                'class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                 'data-mill-method="GET" data-mill-uri="/movies" data-mill-parameter="page">' .
                                 '/movies</span>.',
                             [
                                 'The following parameters have been added to <span class="mill-changelog_method" ' .
-                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                     'data-mill-uri="/movies">POST</span> on <span class="mill-changelog_uri" ' .
-                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                     'data-mill-uri="/movies">/movies</span>:',
                                 [
                                     '<span class="mill-changelog_parameter" data-mill-parameter="imdb">imdb</span>',
@@ -425,14 +425,14 @@ class JsonTest extends TestCase
                                         Changelog::CHANGESET_TYPE_ACTION_RETURN => [
                                             'hashed-set.1' => [
                                                 [
-                                                    'resource_namespace' => 'Movies',
+                                                    'resource_group' => 'Movies',
                                                     'method' => 'POST',
                                                     'uri' => '/movies',
                                                     'http_code' => '201 Created',
                                                     'representation' => false
                                                 ],
                                                 [
-                                                    'resource_namespace' => 'Movies',
+                                                    'resource_group' => 'Movies',
                                                     'method' => 'POST',
                                                     'uri' => '/movies',
                                                     'http_code' => '200 OK',
@@ -441,7 +441,7 @@ class JsonTest extends TestCase
                                             ],
                                             'hashed-set.2' => [
                                                 [
-                                                    'resource_namespace' => 'Movies',
+                                                    'resource_group' => 'Movies',
                                                     'method' => 'GET',
                                                     'uri' => '/movies',
                                                     'http_code' => '200 OK',
@@ -460,44 +460,44 @@ class JsonTest extends TestCase
                         'added' => [
                             'resources' => [
                                 [
-                                    'The following <span class="mill-changelog_resource_namespace" ' .
-                                        'data-mill-resource-namespace="Movies">Movies</span> resources have added:',
+                                    'The following <span class="mill-changelog_resource_group" ' .
+                                        'data-mill-resource-group="Movies">Movies</span> resources have added:',
                                     [
                                         [
                                             'The <span class="mill-changelog_method" ' .
-                                                'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                                'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                                 'data-mill-uri="/movies">POST</span> on <span ' .
-                                                'class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                                                'class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                                 'data-mill-method="POST" data-mill-uri="/movies">/movies</span> now ' .
                                                 'returns the following responses:',
                                             [
                                                 '<span class="mill-changelog_http_code" ' .
-                                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                                     'data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
                                                     'data-mill-representation="">201 Created</span>',
                                                 '<span class="mill-changelog_http_code" ' .
-                                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                                     'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                                     'data-mill-representation="Movie">200 OK</span> with a <span ' .
                                                     'class="mill-changelog_representation" ' .
-                                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                                     'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                                     'data-mill-representation="Movie">Movie</span> representation'
                                             ]
                                         ],
-                                        'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                                        'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                             'data-mill-method="GET" data-mill-uri="/movies" ' .
                                             'data-mill-http-code="200 OK" data-mill-representation="Movie">/movies' .
                                             '</span>, <span class="mill-changelog_method" ' .
-                                            'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                             'data-mill-representation="Movie">GET</span> requests now return a ' .
                                             '<span class="mill-changelog_http_code" ' .
-                                            'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                             'data-mill-representation="Movie">200 OK</span> with a <span ' .
                                             'class="mill-changelog_representation" ' .
-                                            'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                             'data-mill-representation="Movie">Movie</span> representation.'
                                     ]
@@ -517,14 +517,14 @@ class JsonTest extends TestCase
                                         Changelog::CHANGESET_TYPE_ACTION_RETURN => [
                                             'hashed-set.1' => [
                                                 [
-                                                    'resource_namespace' => 'Movies',
+                                                    'resource_group' => 'Movies',
                                                     'method' => 'POST',
                                                     'uri' => '/movies',
                                                     'http_code' => '201 Created',
                                                     'representation' => false
                                                 ],
                                                 [
-                                                    'resource_namespace' => 'Movies',
+                                                    'resource_group' => 'Movies',
                                                     'method' => 'POST',
                                                     'uri' => '/movies',
                                                     'http_code' => '200 OK',
@@ -533,7 +533,7 @@ class JsonTest extends TestCase
                                             ],
                                             'hashed-set.2' => [
                                                 [
-                                                    'resource_namespace' => 'Movies',
+                                                    'resource_group' => 'Movies',
                                                     'method' => 'GET',
                                                     'uri' => '/movies',
                                                     'http_code' => '200 OK',
@@ -552,44 +552,44 @@ class JsonTest extends TestCase
                         'removed' => [
                             'resources' => [
                                 [
-                                    'The following <span class="mill-changelog_resource_namespace" ' .
-                                        'data-mill-resource-namespace="Movies">Movies</span> resources have removed:',
+                                    'The following <span class="mill-changelog_resource_group" ' .
+                                        'data-mill-resource-group="Movies">Movies</span> resources have removed:',
                                     [
                                         [
                                             'The <span class="mill-changelog_method" ' .
-                                                'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                                'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                                 'data-mill-uri="/movies">POST</span> on <span ' .
-                                                'class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                                                'class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                                 'data-mill-method="POST" data-mill-uri="/movies">/movies</span> no ' .
                                                 'longer returns the following responses:',
                                             [
                                                 '<span class="mill-changelog_http_code" ' .
-                                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                                     'data-mill-uri="/movies" data-mill-http-code="201 Created" ' .
                                                     'data-mill-representation="">201 Created</span>',
                                                 '<span class="mill-changelog_http_code" ' .
-                                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                                     'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                                     'data-mill-representation="Movie">200 OK</span> with a <span ' .
                                                     'class="mill-changelog_representation" ' .
-                                                    'data-mill-resource-namespace="Movies" data-mill-method="POST" ' .
+                                                    'data-mill-resource-group="Movies" data-mill-method="POST" ' .
                                                     'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                                     'data-mill-representation="Movie">Movie</span> representation'
                                             ]
                                         ],
-                                        'On <span class="mill-changelog_uri" data-mill-resource-namespace="Movies" ' .
+                                        'On <span class="mill-changelog_uri" data-mill-resource-group="Movies" ' .
                                             'data-mill-method="GET" data-mill-uri="/movies" ' .
                                             'data-mill-http-code="200 OK" data-mill-representation="Movie">/movies' .
                                             '</span>, <span class="mill-changelog_method" ' .
-                                            'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                             'data-mill-representation="Movie">GET</span> requests no longer return ' .
                                             'a <span class="mill-changelog_http_code" ' .
-                                            'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                             'data-mill-representation="Movie">200 OK</span> with a <span ' .
                                             'class="mill-changelog_representation" ' .
-                                            'data-mill-resource-namespace="Movies" data-mill-method="GET" ' .
+                                            'data-mill-resource-group="Movies" data-mill-method="GET" ' .
                                             'data-mill-uri="/movies" data-mill-http-code="200 OK" ' .
                                             'data-mill-representation="Movie">Movie</span> representation.'
                                     ]

--- a/tests/Generator/ChangelogTest.php
+++ b/tests/Generator/ChangelogTest.php
@@ -64,7 +64,7 @@ class ChangelogTest extends TestCase
                     'error' => [
                         '2e302f7f79' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movie/{id}',
                                 'http_code' => '404 Not Found',
@@ -72,7 +72,7 @@ class ChangelogTest extends TestCase
                                 'description' => 'For no reason.'
                             ],
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movie/{id}',
                                 'http_code' => '404 Not Found',
@@ -86,7 +86,7 @@ class ChangelogTest extends TestCase
                     'return' => [
                         '3781891d58' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'POST',
                                 'uri' => '/movies',
                                 'http_code' => '201 Created',
@@ -99,7 +99,7 @@ class ChangelogTest extends TestCase
                     'error' => [
                         'e7dc298139' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '404 Not Found',
@@ -107,7 +107,7 @@ class ChangelogTest extends TestCase
                                 'description' => 'For no reason.'
                             ],
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '404 Not Found',
@@ -117,7 +117,7 @@ class ChangelogTest extends TestCase
                         ],
                         '162944fa14' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '404 Not Found',
@@ -125,7 +125,7 @@ class ChangelogTest extends TestCase
                                 'description' => 'If the trailer URL could not be validated.'
                             ],
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '403 Forbidden',
@@ -137,7 +137,7 @@ class ChangelogTest extends TestCase
                     'return' => [
                         '162944fa14' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'http_code' => '202 Accepted',
@@ -152,7 +152,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movie/{id}',
                                 'content_type' => 'application/mill.example.movie'
@@ -164,7 +164,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies',
                                 'content_type' => 'application/mill.example.movie'
@@ -172,7 +172,7 @@ class ChangelogTest extends TestCase
                         ],
                         '066564ef49' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'POST',
                                 'uri' => '/movies',
                                 'content_type' => 'application/mill.example.movie'
@@ -184,7 +184,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies/{id}',
                                 'content_type' => 'application/mill.example.movie'
@@ -192,7 +192,7 @@ class ChangelogTest extends TestCase
                         ],
                         'f4628f751a' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'content_type' => 'application/mill.example.movie'
@@ -204,7 +204,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
-                                'resource_namespace' => 'Theaters',
+                                'resource_group' => 'Theaters',
                                 'method' => 'GET',
                                 'uri' => '/theaters',
                                 'content_type' => 'application/mill.example.theater'
@@ -212,7 +212,7 @@ class ChangelogTest extends TestCase
                         ],
                         '066564ef49' => [
                             [
-                                'resource_namespace' => 'Theaters',
+                                'resource_group' => 'Theaters',
                                 'method' => 'POST',
                                 'uri' => '/theaters',
                                 'content_type' => 'application/mill.example.theater'
@@ -224,7 +224,7 @@ class ChangelogTest extends TestCase
                     'action_error' => [
                         'b3a16c4d74' => [
                             [
-                                'resource_namespace' => 'Theaters',
+                                'resource_group' => 'Theaters',
                                 'method' => 'PATCH',
                                 'uri' => '/theaters/{id}',
                                 'http_code' => '403 Forbidden',
@@ -236,7 +236,7 @@ class ChangelogTest extends TestCase
                     'content_type' => [
                         '979fc6e97f' => [
                             [
-                                'resource_namespace' => 'Theaters',
+                                'resource_group' => 'Theaters',
                                 'method' => 'GET',
                                 'uri' => '/theaters/{id}',
                                 'content_type' => 'application/mill.example.theater'
@@ -244,7 +244,7 @@ class ChangelogTest extends TestCase
                         ],
                         'f4628f751a' => [
                             [
-                                'resource_namespace' => 'Theaters',
+                                'resource_group' => 'Theaters',
                                 'method' => 'PATCH',
                                 'uri' => '/theaters/{id}',
                                 'content_type' => 'application/mill.example.theater'
@@ -258,7 +258,7 @@ class ChangelogTest extends TestCase
                     'param' => [
                         '162944fa14' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}',
                                 'parameter' => 'imdb',
@@ -273,7 +273,7 @@ class ChangelogTest extends TestCase
                     'param' => [
                         '776d02bb83' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'GET',
                                 'uri' => '/movies',
                                 'parameter' => 'page',
@@ -282,14 +282,14 @@ class ChangelogTest extends TestCase
                         ],
                         '3781891d58' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'POST',
                                 'uri' => '/movies',
                                 'parameter' => 'imdb',
                                 'description' => 'IMDB URL'
                             ],
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'POST',
                                 'uri' => '/movies',
                                 'parameter' => 'trailer',
@@ -302,12 +302,12 @@ class ChangelogTest extends TestCase
                     'action' => [
                         'd81e7058dd' => [
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'PATCH',
                                 'uri' => '/movies/{id}'
                             ],
                             [
-                                'resource_namespace' => 'Movies',
+                                'resource_group' => 'Movies',
                                 'method' => 'DELETE',
                                 'uri' => '/movies/{id}'
                             ]
@@ -391,7 +391,7 @@ class ChangelogTest extends TestCase
                                                     // should be available on the complete changelog.
                                                     $actions[2] = $actions[1];
                                                     $actions[1] = [
-                                                        'resource_namespace' => 'Movies',
+                                                        'resource_group' => 'Movies',
                                                         'method' => 'PATCH',
                                                         'uri' => '/movies/{id}',
                                                         'http_code' => '403 Forbidden',

--- a/tests/Parser/Annotations/GroupAnnotationTest.php
+++ b/tests/Parser/Annotations/GroupAnnotationTest.php
@@ -1,0 +1,82 @@
+<?php
+namespace Mill\Tests\Parser\Annotations;
+
+use Mill\Exceptions\Annotations\MissingRequiredFieldException;
+use Mill\Parser\Annotations\GroupAnnotation;
+
+class GroupAnnotationTest extends AnnotationTest
+{
+    /**
+     * @dataProvider providerAnnotation
+     * @param string $content
+     * @param array $expected
+     */
+    public function testAnnotation(string $content, array $expected): void
+    {
+        $annotation = new GroupAnnotation($content, __CLASS__, __METHOD__);
+        $annotation->process();
+
+        $this->assertAnnotation($annotation, $expected);
+    }
+
+    /**
+     * @dataProvider providerAnnotation
+     * @param string $content
+     * @param array $expected
+     */
+    public function testHydrate(string $content, array $expected): void
+    {
+        $annotation = GroupAnnotation::hydrate(array_merge(
+            $expected,
+            [
+                'class' => __CLASS__,
+                'method' => __METHOD__
+            ]
+        ));
+
+        $this->assertAnnotation($annotation, $expected);
+    }
+
+    private function assertAnnotation(GroupAnnotation $annotation, array $expected): void
+    {
+        $this->assertFalse($annotation->supportsAliasing());
+        $this->assertFalse($annotation->supportsDeprecation());
+        $this->assertFalse($annotation->supportsVersioning());
+        $this->assertFalse($annotation->supportsVendorTags());
+        $this->assertFalse($annotation->requiresVisibilityDecorator());
+
+        $this->assertSame($expected, $annotation->toArray());
+        $this->assertEmpty($annotation->getVendorTags());
+        $this->assertFalse($annotation->getVersion());
+        $this->assertEmpty($annotation->getAliases());
+    }
+
+    public function providerAnnotation(): array
+    {
+        return [
+            '_complete' => [
+                'content' => 'Movies\Coming Soon',
+                'expected' => [
+                    'group' => 'Movies\Coming Soon'
+                ]
+            ]
+        ];
+    }
+
+    public function providerAnnotationFailsOnInvalidContent(): array
+    {
+        return [
+            'missing-group' => [
+                'annotation' => GroupAnnotation::class,
+                'content' => '',
+                'expected.exception' => MissingRequiredFieldException::class,
+                'expected.exception.asserts' => [
+                    'getRequiredField' => 'group',
+                    'getAnnotation' => 'group',
+                    'getDocblock' => '',
+                    'getValues' => []
+                ]
+            ]
+        ];
+    }
+}

--- a/tests/Parser/Annotations/UriAnnotationTest.php
+++ b/tests/Parser/Annotations/UriAnnotationTest.php
@@ -63,7 +63,7 @@ class UriAnnotationTest extends AnnotationTest
     {
         $this->getConfig()->addUriSegmentTranslation('movie_id', 'id');
 
-        $annotation = new UriAnnotation('{Movies\Showtimes} /movies/+movie_id/showtimes', __CLASS__, __METHOD__);
+        $annotation = new UriAnnotation('/movies/+movie_id/showtimes', __CLASS__, __METHOD__);
         $annotation->process();
 
         $this->assertSame('/movies/{id}/showtimes', $annotation->getCleanPath());
@@ -74,7 +74,7 @@ class UriAnnotationTest extends AnnotationTest
     {
         return [
             'private' => [
-                'content' => '{Movies\Showtimes} /movies/+id/showtimes',
+                'content' => '/movies/+id/showtimes',
                 'visible' => false,
                 'deprecated' => false,
                 'expected' => [
@@ -83,30 +83,13 @@ class UriAnnotationTest extends AnnotationTest
                         'aliased' => false,
                         'aliases' => [],
                         'deprecated' => false,
-                        'namespace' => 'Movies\Showtimes',
                         'path' => '/movies/+id/showtimes',
                         'visible' => false
                     ]
                 ]
             ],
-            'private.namespace_with_no_depth' => [
-                'content' => '{Movies} /movies',
-                'visible' => false,
-                'deprecated' => false,
-                'expected' => [
-                    'clean.path' => '/movies',
-                    'array' => [
-                        'aliased' => false,
-                        'aliases' => [],
-                        'deprecated' => false,
-                        'namespace' => 'Movies',
-                        'path' => '/movies',
-                        'visible' => false
-                    ]
-                ]
-            ],
             'public' => [
-                'content' => '{Movies\Showtimes} /movies/+id/showtimes',
+                'content' => '/movies/+id/showtimes',
                 'visible' => true,
                 'deprecated' => false,
                 'expected' => [
@@ -115,14 +98,13 @@ class UriAnnotationTest extends AnnotationTest
                         'aliased' => false,
                         'aliases' => [],
                         'deprecated' => false,
-                        'namespace' => 'Movies\Showtimes',
                         'path' => '/movies/+id/showtimes',
                         'visible' => true
                     ]
                 ]
             ],
             'public.deprecated' => [
-                'content' => '{Movies\Showtimes} /movies/+id/showtimes',
+                'content' => '/movies/+id/showtimes',
                 'visible' => true,
                 'deprecated' => true,
                 'expected' => [
@@ -131,24 +113,7 @@ class UriAnnotationTest extends AnnotationTest
                         'aliased' => false,
                         'aliases' => [],
                         'deprecated' => true,
-                        'namespace' => 'Movies\Showtimes',
                         'path' => '/movies/+id/showtimes',
-                        'visible' => true
-                    ]
-                ]
-            ],
-            'public.non-alphanumeric_namespace' => [
-                'content' => '{/} /',
-                'visible' => true,
-                'deprecated' => false,
-                'expected' => [
-                    'clean.path' => '/',
-                    'array' => [
-                        'aliased' => false,
-                        'aliases' => [],
-                        'deprecated' => false,
-                        'namespace' => '/',
-                        'path' => '/',
                         'visible' => true
                     ]
                 ]
@@ -159,25 +124,14 @@ class UriAnnotationTest extends AnnotationTest
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [
-            'missing-namespace' => [
+            'missing-path' => [
                 'annotation' => UriAnnotation::class,
                 'content' => '',
                 'expected.exception' => MissingRequiredFieldException::class,
                 'expected.exception.asserts' => [
-                    'getRequiredField' => 'namespace',
-                    'getAnnotation' => 'uri',
-                    'getDocblock' => '',
-                    'getValues' => []
-                ]
-            ],
-            'missing-path' => [
-                'annotation' => UriAnnotation::class,
-                'content' => '{Movies}',
-                'expected.exception' => MissingRequiredFieldException::class,
-                'expected.exception.asserts' => [
                     'getRequiredField' => 'path',
                     'getAnnotation' => 'uri',
-                    'getDocblock' => '{Movies}',
+                    'getDocblock' => '',
                     'getValues' => []
                 ]
             ]

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -195,6 +195,7 @@ DESCRIPTION;
                 'expected' => [
                     'label' => 'Get a single movie.',
                     'description' => $get_description,
+                    'group' => 'Movies',
                     'vendor_tags.total' => 0,
                     'content_types.latest-version' => '1.1.2',
                     'content_types' => [
@@ -263,7 +264,6 @@ DESCRIPTION;
                                 'aliased' => true,
                                 'aliases' => [],
                                 'deprecated' => false,
-                                'namespace' => 'Movies',
                                 'path' => '/movie/+id',
                                 'visible' => false
                             ],
@@ -274,13 +274,11 @@ DESCRIPTION;
                                         'aliased' => true,
                                         'aliases' => [],
                                         'deprecated' => false,
-                                        'namespace' => 'Movies',
                                         'path' => '/movie/+id',
                                         'visible' => false
                                     ]
                                 ],
                                 'deprecated' => false,
-                                'namespace' => 'Movies',
                                 'path' => '/movies/+id',
                                 'visible' => true
                             ]
@@ -309,6 +307,7 @@ DESCRIPTION;
                 'expected' => [
                     'label' => 'Update a movie.',
                     'description' => 'Update a movies data.',
+                    'group' => 'Movies',
                     'vendor_tags.total' => 0,
                     'content_types.latest-version' => '1.1.2',
                     'content_types' => [
@@ -569,7 +568,6 @@ DESCRIPTION;
                                 'aliased' => false,
                                 'aliases' => [],
                                 'deprecated' => false,
-                                'namespace' => 'Movies',
                                 'path' => '/movies/+id',
                                 'visible' => true
                             ]
@@ -591,6 +589,7 @@ DESCRIPTION;
                 'expected' => [
                     'label' => 'Delete a movie.',
                     'description' => 'Delete a movie.',
+                    'group' => 'Movies',
                     'vendor_tags.total' => 1,
                     'content_types.latest-version' => null,
                     'content_types' => [
@@ -640,7 +639,6 @@ DESCRIPTION;
                                 'aliased' => false,
                                 'aliases' => [],
                                 'deprecated' => false,
-                                'namespace' => 'Movies',
                                 'path' => '/movies/+id',
                                 'visible' => false
                             ]
@@ -671,9 +669,10 @@ DESCRIPTION;
             'with-aliased-uris' => [
                 'docblock' => '/**
                   * @api-label Update a piece of content.
+                  * @api-group Foo\Bar
                   *
-                  * @api-uri:public {Foo\Bar} /foo
-                  * @api-uri:private:alias {Foo\Bar} /bar
+                  * @api-uri:public /foo
+                  * @api-uri:private:alias /bar
                   *
                   * @api-contentType application/json
                   * @api-scope public
@@ -692,13 +691,11 @@ DESCRIPTION;
                                         'aliased' => true,
                                         'aliases' => [],
                                         'deprecated' => false,
-                                        'namespace' => 'Foo\Bar',
                                         'path' => '/bar',
                                         'visible' => false
                                     ]
                                 ],
                                 'deprecated' => false,
-                                'namespace' => 'Foo\Bar',
                                 'path' => '/foo',
                                 'visible' => true
                             ],
@@ -706,7 +703,6 @@ DESCRIPTION;
                                 'aliased' => true,
                                 'aliases' => [],
                                 'deprecated' => false,
-                                'namespace' => 'Foo\Bar',
                                 'path' => '/bar',
                                 'visible' => false
                             ]
@@ -717,9 +713,10 @@ DESCRIPTION;
             'with-multiple-visibilities' => [
                 'docblock' => '/**
                   * @api-label Update a piece of content.
+                  * @api-group Foo\Bar
                   *
-                  * @api-uri:public {Foo\Bar} /foo
-                  * @api-uri:private {Foo\Bar} /bar
+                  * @api-uri:public /foo
+                  * @api-uri:private /bar
                   *
                   * @api-contentType application/json
                   * @api-scope public
@@ -735,7 +732,6 @@ DESCRIPTION;
                                 'aliased' => false,
                                 'aliases' => [],
                                 'deprecated' => false,
-                                'namespace' => 'Foo\Bar',
                                 'path' => '/foo',
                                 'visible' => true
                             ],
@@ -743,7 +739,6 @@ DESCRIPTION;
                                 'aliased' => false,
                                 'aliases' => [],
                                 'deprecated' => false,
-                                'namespace' => 'Foo\Bar',
                                 'path' => '/bar',
                                 'visible' => false
                             ]
@@ -754,8 +749,9 @@ DESCRIPTION;
             'with-capabilities' => [
                 'docblock' => '/**
                   * @api-label Delete a piece of content.
+                  * @api-group Foo\Bar
                   *
-                  * @api-uri:private {Foo\Bar} /foo
+                  * @api-uri:private /foo
                   *
                   * @api-contentType application/json
                   * @api-scope delete
@@ -790,7 +786,7 @@ DESCRIPTION;
                 'docblock' => '/**
                   * Test throwing an exception when a required `@api-label` annotation is missing.
                   *
-                  * @api-uri {Something} /some/page
+                  * @api-uri /some/page
                   */',
                 'expected.exception' => '\Mill\Exceptions\Annotations\RequiredAnnotationException',
                 'expected.exception.asserts' => [
@@ -814,7 +810,8 @@ DESCRIPTION;
                   * Test throwing an exception when a required `@api-contentType` annotation is missing.
                   *
                   * @api-label Test Method
-                  * @api-uri {Something} /some/page
+                  * @api-group Something
+                  * @api-uri /some/page
                   */',
                 'expected.exception' => '\Mill\Exceptions\Annotations\RequiredAnnotationException',
                 'expected.exception.asserts' => [
@@ -826,7 +823,8 @@ DESCRIPTION;
                   * Test throwing an exception when a required visibility decorator is missing on an annotation.
                   *
                   * @api-label Test method
-                  * @api-uri {Root} /
+                  * @api-group Root
+                  * @api-uri /
                   * @api-contentType application/json
                   * @api-return:public {collection} \Mill\Examples\Showtimes\Representations\Representation
                   */',
@@ -840,7 +838,8 @@ DESCRIPTION;
                   * Test throwing an exception when an unsupported decorator is found.
                   *
                   * @api-label Test method
-                  * @api-uri:special {Root} /
+                  * @api-group Root
+                  * @api-uri:special /
                   * @api-contentType application/json
                   * @api-return {collection} \Mill\Examples\Showtimes\Representations\Representation
                   */',
@@ -855,6 +854,7 @@ DESCRIPTION;
                   * Test throwing an exception when a required `@api-uri` annotation is missing.
                   *
                   * @api-label Test method
+                  * @api-group Something
                   * @api-contentType application/json
                   * @api-param:public {page}
                   */',
@@ -868,7 +868,8 @@ DESCRIPTION;
                   * Test throwing an exception when there are private annotations on a private action.
                   *
                   * @api-label Test method
-                  * @api-uri:private {Search} /search
+                  * @api-group Search
+                  * @api-uri:private /search
                   * @api-contentType application/json
                   * @api-scope public
                   * @api-return:private {collection} \Mill\Examples\Showtimes\Representations\Representation
@@ -882,11 +883,12 @@ DESCRIPTION;
             ],
             'too-many-aliases' => [
                 'docblock' => '/**
-                  * Test throwing an exception when there are private annotations on a private action.
+                  * Test throwing an exception when there is no canonical URI and only URI aliases.
                   *
                   * @api-label Test method
-                  * @api-uri:private:alias {Search} /search
-                  * @api-uri:private:alias {Search} /search2
+                  * @api-group Search
+                  * @api-uri:private:alias /search
+                  * @api-uri:private:alias /search2
                   * @api-contentType application/json
                   * @api-scope public
                   * @api-return:private {collection} \Mill\Examples\Showtimes\Representations\Representation

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -58,9 +58,10 @@ These actions will allow you to pull information on a specific movie.', $annotat
     {
         $this->overrideReadersWithFakeDocblockReturn('/**
           * @api-label Update a piece of content.
+          * @api-group Foo\Bar
           *
-          * @api-uri:public {Foo\Bar} /foo
-          * @api-uri:private:deprecated {Foo\Bar} /bar
+          * @api-uri:public /foo
+          * @api-uri:private:deprecated /bar
           *
           * @api-contentType application/json
           * @api-scope public
@@ -105,6 +106,10 @@ These actions will allow you to pull information on a specific movie.', $annotat
                         'class' => Parser\Annotations\ErrorAnnotation::class,
                         'count' => 3
                     ],
+                    'group' => [
+                        'class' => Parser\Annotations\GroupAnnotation::class,
+                        'count' => 1
+                    ],
                     'label' => [
                         'class' => Parser\Annotations\LabelAnnotation::class,
                         'count' => 1
@@ -141,6 +146,10 @@ These actions will allow you to pull information on a specific movie.', $annotat
                     'error' => [
                         'class' => Parser\Annotations\ErrorAnnotation::class,
                         'count' => 6
+                    ],
+                    'group' => [
+                        'class' => Parser\Annotations\GroupAnnotation::class,
+                        'count' => 1
                     ],
                     'label' => [
                         'class' => Parser\Annotations\LabelAnnotation::class,
@@ -185,6 +194,10 @@ These actions will allow you to pull information on a specific movie.', $annotat
                     ],
                     'error' => [
                         'class' => Parser\Annotations\ErrorAnnotation::class,
+                        'count' => 1
+                    ],
+                    'group' => [
+                        'class' => Parser\Annotations\GroupAnnotation::class,
                         'count' => 1
                     ],
                     'label' => [

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -17,8 +17,8 @@
         <blueprint>
             <excludes>
                 <!-- This is here just for code coverage purposes, and to verify that we're able to exclude resource
-                    namespaces when loading a config XML file. -->
-                <exclude namespace="FakeExcludeNamespace" />
+                    groups when loading a config XML file. -->
+                <exclude group="FakeExcludeGroup" />
             </excludes>
         </blueprint>
     </generators>


### PR DESCRIPTION
Simplifying `@api-uri` annotations by splitting the namespace into `@api-group`.

It works exactly the same as the `namespace` parameter on `@api-uri` does, just it's now a separate annotation.