### PR TITLE
Non-aliased paths can no longer be selected as the primary path for a resource action

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -117,6 +117,11 @@ class Generator
                         continue;
                     }
 
+                    // We're always going to be generating documentation for this path, regardless if it's an alias or
+                    // not, so let's strip any awareness of that.
+                    $path->setAliased(false);
+                    $path->setAliases([]);
+
                     $resource_label = $annotations['label'];
                     if (!isset($resources[$group]['resources'][$resource_label])) {
                         $resources[$group]['resources'][$resource_label] = [

--- a/src/Parser/Annotation.php
+++ b/src/Parser/Annotation.php
@@ -21,13 +21,6 @@ abstract class Annotation
     const REQUIRES_VISIBILITY_DECORATOR = false;
 
     /**
-     * Does this annotation support aliasing?
-     *
-     * @var bool
-     */
-    const SUPPORTS_ALIASING = false;
-
-    /**
      * Does this annotation support being deprecated?
      *
      * @var bool
@@ -285,20 +278,6 @@ abstract class Annotation
             $annotation->setVisibility($data['visible']);
         }
 
-        if ($annotation->supportsAliasing()) {
-            $annotation->setAliased($data['aliased']);
-
-            $aliases = [];
-            foreach ($data['aliases'] as $alias) {
-                $aliases[] = PathAnnotation::hydrate(array_merge([
-                    'class' => $data['class'],
-                    'method' => $data['method']
-                ], $alias));
-            }
-
-            $annotation->setAliases($aliases);
-        }
-
         if ($annotation->supportsDeprecation()) {
             $annotation->setDeprecated($data['deprecated']);
         }
@@ -349,16 +328,6 @@ abstract class Annotation
     public function requiresVisibilityDecorator(): bool
     {
         return static::REQUIRES_VISIBILITY_DECORATOR;
-    }
-
-    /**
-     * Does this annotation support aliasing?
-     *
-     * @return bool
-     */
-    public function supportsAliasing(): bool
-    {
-        return static::SUPPORTS_ALIASING;
     }
 
     /**
@@ -420,17 +389,6 @@ abstract class Annotation
         // If this annotation requires visibility decorators, then we should include that.
         if ($this->requiresVisibilityDecorator()) {
             $arr['visible'] = $this->isVisible();
-        }
-
-        // If this annotation supports aliasing, then we should include any aliasing data about it.
-        if ($this->supportsAliasing()) {
-            $arr['aliased'] = $this->isAliased();
-            $arr['aliases'] = [];
-
-            /** @var Annotation $alias */
-            foreach ($this->getAliases() as $alias) {
-                $arr['aliases'][] = $alias->toArray();
-            }
         }
 
         if ($this->supportsDeprecation()) {

--- a/src/Parser/Annotations/PathAnnotation.php
+++ b/src/Parser/Annotations/PathAnnotation.php
@@ -12,7 +12,6 @@ use Mill\Parser\Version;
 class PathAnnotation extends Annotation
 {
     const REQUIRES_VISIBILITY_DECORATOR = true;
-    const SUPPORTS_ALIASING = true;
     const SUPPORTS_DEPRECATION = true;
 
     const ARRAYABLE = [
@@ -52,6 +51,18 @@ class PathAnnotation extends Annotation
         /** @var PathAnnotation $annotation */
         $annotation = parent::hydrate($data, $version);
         $annotation->setPath($data['path']);
+
+        $annotation->setAliased($data['aliased']);
+
+        $aliases = [];
+        foreach ($data['aliases'] as $alias) {
+            $aliases[] = PathAnnotation::hydrate(array_merge([
+                'class' => $data['class'],
+                'method' => $data['method']
+            ], $alias));
+        }
+
+        $annotation->setAliases($aliases);
 
         return $annotation;
     }
@@ -97,5 +108,26 @@ class PathAnnotation extends Annotation
     public function doesPathHaveParam(PathParamAnnotation $param): bool
     {
         return strpos($this->getCleanPath(), '{' . $param->getField() . '}') !== false;
+    }
+
+    /**
+     * Convert the parsed annotation into an array.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $arr = parent::toArray();
+        $arr['aliased'] = $this->isAliased();
+        $arr['aliases'] = [];
+
+        /** @var Annotation $alias */
+        foreach ($this->getAliases() as $alias) {
+            $arr['aliases'][] = $alias->toArray();
+        }
+
+        ksort($arr);
+
+        return $arr;
     }
 }

--- a/src/Parser/Resource/Action/Documentation.php
+++ b/src/Parser/Resource/Action/Documentation.php
@@ -387,7 +387,25 @@ class Documentation
      */
     public function getPath(): PathAnnotation
     {
-        $paths = $this->getPaths();
+        $paths = [];
+
+        /** @var PathAnnotation $path */
+        foreach ($this->getPaths() as $k => $path) {
+            if (!$path->isAliased()) {
+                $paths[] = $path;
+            }
+        }
+
+        if (empty($paths)) {
+            throw new \Exception(
+                sprintf(
+                    'There were zero non-aliased paths detected in this %s::%s.',
+                    $this->getClass(),
+                    $this->getMethod()
+                )
+            );
+        }
+
         return array_shift($paths);
     }
 

--- a/tests/Parser/Annotations/ContentTypeAnnotationTest.php
+++ b/tests/Parser/Annotations/ContentTypeAnnotationTest.php
@@ -42,7 +42,6 @@ class ContentTypeAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(ContentTypeAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertFalse($annotation->supportsDeprecation());
         $this->assertTrue($annotation->supportsVersioning());
         $this->assertFalse($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/DataAnnotationTest.php
+++ b/tests/Parser/Annotations/DataAnnotationTest.php
@@ -42,7 +42,6 @@ class DataAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(DataAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertFalse($annotation->supportsDeprecation());
         $this->assertTrue($annotation->supportsVersioning());
         $this->assertTrue($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/DescriptionAnnotationTest.php
+++ b/tests/Parser/Annotations/DescriptionAnnotationTest.php
@@ -39,7 +39,6 @@ class DescriptionAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(DescriptionAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertFalse($annotation->supportsDeprecation());
         $this->assertFalse($annotation->supportsVersioning());
         $this->assertFalse($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/ErrorAnnotationTest.php
+++ b/tests/Parser/Annotations/ErrorAnnotationTest.php
@@ -51,7 +51,6 @@ class ErrorAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(ErrorAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertFalse($annotation->supportsDeprecation());
         $this->assertTrue($annotation->supportsVersioning());
         $this->assertTrue($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/GroupAnnotationTest.php
+++ b/tests/Parser/Annotations/GroupAnnotationTest.php
@@ -39,7 +39,6 @@ class GroupAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(GroupAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertFalse($annotation->supportsDeprecation());
         $this->assertFalse($annotation->supportsVersioning());
         $this->assertFalse($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/LabelAnnotationTest.php
+++ b/tests/Parser/Annotations/LabelAnnotationTest.php
@@ -39,7 +39,6 @@ class LabelAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(LabelAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertFalse($annotation->supportsDeprecation());
         $this->assertFalse($annotation->supportsVersioning());
         $this->assertFalse($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/MaxVersionAnnotationTest.php
+++ b/tests/Parser/Annotations/MaxVersionAnnotationTest.php
@@ -40,7 +40,6 @@ class MaxVersionAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(MaxVersionAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertFalse($annotation->supportsDeprecation());
         $this->assertFalse($annotation->supportsVersioning());
         $this->assertFalse($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/MinVersionAnnotationTest.php
+++ b/tests/Parser/Annotations/MinVersionAnnotationTest.php
@@ -40,7 +40,6 @@ class MinVersionAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(MinVersionAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertFalse($annotation->supportsDeprecation());
         $this->assertFalse($annotation->supportsVersioning());
         $this->assertFalse($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/ParamAnnotationTest.php
+++ b/tests/Parser/Annotations/ParamAnnotationTest.php
@@ -60,7 +60,6 @@ class ParamAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(ParamAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertTrue($annotation->supportsDeprecation());
         $this->assertTrue($annotation->supportsVersioning());
         $this->assertTrue($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/PathAnnotationTest.php
+++ b/tests/Parser/Annotations/PathAnnotationTest.php
@@ -46,7 +46,6 @@ class PathAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(PathAnnotation $annotation, array $expected): void
     {
-        $this->assertTrue($annotation->supportsAliasing());
         $this->assertTrue($annotation->supportsDeprecation());
         $this->assertFalse($annotation->supportsVersioning());
         $this->assertFalse($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/PathParamAnnotationTest.php
+++ b/tests/Parser/Annotations/PathParamAnnotationTest.php
@@ -41,7 +41,6 @@ class PathParamAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(PathParamAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertFalse($annotation->supportsDeprecation());
         $this->assertFalse($annotation->supportsVersioning());
         $this->assertFalse($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/ReturnAnnotationTest.php
+++ b/tests/Parser/Annotations/ReturnAnnotationTest.php
@@ -47,7 +47,6 @@ class ReturnAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(ReturnAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertFalse($annotation->supportsDeprecation());
         $this->assertTrue($annotation->supportsVersioning());
         $this->assertFalse($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/ScopeAnnotationTest.php
+++ b/tests/Parser/Annotations/ScopeAnnotationTest.php
@@ -40,7 +40,6 @@ class ScopeAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(ScopeAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertFalse($annotation->supportsDeprecation());
         $this->assertFalse($annotation->supportsVersioning());
         $this->assertFalse($annotation->supportsVendorTags());

--- a/tests/Parser/Annotations/VendorTagAnnotationTest.php
+++ b/tests/Parser/Annotations/VendorTagAnnotationTest.php
@@ -40,7 +40,6 @@ class VendorTagAnnotationTest extends AnnotationTest
 
     private function assertAnnotation(VendorTagAnnotation $annotation, array $expected): void
     {
-        $this->assertFalse($annotation->supportsAliasing());
         $this->assertFalse($annotation->supportsDeprecation());
         $this->assertFalse($annotation->supportsVersioning());
         $this->assertFalse($annotation->supportsVendorTags());

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -108,6 +108,7 @@ class DocumentationTest extends TestCase
         $this->assertSame($expected['description'], $docs['description']);
         $this->assertSame($method, $docs['method']);
         $this->assertSame($expected['content_types'], $docs['content_types']);
+        $this->assertSame($expected['path'], $parser->getPath()->getPath());
 
         if (empty($docs['annotations'])) {
             $this->fail('No parsed annotations for ' . $class);
@@ -224,6 +225,7 @@ DESCRIPTION;
                             'version' => '<1.1.2'
                         ]
                     ],
+                    'path' => '/movies/+id',
                     'minimum_version' => false,
                     'maximum_version' => false,
                     'responses.length' => 5,
@@ -330,6 +332,7 @@ DESCRIPTION;
                             'version' => '<1.1.2'
                         ]
                     ],
+                    'path' => '/movies/+id',
                     'minimum_version' => '1.1',
                     'maximum_version' => false,
                     'responses.length' => 8,
@@ -866,6 +869,7 @@ DESCRIPTION;
                             'version' => false
                         ]
                     ],
+                    'path' => '/movies/+id',
                     'minimum_version' => '1.1',
                     'maximum_version' => '1.1.2',
                     'responses.length' => 2,


### PR DESCRIPTION
Resolves https://github.com/vimeo/mill/issues/139