### PR TITLE
Now throwing an exception when `string` MSON should be written as `enum`

### DIFF
--- a/resources/examples/Showtimes/Controllers/Movies.php
+++ b/resources/examples/Showtimes/Controllers/Movies.php
@@ -47,7 +47,7 @@ class Movies
      * @api-param:public name (string, required) - Name of the movie.
      * @api-param:public description (string, required) - Description, or tagline, for the movie.
      * @api-param:public runtime (string, optional) - Movie runtime, in `HHhr MMmin` format.
-     * @api-param:public content_rating (string, optional) - MPAA rating
+     * @api-param:public content_rating (enum, optional) - MPAA rating
      *  + Members
      *      - `G`
      *      - `PG`

--- a/src/Exceptions/MSON/ImproperlyWrittenEnumException.php
+++ b/src/Exceptions/MSON/ImproperlyWrittenEnumException.php
@@ -1,0 +1,27 @@
+<?php
+namespace Mill\Exceptions\MSON;
+
+use Mill\Exceptions\Annotations\AnnotationExceptionTrait;
+use Mill\Exceptions\BaseException;
+
+class ImproperlyWrittenEnumException extends BaseException
+{
+    use AnnotationExceptionTrait;
+
+    public static function create(string $annotation, string $class, ?string $method): ImproperlyWrittenEnumException
+    {
+        $message = sprintf(
+            'The type on `%s` in %s::%s should be written as `enum`.',
+            $annotation,
+            $class,
+            $method
+        );
+
+        $exception = new self($message);
+        $exception->annotation = $annotation;
+        $exception->class = $class;
+        $exception->method = $method;
+
+        return $exception;
+    }
+}

--- a/src/Parser/MSON.php
+++ b/src/Parser/MSON.php
@@ -6,8 +6,8 @@ use Mill\Exceptions\Annotations\UnknownErrorRepresentationException;
 use Mill\Exceptions\Annotations\UnsupportedTypeException;
 use Mill\Exceptions\Config\UnconfiguredErrorRepresentationException;
 use Mill\Exceptions\Config\UnconfiguredRepresentationException;
+use Mill\Exceptions\MSON\ImproperlyWrittenEnumException;
 use Mill\Exceptions\MSON\MissingOptionsException;
-use Mill\Parser\Annotations\VendorTagAnnotation;
 
 class MSON
 {
@@ -167,6 +167,7 @@ class MSON
      * @return self
      * @throws UnsupportedTypeException If an unsupported MSON field type has been supplied.
      * @throws MissingOptionsException If a supplied MSON type of `enum` missing corresponding acceptable values.
+     * @throws UnsupportedTypeException If a supplied MSON type of `string` should actually be written as `enum`.
      */
     public function parse(string $content): self
     {
@@ -292,6 +293,10 @@ class MSON
 
         if ($this->type === 'enum' && empty($this->values)) {
             throw MissingOptionsException::create($this->type, $this->class, $this->method);
+        }
+
+        if ($this->type !== 'enum' && !empty($this->values)) {
+            throw ImproperlyWrittenEnumException::create($content, $this->class, $this->method);
         }
 
         return $this;

--- a/tests/Parser/Annotations/ParamAnnotationTest.php
+++ b/tests/Parser/Annotations/ParamAnnotationTest.php
@@ -95,7 +95,7 @@ class ParamAnnotationTest extends AnnotationTest
     {
         return [
             '_complete' => [
-                'content' => 'content_rating `G` (string, optional, nullable, tag:MOVIE_RATINGS) - MPAA rating
+                'content' => 'content_rating `G` (enum, optional, nullable, tag:MOVIE_RATINGS) - MPAA rating
                     + Members
                         - `G` - G rated
                         - `PG` - PG rated
@@ -110,7 +110,7 @@ class ParamAnnotationTest extends AnnotationTest
                     'nullable' => true,
                     'required' => false,
                     'sample_data' => 'G',
-                    'type' => 'string',
+                    'type' => 'enum',
                     'values' => [
                         'G' => 'G rated',
                         'PG' => 'PG rated',
@@ -124,7 +124,7 @@ class ParamAnnotationTest extends AnnotationTest
                 ]
             ],
             '_complete-with-markdown-description' => [
-                'content' => 'content_rating `G` (string, optional, nullable, tag:MOVIE_RATINGS) - This denotes the
+                'content' => 'content_rating `G` (enum, optional, nullable, tag:MOVIE_RATINGS) - This denotes the
                     [MPAA rating](http://www.mpaa.org/film-ratings/) for the movie.
                     + Members
                         - `G` - G rated
@@ -140,7 +140,7 @@ class ParamAnnotationTest extends AnnotationTest
                     'nullable' => true,
                     'required' => false,
                     'sample_data' => 'G',
-                    'type' => 'string',
+                    'type' => 'enum',
                     'values' => [
                         'G' => 'G rated',
                         'PG' => 'PG rated',
@@ -173,7 +173,7 @@ class ParamAnnotationTest extends AnnotationTest
                 ]
             ],
             'enum-with-no-descriptions' => [
-                'content' => 'is_kid_friendly `yes` (string, optional) - Is this movie kid friendly?
+                'content' => 'is_kid_friendly `yes` (enum, optional) - Is this movie kid friendly?
                     + Members
                         - `yes`
                         - `no`',
@@ -187,7 +187,7 @@ class ParamAnnotationTest extends AnnotationTest
                     'nullable' => false,
                     'required' => false,
                     'sample_data' => 'yes',
-                    'type' => 'string',
+                    'type' => 'enum',
                     'values' => [
                         'no' => '',
                         'yes' => ''
@@ -198,7 +198,7 @@ class ParamAnnotationTest extends AnnotationTest
                 ]
             ],
             'enum-with-no-set-default' => [
-                'content' => 'content_rating `G` (string, optional) - MPAA rating
+                'content' => 'content_rating `G` (enum, optional) - MPAA rating
                     + Members
                         - `G` - G rated
                         - `PG` - PG rated
@@ -218,7 +218,7 @@ class ParamAnnotationTest extends AnnotationTest
                     'nullable' => false,
                     'required' => false,
                     'sample_data' => 'G',
-                    'type' => 'string',
+                    'type' => 'enum',
                     'values' => [
                         'G' => 'G rated',
                         'NC-17' => 'NC-17 rated',
@@ -306,7 +306,7 @@ class ParamAnnotationTest extends AnnotationTest
                     'nullable' => false,
                     'required' => false,
                     'sample_data' => false,
-                    'type' => 'string',
+                    'type' => 'enum',
                     'values' => [
                         'embeddable' => 'Embeddable',
                         'playable' => 'Playable'

--- a/tests/Parser/MSONTest.php
+++ b/tests/Parser/MSONTest.php
@@ -25,6 +25,19 @@ class MSONTest extends TestCase
         (new MSON(__CLASS__, __METHOD__))->parse($content);
     }
 
+    public function testEnumFailsWhenWrittenAsAString(): void
+    {
+        $this->expectException('Mill\Exceptions\MSON\ImproperlyWrittenEnumException');
+
+        $content = 'content_rating `G` (string, optional) - MPAA rating
+            + Members
+                - `G` - G rated
+                - `PG` - PG rated
+                - `PG-13` - PG-13 rated';
+
+        (new MSON(__CLASS__, __METHOD__))->parse($content);
+    }
+
     /**
      * @dataProvider providerTestParseFailsOnInvalidTypes
      * @param string $content
@@ -39,7 +52,7 @@ class MSONTest extends TestCase
     {
         return [
             '_complete' => [
-                'content' => 'content_rating `G` (string, optional, tag:MOVIE_RATINGS, needs:validUser) - MPAA rating
+                'content' => 'content_rating `G` (enum, optional, tag:MOVIE_RATINGS, needs:validUser) - MPAA rating
                     + Members
                         - `G` - G rated
                         - `PG` - PG rated
@@ -51,7 +64,7 @@ class MSONTest extends TestCase
                     'required' => false,
                     'sample_data' => 'G',
                     'subtype' => false,
-                    'type' => 'string',
+                    'type' => 'enum',
                     'values' => [
                         'G' => 'G rated',
                         'PG' => 'PG rated',
@@ -98,7 +111,7 @@ class MSONTest extends TestCase
                 ]
             ],
             'description-markdown' => [
-                'content' => 'content_rating `G` (string, optional, nullable, tag:MOVIE_RATINGS) - This denotes the
+                'content' => 'content_rating `G` (enum, optional, nullable, tag:MOVIE_RATINGS) - This denotes the
                     [MPAA rating](http://www.mpaa.org/film-ratings/) for the movie.
                     + Members
                         - `G` - G rated
@@ -111,7 +124,7 @@ class MSONTest extends TestCase
                     'required' => false,
                     'sample_data' => 'G',
                     'subtype' => false,
-                    'type' => 'string',
+                    'type' => 'enum',
                     'values' => [
                         'G' => 'G rated',
                         'PG' => 'PG rated',
@@ -123,7 +136,7 @@ class MSONTest extends TestCase
                 ]
             ],
             'description-starts-on-new-line' => [
-                'content' => 'content_rating `G` (string)
+                'content' => 'content_rating `G` (enum)
                     - MPAA Rating
                     + Members
                         - `G` - G rated
@@ -136,7 +149,7 @@ class MSONTest extends TestCase
                     'required' => false,
                     'sample_data' => 'G',
                     'subtype' => false,
-                    'type' => 'string',
+                    'type' => 'enum',
                     'values' => [
                         'G' => 'G rated',
                         'PG' => 'PG rated',
@@ -146,7 +159,7 @@ class MSONTest extends TestCase
                 ]
             ],
             'enum-without-descriptions' => [
-                'content' => 'is_kid_friendly `yes` (string, optional) - Is this movie kid friendly?
+                'content' => 'is_kid_friendly `yes` (enum, optional) - Is this movie kid friendly?
                     + Members
                         - `yes`
                         - `no`',
@@ -157,7 +170,7 @@ class MSONTest extends TestCase
                     'required' => false,
                     'sample_data' => 'yes',
                     'subtype' => false,
-                    'type' => 'string',
+                    'type' => 'enum',
                     'values' => [
                         'no' => '',
                         'yes' => ''
@@ -166,7 +179,7 @@ class MSONTest extends TestCase
                 ]
             ],
             'enum-without-set-default' => [
-                'content' => 'content_rating `G` (string, optional) - MPAA rating
+                'content' => 'content_rating `G` (enum, optional) - MPAA rating
                     + Members
                         - `G` - G rated
                         - `PG` - PG rated
@@ -183,7 +196,7 @@ class MSONTest extends TestCase
                     'required' => false,
                     'sample_data' => 'G',
                     'subtype' => false,
-                    'type' => 'string',
+                    'type' => 'enum',
                     'values' => [
                         'G' => 'G rated',
                         'NC-17' => 'NC-17 rated',

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -70,7 +70,7 @@
     <parameterTokens>
         <token name="page">page (integer, optional) - The page number to show.</token>
         <token name="per_page">per_page (integer, optional) - Number of items to show on each page. Max 100.</token>
-        <token name="filter">filter (string, optional) - Filter to apply to the results.</token>
+        <token name="filter">filter (enum, optional) - Filter to apply to the results.</token>
     </parameterTokens>
 
     <pathParams>


### PR DESCRIPTION
This adds a new `ImproperlyWrittenEnumException` exception that's thrown during the processing of MSON-compatible annotations (data, param, path param) when Mill detects `string` types accompanied with `enum` values. 

The exception is to direct the developer to update their annotation to use the proper `enum` type instead.

This all a roundabout way to fix issues where data annotations that were written this way weren't being compiled with member values when present.

https://github.com/vimeo/mill/issues/150