### PR TITLE
Addition of a new `@api-operationid` annotation.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,14 +224,14 @@ Required attributes for the `<class>` element are:
 
 ```php
 /**
- * …
+ * ...
  *
  * @api-error:public 403 (\ErrorRepresentation<7701>) - If the user isn't
  *     allowed to do something.
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```
 

--- a/docs/generate-changelogs.md
+++ b/docs/generate-changelogs.md
@@ -31,18 +31,18 @@ Help:
 Example usage:
 
 ```shell
-$ ./vendor/bin/mill changelog blueprints/
-Generating a changelog…
+$ ./vendor/bin/mill changelog specs/
+Compiling a changelog...
 
 Done!
 ```
 
-This will compile a `changelog.md` file into the `blueprints/` directory.
+This will compile a `changelog.md` file into the `specs/` directory.
 
 Looking at that file, we can see that we have changelog!
 
 ```shell
-$ cat resources/examples/Showtimes/blueprints/changelog.md
+$ cat resources/examples/Showtimes/specs/changelog.md | less
 # Changelog: Mill unit test API, Showtimes
 
 ## 1.1.3
@@ -62,7 +62,6 @@ $ cat resources/examples/Showtimes/blueprints/changelog.md
 ### Removed
 #### Representations
 - `external_urls.tickets` has been removed from the `Movie` representation.
-…
 ```
 
 ## JSON

--- a/docs/reference-api-contenttype.md
+++ b/docs/reference-api-contenttype.md
@@ -11,13 +11,11 @@ This designates the HTTP `Content-Type` that a resource action returns.
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | ✓ | × | ✓ | × |
 
 ### Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | content-type | × | HTTP Content-Type that a resource action returns. |
@@ -25,12 +23,14 @@ This designates the HTTP `Content-Type` that a resource action returns.
 ## Examples
 ```php
 /**
- * …
+ * ...
+ *
  * @api-contenttype application/json
- * …
+ *
+ * ...
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```

--- a/docs/reference-api-data.md
+++ b/docs/reference-api-data.md
@@ -13,13 +13,11 @@ This describes a piece of data within a representation that a resource action ca
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | × | × | ✓ | × |
 
 ## Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | fieldName | × | The data in a representation that you're documenting. So if your representation has a `link`, `field_name` would be `link`. If you're documenting nested objects, you should use dot-notation to map out the field name. So say you have a `metadata[connections][albums]` array in your representation, the `field_name` would then be `metadata.connections.albums`. |
@@ -32,7 +30,6 @@ This describes a piece of data within a representation that a resource action ca
 | Members | ✓ | If this data has acceptable values (like in the case of an `enum` type), you can document those values here along with a description for what the value is, or means. |
 
 ### Supported Types
-
 | Type | Specification representation |
 | :--- | :--- |
 | array | array |
@@ -68,7 +65,7 @@ Common uses:
 
 ```php
 $representation = [
-    …
+    ...
 
     /**
      * @api-data uri (uri) - The canonical relative URI for the user.
@@ -110,7 +107,7 @@ $representation = [
         ]
     ],
 
-    …
+    ...
 ];
 ```
 
@@ -118,7 +115,7 @@ Documented enum:
 
 ```php
 $representation = [
-    …
+    ...
 
     /**
      * @api-data content_rating (enum) - MPAA rating
@@ -134,7 +131,7 @@ $representation = [
      */
     'content_rating' => $content_rating,
 
-    …
+    ...
 ];
 ```
 
@@ -142,14 +139,14 @@ Array of objects:
 
 ```php
 $representation = [
-    …
+    ...
 
     /**
      * @api-data content_ratings (array<object>) - MPAA ratings
      */
     'content_ratings' => $content_ratings,
 
-    …
+    ...
 ];
 ```
 
@@ -157,13 +154,13 @@ Representation:
 
 ```php
 $representation = [
-    …
+    ...
 
     /**
      * @api-data pictures (\PictureRepresentation) - Pictures
      */
     'pictures' => (new \PictureRepresentation)->create(),
 
-    …
+    ...
 ];
 ```

--- a/docs/reference-api-error.md
+++ b/docs/reference-api-error.md
@@ -11,13 +11,11 @@ This represents an exception that may be returned on a resource action.
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | × | ✓ | ✓ | × |
 
 ## Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | :visibility | ✓ | [Visibility decorator](reference-visibility.md) |
@@ -49,13 +47,13 @@ Usage with a vendor tag and description type:
 
 ```php
 /**
- * …
+ * ...
  *
  * @api-error:public 404 (\ErrorRepresentation, needs:SomeApplicationFeature) - {user}
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```
 
@@ -63,14 +61,14 @@ With an error code:
 
 ```php
 /**
- * …
+ * ...
  *
  * @api-error:public 403 (\ErrorRepresentation<7701>) If the user isn't
  *     allowed to do something.
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```
 
@@ -78,13 +76,13 @@ Standard usage:
 
 ```php
 /**
- * …
+ * ...
  *
  * @api-error:public 404 (\ErrorRepresentation) - If the user isn't allowed
  *     to do something.
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```

--- a/docs/reference-api-group.md
+++ b/docs/reference-api-group.md
@@ -11,13 +11,11 @@ Name of the group that this action should be grouped under when generating docum
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | ✓ | × | × | × |
 
 ## Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | groupName | × | Group name |
@@ -27,15 +25,16 @@ On a resource action:
 
 ```php
 /**
- * @api-label Update data on a group of videos.
+ * @api-label Update data on a group of users.
+ * @api-operationid updateUsers
  * @api-group Users
  *
  * @api-path:public /users
  *
- * …
+ * ...
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```

--- a/docs/reference-api-maxversion.md
+++ b/docs/reference-api-maxversion.md
@@ -11,13 +11,11 @@ This allows you to denote the maximum API version required for a resource action
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | × | × | × | × |
 
 ## Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | version | × | A specific, maximum API version required for a resource action. |
@@ -26,6 +24,7 @@ This allows you to denote the maximum API version required for a resource action
 ```php
 /**
  * @api-label Update a movie.
+ * @api-operationid updateMovie
  * @api-group Movies
  *
  * @api-path:public /movies/+id
@@ -38,6 +37,6 @@ This allows you to denote the maximum API version required for a resource action
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```

--- a/docs/reference-api-minversion.md
+++ b/docs/reference-api-minversion.md
@@ -11,13 +11,11 @@ This allows you to denote the minimum API version required for a resource action
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | × | × | × | × |
 
 ## Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | version | × | A specific, minimum API version required for a resource action. |
@@ -26,6 +24,7 @@ This allows you to denote the minimum API version required for a resource action
 ```php
 /**
  * @api-label Update a movie.
+ * @api-operationid updateMovie
  * @api-group Movies
  *
  * @api-path:public /movies/+id
@@ -38,6 +37,6 @@ This allows you to denote the minimum API version required for a resource action
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```

--- a/docs/reference-api-operationid.md
+++ b/docs/reference-api-operationid.md
@@ -1,13 +1,13 @@
 ---
-id: api-label
-title: @api-label
+id: api-operationid
+title: @api-operationid
 ---
 
-A short description of what the resource, or resource action handles.
+A unique identifier for a resource action. This is used when compiling specifications.
 
 ## Syntax
 ```php
-@api-label description
+@api-operationid identifier
 ```
 
 ## Requirements
@@ -18,23 +18,9 @@ A short description of what the resource, or resource action handles.
 ## Breakdown
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
-| description | × | Description of what resource, or resource action handles. |
+| identifier | × | Unique identifier for a resource action. |
 
 ## Examples
-On a resource:
-
-```php
-/**
- * @api-label Videos
- */
-class Controller
-{
-    ...
-}
-```
-
-On a resource action:
-
 ```php
 /**
  * Update a movies data.

--- a/docs/reference-api-param.md
+++ b/docs/reference-api-param.md
@@ -15,13 +15,11 @@ A request parameter that can be supplied to a resource action via a body payload
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | × | ✓ | ✓ | ✓ |
 
 ## Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | :visibility | ✓ | [Visibility decorator](reference-visibility.md) |
@@ -35,7 +33,6 @@ A request parameter that can be supplied to a resource action via a body payload
 | Members | ✓ | If this parameter has acceptable values (like in the case of an `enum` type), you can document those values here along with a description for what the value is, or means. |
 
 ### Supported Types
-
 | Type | Specification representation |
 | :--- | :--- |
 | array | array |

--- a/docs/reference-api-path.md
+++ b/docs/reference-api-path.md
@@ -11,13 +11,11 @@ This allows you to describe the path(s) that a resource action services.
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | ✓ | ✓ | × | ✓ |
 
 ## Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | path | × | This is the path that the resource action services. It's recommended that these conform to [RFC 3986](https://tools.ietf.org/html/rfc3986) and [RFC 6570](https://tools.ietf.org/html/rfc6570). |
@@ -25,14 +23,21 @@ This allows you to describe the path(s) that a resource action services.
 ## Examples
 ```php
 /**
- * …
- * @api-path:private /movies
+ * Update a movies data.
  *
- * @api-path:private:deprecated /theaters/+id/movies
- * …
+ * @api-label Update a movie.
+ * @api-operationid updateMovie
+ * @api-group Movies
+ *
+ * @api-path:public /movies/+id
+ * @api-pathparam id `1234` (integer) - Movie ID
+
+ * @api-path:private:deprecated /movie/+id
+ *
+ * ...
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```

--- a/docs/reference-api-pathparam.md
+++ b/docs/reference-api-pathparam.md
@@ -13,13 +13,11 @@ This allows you to describe the parameters of a coupled resource action path.
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | × | × | × | × |
 
 ## Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | paramName | × | This is the name of the parameter that is used within the path. |
@@ -29,7 +27,6 @@ This allows you to describe the parameters of a coupled resource action path.
 | Members | ✓ | If this path parameter has acceptable values (like in the case of an `enum` type), you can document those values here along with a description for what the value is, or means. |
 
 ### Supported Types
-
 | Type | Specification representation |
 | :--- | :--- |
 | array | array |
@@ -48,15 +45,15 @@ This allows you to describe the parameters of a coupled resource action path.
 ## Examples
 ```php
 /**
- * …
+ * ...
  *
  * @api-path:private:deprecated /movies/+id
  * @api-pathparam id `1234` (integer) - Movie ID
  *
- * …
+ * ...
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```

--- a/docs/reference-api-return.md
+++ b/docs/reference-api-return.md
@@ -8,9 +8,7 @@ Like a standard [PHPDoc](https://phpdoc.org/) [`@return`](https://phpdoc.org/doc
 * Return type
 * Representation
 
-The return type should be indicative of the HTTP code that will be delivered (ex. "collection", "object", "created",
-etc.), and the representation should be representative of the type of response and data that this action deals with.
-Say if this is a user data action, it might return a `\UserRepresentation`.
+The return type should be indicative of the HTTP code that will be delivered (ex. "collection", "object", "created", etc.), and the representation should be representative of the type of response and data that this action deals with. Say if this is a user data action, it might return a `\UserRepresentation`.
 
 ## Syntax
 ```php
@@ -18,13 +16,11 @@ Say if this is a user data action, it might return a `\UserRepresentation`.
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | × | ✓ | ✓ | × |
 
 ## Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | :visibility | ✓ | [Visibility decorator](reference-visibility.md) |
@@ -33,7 +29,6 @@ Say if this is a user data action, it might return a `\UserRepresentation`.
 | description | * | A short description describing why, or what, this response is. A description is only required when the returning HTTP code for this return is non-200. |
 
 ## Available return types
-
 | HTTP Code | Designator |
 | :--- | :--- |
 | 200 OK | collection |
@@ -53,24 +48,24 @@ Say if this is a user data action, it might return a `\UserRepresentation`.
 ## Examples
 ```php
 /**
- * …
+ * ...
  *
  * @api-return:private {accepted} \Some\Representation
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```
 
 ```php
 /**
- * …
+ * ...
  *
- * @api-public {notmodified} If no content has changed since the last modified date.
+ * @api-return:public {notmodified} If no content has changed since the last modified date.
  */
 public function GET()
 {
-    …
+    ...
 }
 ```

--- a/docs/reference-api-scope.md
+++ b/docs/reference-api-scope.md
@@ -11,13 +11,11 @@ This corresponds to an available user authentication token scope (ex. "create", 
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | × | × | × | × |
 
 ## Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | scope | × | Authentication scope required for the resource action. |
@@ -27,6 +25,7 @@ This corresponds to an available user authentication token scope (ex. "create", 
 ```php
 /**
  * @api-label Update a movie
+ * @api-operationid updateMovie
  * @api-group Movies
  *
  * @api-path:public /movies/+id
@@ -39,7 +38,7 @@ This corresponds to an available user authentication token scope (ex. "create", 
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```
 

--- a/docs/reference-api-see.md
+++ b/docs/reference-api-see.md
@@ -11,13 +11,11 @@ This is a reference pointer that allows you to pull in related documentation int
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | × | × | × | × |
 
 ## Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | \Class::method | × | This is a fully qualified class name and method where the related representation that you want to import exists. |
@@ -26,7 +24,7 @@ This is a reference pointer that allows you to pull in related documentation int
 ## Examples
 ```php
 $representation = [
-    …
+    ...
 
     /**
      * @api-data privacy (object) - Privacy settings
@@ -34,7 +32,7 @@ $representation = [
      */
     'privacy' => $this->getPrivacy($object, $request)
 
-    …
+    ...
 ];
 ```
 
@@ -50,5 +48,4 @@ private function getPrivacy($object, $request)
 }
 ```
 
-From here, `download` will be imported into the representation documentation as
-`privacy.download`.
+From here, `download` will be imported into the representation documentation as `privacy.download`.

--- a/docs/reference-api-vendortag.md
+++ b/docs/reference-api-vendortag.md
@@ -13,13 +13,11 @@ With Mill's generator commands, you can also later filter down your documentatio
 ```
 
 ## Requirements
-
 | Required? | Needs a visibility | Supports versioning | Supports deprecation |
 | :--- | :--- | :--- | :--- |
 | × | × | × | × |
 
 ## Breakdown
-
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | vendortag | × | Name of the vendor tag |
@@ -29,13 +27,15 @@ On a resource action:
 
 ```php
 /**
- * …
+ * ...
+ *
  * @api-vendortag needs:SomeApplicationFeature
- * …
+ *
+ * ...
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```
 
@@ -43,7 +43,7 @@ On a representation field:
 
 ```php
 $representation = [
-    …
+    ...
 
     /**
      * @api-data download (boolean, needs:SomeApplicationFeature) - Download
@@ -51,7 +51,6 @@ $representation = [
      */
     'download' => true,
 
-    …
+    ...
 ];
 ```
-

--- a/docs/reference-deprecation.md
+++ b/docs/reference-deprecation.md
@@ -13,6 +13,7 @@ You might have instances where you need to deprecate a resource action request p
  * Return information on a specific movie.
  *
  * @api-label Get a single movie.
+ * @api-operationid getMovie
  * @api-group Movies
  *
  * @api-path:public /movies/+id
@@ -29,7 +30,7 @@ You might have instances where you need to deprecate a resource action request p
  */
 public function GET()
 {
-    …
+    ...
 }
 ```
 

--- a/docs/reference-resource-actions.md
+++ b/docs/reference-resource-actions.md
@@ -12,6 +12,7 @@ title: "Resource Actions"
 | [`@api-maxversion`](reference-api-maxversion.md) | Maximum version required for this action. |
 | [`@api-minversion`](reference-api-minversion.md) | Minimum version required for this action. |
 | [`@api-param`](reference-api-param.md) | A request parameter for this action that can be supplied in a body payload. |
+| [`@api-operationid`](reference-api-operationid.md) | A unique identifier for a resource action. |
 | [`@api-path`](reference-api-path.md) | Denotes a path that this action services. |
 | [`@api-pathparam`](reference-api-pathparam.md) | Describes parameters for the path. |
 | [`@api-queryparam`](reference-api-queryparam.md) | A request parameter for this action that can be supplied in a query string. |

--- a/docs/reference-visibility.md
+++ b/docs/reference-visibility.md
@@ -12,8 +12,10 @@ To choose what visibility your annotation should have, suffix your annotation wi
 
 ```php
 /**
+ * @api-label Update a movie
+ * @api-operationid updateMovie
  * @api-group Movies
-
+ *
  * @api-path:public /movies/+id
  * @api-path:private /films/+id
  * @api-pathparam id (integer) - Movie ID
@@ -23,7 +25,7 @@ To choose what visibility your annotation should have, suffix your annotation wi
  */
 public function PATCH()
 {
-    …
+    ...
 }
 ```
 

--- a/docs/writing-documentation.md
+++ b/docs/writing-documentation.md
@@ -17,7 +17,7 @@ namespace MyApplication;
  */
 class UsersController extends \MyApplication\Controller
 {
-    …
+    ...
 }
 
 ```
@@ -44,7 +44,7 @@ namespace MyApplication;
  */
 class UsersController extends \MyApplication\Controller
 {
-    …
+    ...
 }
 ```
 
@@ -65,6 +65,7 @@ class UsersController extends \MyApplication\Controller
      * Search for users.
      *
      * @api-label Search
+     * @api-operationid searchUsers
      * @api-group Users
      *
      * @api-path:public /users
@@ -83,7 +84,7 @@ class UsersController extends \MyApplication\Controller
      */
     public function GET()
     {
-        …
+        ...
     }
 }
 ```

--- a/resources/examples/Showtimes/Controllers/Movie.php
+++ b/resources/examples/Showtimes/Controllers/Movie.php
@@ -25,6 +25,7 @@ class Movie
      * ```
      *
      * @api-label Get a single movie.
+     * @api-operationid getMovie
      * @api-group Movies
      *
      * @api-path:private:alias /movie/+movie_id
@@ -55,6 +56,7 @@ class Movie
      * Update a movies data.
      *
      * @api-label Update a movie.
+     * @api-operationid updateMovie
      * @api-group Movies
      *
      * @api-path:public /movies/+id
@@ -118,6 +120,7 @@ class Movie
      * Delete a movie.
      *
      * @api-label Delete a movie.
+     * @api-operationid deleteMovie
      * @api-group Movies
      *
      * @api-path:private /movies/+id

--- a/resources/examples/Showtimes/Controllers/Movies.php
+++ b/resources/examples/Showtimes/Controllers/Movies.php
@@ -10,6 +10,7 @@ class Movies
      * Returns all movies for a specific location.
      *
      * @api-label Get movies.
+     * @api-operationid getMovies
      * @api-group Movies
      *
      * @api-path:public /movies
@@ -38,6 +39,7 @@ class Movies
      * Create a new movie.
      *
      * @api-label Create a movie.
+     * @api-operationid createMovie
      * @api-group Movies
      *
      * @api-path:public /movies

--- a/resources/examples/Showtimes/Controllers/Theater.php
+++ b/resources/examples/Showtimes/Controllers/Theater.php
@@ -14,6 +14,7 @@ class Theater
      * Return information on a specific movie theater.
      *
      * @api-label Get a single movie theater.
+     * @api-operationid getTheater
      * @api-group Theaters
      *
      * @api-path:public /theaters/+id
@@ -39,6 +40,7 @@ class Theater
      * Update a movie theaters' data.
      *
      * @api-label Update a movie theater.
+     * @api-operationid updateTheater
      * @api-group Theaters
      *
      * @api-path:public /theaters/+id
@@ -71,6 +73,7 @@ class Theater
      * Delete a movie theater.
      *
      * @api-label Delete a movie theater.
+     * @api-operationid deleteTheater
      * @api-group Theaters
      *
      * @api-path:private /theaters/+id

--- a/resources/examples/Showtimes/Controllers/Theaters.php
+++ b/resources/examples/Showtimes/Controllers/Theaters.php
@@ -10,6 +10,7 @@ class Theaters
      * Returns all movie theatres for a specific location.
      *
      * @api-label Get movie theaters.
+     * @api-operationid getTheaters
      * @api-group Theaters
      *
      * @api-path:public /theaters
@@ -35,6 +36,7 @@ class Theaters
      * Create a new movie theater.
      *
      * @api-label Create a movie theater.
+     * @api-operationid createTheater
      * @api-group Theaters
      *
      * @api-path:public /theaters

--- a/resources/examples/Showtimes/compiled/1.0/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/api.yaml
@@ -23,7 +23,7 @@ paths:
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
-      operationId: getMovieId
+      operationId: getMovie_alt1
       tags:
         - Movies
       parameters:
@@ -54,7 +54,7 @@ paths:
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
-      operationId: getMoviesId
+      operationId: getMovie
       tags:
         - Movies
       parameters:
@@ -116,7 +116,7 @@ paths:
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
-      operationId: postMovies
+      operationId: createMovie
       tags:
         - Movies
       requestBody:
@@ -205,7 +205,7 @@ paths:
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
-      operationId: getTheatersId
+      operationId: getTheater
       tags:
         - Theaters
       parameters:
@@ -236,7 +236,7 @@ paths:
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
-      operationId: patchTheatersId
+      operationId: updateTheater
       tags:
         - Theaters
       parameters:
@@ -304,7 +304,7 @@ paths:
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
-      operationId: deleteTheatersId
+      operationId: deleteTheater
       tags:
         - Theaters
       parameters:
@@ -363,7 +363,7 @@ paths:
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
-      operationId: postTheaters
+      operationId: createTheater
       tags:
         - Theaters
       requestBody:

--- a/resources/examples/Showtimes/compiled/1.1.1/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/api.yaml
@@ -23,7 +23,7 @@ paths:
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
-      operationId: getMovieId
+      operationId: getMovie_alt1
       tags:
         - Movies
       parameters:
@@ -54,7 +54,7 @@ paths:
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
-      operationId: getMoviesId
+      operationId: getMovie
       tags:
         - Movies
       parameters:
@@ -85,7 +85,7 @@ paths:
     patch:
       summary: 'Update a movie.'
       description: 'Update a movies data.'
-      operationId: patchMoviesId
+      operationId: updateMovie
       tags:
         - Movies
       parameters:
@@ -197,7 +197,7 @@ paths:
     delete:
       summary: 'Delete a movie.'
       description: 'Delete a movie.'
-      operationId: deleteMoviesId
+      operationId: deleteMovie
       tags:
         - Movies
       parameters:
@@ -265,7 +265,7 @@ paths:
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
-      operationId: postMovies
+      operationId: createMovie
       tags:
         - Movies
       requestBody:
@@ -363,7 +363,7 @@ paths:
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
-      operationId: getTheatersId
+      operationId: getTheater
       tags:
         - Theaters
       parameters:
@@ -394,7 +394,7 @@ paths:
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
-      operationId: patchTheatersId
+      operationId: updateTheater
       tags:
         - Theaters
       parameters:
@@ -462,7 +462,7 @@ paths:
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
-      operationId: deleteTheatersId
+      operationId: deleteTheater
       tags:
         - Theaters
       parameters:
@@ -521,7 +521,7 @@ paths:
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
-      operationId: postTheaters
+      operationId: createTheater
       tags:
         - Theaters
       requestBody:

--- a/resources/examples/Showtimes/compiled/1.1.2/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/api.yaml
@@ -23,7 +23,7 @@ paths:
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
-      operationId: getMovieId
+      operationId: getMovie_alt1
       tags:
         - Movies
       parameters:
@@ -54,7 +54,7 @@ paths:
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
-      operationId: getMoviesId
+      operationId: getMovie
       tags:
         - Movies
       parameters:
@@ -85,7 +85,7 @@ paths:
     patch:
       summary: 'Update a movie.'
       description: 'Update a movies data.'
-      operationId: patchMoviesId
+      operationId: updateMovie
       tags:
         - Movies
       parameters:
@@ -197,7 +197,7 @@ paths:
     delete:
       summary: 'Delete a movie.'
       description: 'Delete a movie.'
-      operationId: deleteMoviesId
+      operationId: deleteMovie
       tags:
         - Movies
       parameters:
@@ -265,7 +265,7 @@ paths:
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
-      operationId: postMovies
+      operationId: createMovie
       tags:
         - Movies
       requestBody:
@@ -363,7 +363,7 @@ paths:
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
-      operationId: getTheatersId
+      operationId: getTheater
       tags:
         - Theaters
       parameters:
@@ -394,7 +394,7 @@ paths:
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
-      operationId: patchTheatersId
+      operationId: updateTheater
       tags:
         - Theaters
       parameters:
@@ -456,7 +456,7 @@ paths:
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
-      operationId: deleteTheatersId
+      operationId: deleteTheater
       tags:
         - Theaters
       parameters:
@@ -515,7 +515,7 @@ paths:
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
-      operationId: postTheaters
+      operationId: createTheater
       tags:
         - Theaters
       requestBody:

--- a/resources/examples/Showtimes/compiled/1.1.3/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/api.yaml
@@ -23,7 +23,7 @@ paths:
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
-      operationId: getMovieId
+      operationId: getMovie_alt1
       tags:
         - Movies
       parameters:
@@ -54,7 +54,7 @@ paths:
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
-      operationId: getMoviesId
+      operationId: getMovie
       tags:
         - Movies
       parameters:
@@ -85,7 +85,7 @@ paths:
     patch:
       summary: 'Update a movie.'
       description: 'Update a movies data.'
-      operationId: patchMoviesId
+      operationId: updateMovie
       tags:
         - Movies
       parameters:
@@ -247,7 +247,7 @@ paths:
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
-      operationId: postMovies
+      operationId: createMovie
       tags:
         - Movies
       requestBody:
@@ -347,7 +347,7 @@ paths:
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
-      operationId: getTheatersId
+      operationId: getTheater
       tags:
         - Theaters
       parameters:
@@ -378,7 +378,7 @@ paths:
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
-      operationId: patchTheatersId
+      operationId: updateTheater
       tags:
         - Theaters
       parameters:
@@ -440,7 +440,7 @@ paths:
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
-      operationId: deleteTheatersId
+      operationId: deleteTheater
       tags:
         - Theaters
       parameters:
@@ -499,7 +499,7 @@ paths:
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
-      operationId: postTheaters
+      operationId: createTheater
       tags:
         - Theaters
       requestBody:

--- a/resources/examples/Showtimes/compiled/1.1/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/api.yaml
@@ -23,7 +23,7 @@ paths:
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
-      operationId: getMovieId
+      operationId: getMovie_alt1
       tags:
         - Movies
       parameters:
@@ -54,7 +54,7 @@ paths:
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
-      operationId: getMoviesId
+      operationId: getMovie
       tags:
         - Movies
       parameters:
@@ -85,7 +85,7 @@ paths:
     patch:
       summary: 'Update a movie.'
       description: 'Update a movies data.'
-      operationId: patchMoviesId
+      operationId: updateMovie
       tags:
         - Movies
       parameters:
@@ -193,7 +193,7 @@ paths:
     delete:
       summary: 'Delete a movie.'
       description: 'Delete a movie.'
-      operationId: deleteMoviesId
+      operationId: deleteMovie
       tags:
         - Movies
       parameters:
@@ -261,7 +261,7 @@ paths:
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
-      operationId: postMovies
+      operationId: createMovie
       tags:
         - Movies
       requestBody:
@@ -359,7 +359,7 @@ paths:
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
-      operationId: getTheatersId
+      operationId: getTheater
       tags:
         - Theaters
       parameters:
@@ -390,7 +390,7 @@ paths:
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
-      operationId: patchTheatersId
+      operationId: updateTheater
       tags:
         - Theaters
       parameters:
@@ -458,7 +458,7 @@ paths:
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
-      operationId: deleteTheatersId
+      operationId: deleteTheater
       tags:
         - Theaters
       parameters:
@@ -517,7 +517,7 @@ paths:
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
-      operationId: postTheaters
+      operationId: createTheater
       tags:
         - Theaters
       requestBody:

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -94,12 +94,18 @@ class Compiler
             foreach ($docs->getMethods() as $method) {
                 $group = $method->getGroup();
 
+                // Set the amount of aliases that we've accrued here so we can properly enforce uniqueness of operation
+                // IDs on aliased paths.
+                $aliases = 0;
+
                 /** @var \Mill\Parser\Annotations\PathAnnotation $path */
                 foreach ($method->getPaths() as $path) {
                     // Are we compiling documentation for a private or protected resource?
                     if (!$this->shouldParsePath($method, $path)) {
                         continue;
                     }
+
+                    $is_aliased = $path->isAliased();
 
                     // We're always going to be compiling documentation for this path, regardless if it's an alias or
                     // not, so let's strip any awareness of that.
@@ -130,6 +136,10 @@ class Compiler
                     $action->setPath($path);
                     $action->setPathParams($params);
                     $action->filterAnnotationsForVisibility($this->load_private_docs, $this->load_vendor_tag_docs);
+
+                    if ($is_aliased) {
+                        $action->incrementOperationId(++$aliases);
+                    }
 
                     // Hash the action so we don't happen to double up and end up with dupes.
                     $identifier = $action->getPath()->getPath() . '::' . $action->getMethod();

--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -118,8 +118,9 @@ class OpenApi extends Compiler\Specification
                 foreach ($data['resources'] as $identifier => $resource) {
                     /** @var Action\Documentation $action */
                     foreach ($resource['actions'] as $action) {
+                        $path = $action->getPath();
                         $method = strtolower($action->getMethod());
-                        $identifier = $action->getPath()->getCleanPath();
+                        $identifier = $path->getCleanPath();
                         if (!isset($specifications[$this->version]['paths'][$identifier])) {
                             $specifications[$this->version]['paths'][$identifier] = [];
                         }
@@ -127,7 +128,7 @@ class OpenApi extends Compiler\Specification
                         $spec = [
                             'summary' => $action->getLabel(),
                             'description' => $action->getDescription(),
-                            'operationId' => $this->transformActionIntoOperationId($action),
+                            'operationId' => $action->getOperationId(),
                             'tags' => [
                                 $group
                             ],
@@ -415,22 +416,6 @@ class OpenApi extends Compiler\Specification
         return array_map(function (VendorTagAnnotation $vendor_tag): string {
             return $vendor_tag->getVendorTag();
         }, $vendor_tags);
-    }
-
-    /**
-     * @param Action\Documentation $action
-     * @return string
-     * @throws \Exception
-     */
-    private function transformActionIntoOperationId(Action\Documentation $action): string
-    {
-        $path = $action->getPath()->getCleanPath();
-        $path = str_replace(['{', '}'], '', $path);
-        $path = str_replace('/', ' ', $path);
-        $path = ucwords($path);
-        $path = str_replace(' ', '', $path);
-
-        return strtolower($action->getMethod()) . $path;
     }
 
     /**

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -261,6 +261,10 @@ class Parser
                 $annotation = 'MinVersion';
                 break;
 
+            case 'operationid':
+                $annotation = 'OperationId';
+                break;
+
             case 'pathparam':
                 $annotation = 'PathParam';
                 break;

--- a/src/Parser/Annotations/OperationIdAnnotation.php
+++ b/src/Parser/Annotations/OperationIdAnnotation.php
@@ -1,0 +1,50 @@
+<?php
+namespace Mill\Parser\Annotations;
+
+use Mill\Parser\Annotation;
+
+class OperationIdAnnotation extends Annotation
+{
+    const ARRAYABLE = [
+        'operation_id'
+    ];
+
+    /** @var string */
+    protected $operation_id;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function parser(): array
+    {
+        return [
+            'operation_id' => $this->docblock
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function interpreter(): void
+    {
+        $this->operation_id = $this->required('operation_id');
+    }
+
+    /**
+     * @return string
+     */
+    public function getOperationId(): string
+    {
+        return $this->operation_id;
+    }
+
+    /**
+     * @param string $operation_id
+     * @return OperationIdAnnotation
+     */
+    public function setOperationId(string $operation_id): self
+    {
+        $this->operation_id = $operation_id;
+        return $this;
+    }
+}

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -35,6 +35,7 @@ class DocumentationTest extends TestCase
         $this->assertSame($class, $parser->getClass());
         $this->assertSame($method, $parser->getMethod());
 
+        $this->assertSame($expected['operation_id'], $parser->getOperationId());
         $this->assertSame($expected['label'], $parser->getLabel());
 
         $this->assertCount(count($expected['content_types']), $parser->getContentTypes());
@@ -197,6 +198,7 @@ DESCRIPTION;
             'GET' => [
                 'method' => 'GET',
                 'expected' => [
+                    'operation_id' => 'getMovie',
                     'label' => 'Get a single movie.',
                     'description' => $get_description,
                     'group' => 'Movies',
@@ -307,6 +309,7 @@ DESCRIPTION;
             'PATCH' => [
                 'method' => 'PATCH',
                 'expected' => [
+                    'operation_id' => 'updateMovie',
                     'label' => 'Update a movie.',
                     'description' => 'Update a movies data.',
                     'group' => 'Movies',
@@ -851,6 +854,7 @@ DESCRIPTION;
             'DELETE' => [
                 'method' => 'DELETE',
                 'expected' => [
+                    'operation_id' => 'deleteMovie',
                     'label' => 'Delete a movie.',
                     'description' => 'Delete a movie.',
                     'group' => 'Movies',
@@ -943,6 +947,7 @@ DESCRIPTION;
             'with-aliased-paths' => [
                 'docblock' => '/**
                   * @api-label Update a piece of content.
+                  * @api-operationid updateFoo
                   * @api-group Foo\Bar
                   *
                   * @api-path:public /foo
@@ -987,6 +992,7 @@ DESCRIPTION;
             'with-multiple-visibilities' => [
                 'docblock' => '/**
                   * @api-label Update a piece of content.
+                  * @api-operationid updateFoo
                   * @api-group Foo\Bar
                   *
                   * @api-path:public /foo
@@ -1023,6 +1029,7 @@ DESCRIPTION;
             'with-capabilities' => [
                 'docblock' => '/**
                   * @api-label Delete a piece of content.
+                  * @api-operationid deleteFoo
                   * @api-group Foo\Bar
                   *
                   * @api-path:private /foo
@@ -1056,10 +1063,34 @@ DESCRIPTION;
                 'expected.exception' => '\Mill\Exceptions\Resource\NoAnnotationsException',
                 'expected.exception.asserts' => []
             ],
+            'missing-required-operation-id-annotation' => [
+                'docblock' => '/**
+                  * Test throwing an exception when a required `@api-operationid` annotation is missing.
+                  *
+                  * @api-path /some/page
+                  */',
+                'expected.exception' => '\Mill\Exceptions\Annotations\RequiredAnnotationException',
+                'expected.exception.asserts' => [
+                    'getAnnotation' => 'operationid'
+                ]
+            ],
+            'multiple-operation-id-annotations' => [
+                'docblock' => '/**
+                  * Test throwing an exception when multiple `@api-operationid` annotations are present.
+                  *
+                  * @api-operationid testFoo
+                  * @api-operationid testFoo
+                  */',
+                'expected.exception' => '\Mill\Exceptions\Annotations\MultipleAnnotationsException',
+                'expected.exception.asserts' => [
+                    'getAnnotation' => 'operationid'
+                ]
+            ],
             'missing-required-label-annotation' => [
                 'docblock' => '/**
                   * Test throwing an exception when a required `@api-label` annotation is missing.
                   *
+                  * @api-operationid testFoo
                   * @api-path /some/page
                   */',
                 'expected.exception' => '\Mill\Exceptions\Annotations\RequiredAnnotationException',
@@ -1071,6 +1102,7 @@ DESCRIPTION;
                 'docblock' => '/**
                   * Test throwing an exception when multiple `@api-label` annotations are present.
                   *
+                  * @api-operationid testFoo
                   * @api-label Test method
                   * @api-label Test method
                   */',
@@ -1084,6 +1116,7 @@ DESCRIPTION;
                   * Test throwing an exception when a required `@api-contenttype` annotation is missing.
                   *
                   * @api-label Test Method
+                  * @api-operationid testFoo
                   * @api-group Something
                   * @api-path /some/page
                   */',
@@ -1097,6 +1130,7 @@ DESCRIPTION;
                   * Test throwing an exception when a required visibility decorator is missing on an annotation.
                   *
                   * @api-label Test method
+                  * @api-operationid testFoo
                   * @api-group Root
                   * @api-path /
                   * @api-contenttype application/json
@@ -1112,6 +1146,7 @@ DESCRIPTION;
                   * Test throwing an exception when an unsupported decorator is found.
                   *
                   * @api-label Test method
+                  * @api-operationid testFoo
                   * @api-group Root
                   * @api-path:special /
                   * @api-contenttype application/json
@@ -1128,6 +1163,7 @@ DESCRIPTION;
                   * Test throwing an exception when a required `@api-path` annotation is missing.
                   *
                   * @api-label Test method
+                  * @api-operationid testFoo
                   * @api-group Something
                   * @api-contenttype application/json
                   * @api-param:public {page}
@@ -1142,6 +1178,7 @@ DESCRIPTION;
                   * Test throwing an exception when there are private annotations on a private action.
                   *
                   * @api-label Test method
+                  * @api-operationid testFoo
                   * @api-group Search
                   * @api-path:private /search
                   * @api-contenttype application/json
@@ -1160,6 +1197,7 @@ DESCRIPTION;
                   * Test throwing an exception when there is no canonical path and only path aliases.
                   *
                   * @api-label Test method
+                  * @api-operationid testFoo
                   * @api-group Search
                   * @api-path:private:alias /search
                   * @api-path:private:alias /search2

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -118,6 +118,10 @@ These actions will allow you to pull information on a specific movie.', $annotat
                         'class' => Parser\Annotations\MinVersionAnnotation::class,
                         'count' => 1
                     ],
+                    'operationid' => [
+                        'class' => Parser\Annotations\OperationIdAnnotation::class,
+                        'count' => 1
+                    ],
                     'path' => [
                         'class' => Parser\Annotations\PathAnnotation::class,
                         'count' => 2
@@ -157,6 +161,10 @@ These actions will allow you to pull information on a specific movie.', $annotat
                     ],
                     'minversion' => [
                         'class' => Parser\Annotations\MinVersionAnnotation::class,
+                        'count' => 1
+                    ],
+                    'operationid' => [
+                        'class' => Parser\Annotations\OperationIdAnnotation::class,
                         'count' => 1
                     ],
                     'param' => [
@@ -210,6 +218,10 @@ These actions will allow you to pull information on a specific movie.', $annotat
                     ],
                     'minversion' => [
                         'class' => Parser\Annotations\MinVersionAnnotation::class,
+                        'count' => 1
+                    ],
+                    'operationid' => [
+                        'class' => Parser\Annotations\OperationIdAnnotation::class,
                         'count' => 1
                     ],
                     'pathparam' => [

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -15,6 +15,7 @@
     "api-label": "@api-label",
     "api-maxversion": "@api-maxversion",
     "api-minversion": "@api-minversion",
+    "api-operationid": "@api-operationid",
     "api-param": "@api-param",
     "api-path": "@api-path",
     "api-pathparam": "@api-pathparam",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -23,6 +23,7 @@
       "api-label",
       "api-maxversion",
       "api-minversion",
+      "api-operationid",
       "api-param",
       "api-path",
       "api-pathparam",


### PR DESCRIPTION
This adds a new `@api-operationid` annotation. This lets you set a unique operation ID on resource actions that is in turn used during specification compilation. It is required.