### PR TITLE
Various OpenAPI compilation updates

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -58,6 +58,7 @@
                             <xs:complexType>
                                 <xs:simpleContent>
                                     <xs:extension base="xs:string">
+                                        <xs:attribute name="environment" type="xs:string" use="required" />
                                         <xs:attribute name="url" type="xs:string" use="required" />
                                         <xs:attribute name="description" type="xs:string" use="required" />
                                     </xs:extension>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,8 +25,8 @@ In order to instruct Mill on where to look for documentation, and any constraint
     </info>
 
     <servers>
-        <server url="https://api.example.com" description="Production" />
-        <server url="https://api.example.local" description="Development" />
+        <server environment="prod" url="https://api.example.com" description="Production" />
+        <server environment="dev" url="https://api.example.local" description="Development" />
     </servers>
 
     <versions>
@@ -242,8 +242,8 @@ Configure your API servers with the `<servers>` element.
 
 ```xml
     <servers>
-        <server url="https://api.example.com" description="Production" />
-        <server url="https://api.example.local" description="Development" />
+        <server environment="prod" url="https://api.example.com" description="Production" />
+        <server environment="dev" url="https://api.example.local" description="Development" />
     </servers>
 ```
 

--- a/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
@@ -50,6 +50,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movie/+id
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -81,6 +82,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
   /movies:
     get:
@@ -112,6 +114,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
@@ -200,6 +203,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
   '/theaters/{id}':
     get:
@@ -232,6 +236,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
@@ -300,6 +305,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
@@ -329,6 +335,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /theaters/+id
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -359,6 +366,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
@@ -406,6 +414,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
@@ -48,6 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movie/+id
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -79,6 +80,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
   /movies:
     get:
@@ -110,6 +112,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
@@ -198,6 +201,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Theaters.yaml
@@ -48,6 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
@@ -116,6 +117,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
@@ -145,6 +147,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /theaters/+id
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -175,6 +178,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
@@ -222,6 +226,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
@@ -50,6 +50,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movie/+id
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -81,6 +82,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
@@ -193,6 +195,7 @@ paths:
         -
           oauth2:
             - edit
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie.'
@@ -222,6 +225,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /movies/+id
       x-mill-vendortags:
         - 'tag:DELETE_CONTENT'
   /movies:
@@ -261,6 +265,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
@@ -358,6 +363,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
   '/theaters/{id}':
     get:
@@ -390,6 +396,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
@@ -458,6 +465,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
@@ -487,6 +495,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /theaters/+id
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -517,6 +526,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
@@ -564,6 +574,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
@@ -226,7 +226,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /movies/+id
-      x-mill-vendortags:
+      x-mill-vendor-tags:
         - 'tag:DELETE_CONTENT'
   /movies:
     get:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
@@ -48,6 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movie/+id
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -79,6 +80,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
@@ -191,6 +193,7 @@ paths:
         -
           oauth2:
             - edit
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie.'
@@ -220,6 +223,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /movies/+id
       x-mill-vendortags:
         - 'tag:DELETE_CONTENT'
   /movies:
@@ -259,6 +263,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
@@ -356,6 +361,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
@@ -224,7 +224,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /movies/+id
-      x-mill-vendortags:
+      x-mill-vendor-tags:
         - 'tag:DELETE_CONTENT'
   /movies:
     get:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Theaters.yaml
@@ -48,6 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
@@ -116,6 +117,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
@@ -145,6 +147,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /theaters/+id
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -175,6 +178,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
@@ -222,6 +226,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
@@ -50,6 +50,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movie/+id
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -81,6 +82,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
@@ -193,6 +195,7 @@ paths:
         -
           oauth2:
             - edit
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie.'
@@ -222,6 +225,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /movies/+id
       x-mill-vendortags:
         - 'tag:DELETE_CONTENT'
   /movies:
@@ -261,6 +265,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
@@ -358,6 +363,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
   '/theaters/{id}':
     get:
@@ -390,6 +396,7 @@ paths:
             application/mill.example.theater+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
@@ -452,6 +459,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
@@ -481,6 +489,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /theaters/+id
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -511,6 +520,7 @@ paths:
             application/mill.example.theater+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
@@ -558,6 +568,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
@@ -226,7 +226,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /movies/+id
-      x-mill-vendortags:
+      x-mill-vendor-tags:
         - 'tag:DELETE_CONTENT'
   /movies:
     get:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
@@ -48,6 +48,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movie/+id
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -79,6 +80,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
@@ -191,6 +193,7 @@ paths:
         -
           oauth2:
             - edit
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie.'
@@ -220,6 +223,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /movies/+id
       x-mill-vendortags:
         - 'tag:DELETE_CONTENT'
   /movies:
@@ -259,6 +263,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
@@ -356,6 +361,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
@@ -224,7 +224,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /movies/+id
-      x-mill-vendortags:
+      x-mill-vendor-tags:
         - 'tag:DELETE_CONTENT'
   /movies:
     get:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Theaters.yaml
@@ -48,6 +48,7 @@ paths:
             application/mill.example.theater+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
@@ -110,6 +111,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
@@ -139,6 +141,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /theaters/+id
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -169,6 +172,7 @@ paths:
             application/mill.example.theater+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
@@ -216,6 +220,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
@@ -50,6 +50,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movie/+id
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -81,6 +82,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
@@ -205,6 +207,7 @@ paths:
         -
           oauth2:
             - edit
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
   /movies:
     get:
@@ -243,6 +246,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
@@ -342,6 +346,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
   '/theaters/{id}':
     get:
@@ -374,6 +379,7 @@ paths:
             application/mill.example.theater+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
@@ -436,6 +442,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
@@ -465,6 +472,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /theaters/+id
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -495,6 +503,7 @@ paths:
             application/mill.example.theater+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
@@ -542,6 +551,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
@@ -48,6 +48,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movie/+id
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -79,6 +80,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
@@ -203,6 +205,7 @@ paths:
         -
           oauth2:
             - edit
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
   /movies:
     get:
@@ -241,6 +244,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
@@ -340,6 +344,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Theaters.yaml
@@ -48,6 +48,7 @@ paths:
             application/mill.example.theater+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
@@ -110,6 +111,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
@@ -139,6 +141,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /theaters/+id
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -169,6 +172,7 @@ paths:
             application/mill.example.theater+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
@@ -216,6 +220,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
@@ -222,7 +222,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /movies/+id
-      x-mill-vendortags:
+      x-mill-vendor-tags:
         - 'tag:DELETE_CONTENT'
   /movies:
     get:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
@@ -50,6 +50,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movie/+id
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -81,6 +82,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
@@ -189,6 +191,7 @@ paths:
         -
           oauth2:
             - edit
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie.'
@@ -218,6 +221,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /movies/+id
       x-mill-vendortags:
         - 'tag:DELETE_CONTENT'
   /movies:
@@ -257,6 +261,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
@@ -354,6 +359,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
   '/theaters/{id}':
     get:
@@ -386,6 +392,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
@@ -454,6 +461,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
@@ -483,6 +491,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /theaters/+id
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -513,6 +522,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
@@ -560,6 +570,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
@@ -48,6 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movie/+id
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -79,6 +80,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
@@ -187,6 +189,7 @@ paths:
         -
           oauth2:
             - edit
+      x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie.'
@@ -216,6 +219,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /movies/+id
       x-mill-vendortags:
         - 'tag:DELETE_CONTENT'
   /movies:
@@ -255,6 +259,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
@@ -352,6 +357,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /movies
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
@@ -220,7 +220,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /movies/+id
-      x-mill-vendortags:
+      x-mill-vendor-tags:
         - 'tag:DELETE_CONTENT'
   /movies:
     get:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Theaters.yaml
@@ -48,6 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
@@ -116,6 +117,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters/+id
       x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
@@ -145,6 +147,7 @@ paths:
         -
           oauth2:
             - delete
+      x-mill-path-template: /theaters/+id
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -175,6 +178,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
@@ -222,6 +226,7 @@ paths:
         -
           oauth2:
             - create
+      x-mill-path-template: /theaters
       x-mill-visibility-private: true
 components:
   securitySchemes:

--- a/resources/examples/mill.xml
+++ b/resources/examples/mill.xml
@@ -17,8 +17,8 @@
     </info>
 
     <servers>
-        <server url="https://api.example.com" description="Production" />
-        <server url="https://api.example.local" description="Development" />
+        <server environment="prod" url="https://api.example.com" description="Production" />
+        <server environment="dev" url="https://api.example.local" description="Development" />
     </servers>
 
     <versions>

--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -84,6 +84,7 @@ class OpenApi extends Compiler\Specification
                         }
 
                         $schema = [
+                            'deprecated' => $path->isDeprecated(),
                             'summary' => $action->getLabel(),
                             'description' => $action->getDescription(),
                             'operationId' => $action->getOperationId(),
@@ -94,9 +95,9 @@ class OpenApi extends Compiler\Specification
                             'requestBody' => $this->processRequest($action),
                             'responses' => $this->processResponses($action),
                             'security' => $this->processSecurity($action),
+                            'x-mill-path-template' => $path->getPath(),
                             'x-mill-vendortags' => $this->processVendorTags($action),
-                            'x-mill-visibility-private' => $action->getPath()->isVisible(),
-                            'x-mill-deprecated' => $action->getPath()->isDeprecated()
+                            'x-mill-visibility-private' => $path->isVisible()
                         ];
 
                         foreach ([
@@ -111,14 +112,14 @@ class OpenApi extends Compiler\Specification
                             }
                         }
 
+                        // Only include the `deprecated` tag if the action is deprecated.
+                        if (!$schema['deprecated']) {
+                            unset($schema['deprecated']);
+                        }
+
                         // Only include the `x-mill-visibility-private` tag if the action is private.
                         if (!$schema['x-mill-visibility-private']) {
                             unset($schema['x-mill-visibility-private']);
-                        }
-
-                        // Only include the `x-mill-deprecated` tag if the action is deprecated.
-                        if (!$schema['x-mill-deprecated']) {
-                            unset($schema['x-mill-deprecated']);
                         }
 
                         $specification['paths'][$identifier][$method] = $schema;

--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -18,6 +18,9 @@ use Symfony\Component\Yaml\Yaml;
 
 class OpenApi extends Compiler\Specification
 {
+    /** @var string|null */
+    protected $environment = null;
+
     /**
      * Take compiled API documentation and create a OpenAPI specification.
      *
@@ -96,7 +99,7 @@ class OpenApi extends Compiler\Specification
                             'responses' => $this->processResponses($action),
                             'security' => $this->processSecurity($action),
                             'x-mill-path-template' => $path->getPath(),
-                            'x-mill-vendortags' => $this->processVendorTags($action),
+                            'x-mill-vendor-tags' => $this->processVendorTags($action),
                             'x-mill-visibility-private' => $path->isVisible()
                         ];
 
@@ -105,7 +108,7 @@ class OpenApi extends Compiler\Specification
                             'parameters',
                             'requestBody',
                             'security',
-                            'x-mill-vendortags'
+                            'x-mill-vendor-tags'
                         ] as $key) {
                             if (empty($schema[$key])) {
                                 unset($schema[$key]);
@@ -202,6 +205,12 @@ class OpenApi extends Compiler\Specification
     {
         $spec = [];
         foreach ($this->config->getServers() as $server) {
+            if (!empty($this->environment)) {
+                if ($server['environment'] !== $this->environment) {
+                    continue;
+                }
+            }
+
             $spec[] = [
                 'url' => $server['url'],
                 'description' => $server['description']
@@ -685,6 +694,16 @@ class OpenApi extends Compiler\Specification
     private function getReferenceName(string $name): string
     {
         return (new Slugify())->slugify($name);
+    }
+
+    /**
+     * @param string $environment
+     * @return OpenApi
+     */
+    public function setEnvironment(string $environment): self
+    {
+        $this->environment = strtolower($environment);
+        return $this;
     }
 
     /**

--- a/src/Config.php
+++ b/src/Config.php
@@ -315,6 +315,7 @@ class Config
     {
         foreach ($xml->servers->server as $server) {
             $this->servers[] = [
+                'environment' => strtolower((string) $server['environment']),
                 'url' => (string) $server['url'],
                 'description' => (string) $server['description']
             ];
@@ -569,6 +570,35 @@ class Config
     public function getServers(): array
     {
         return $this->servers;
+    }
+
+    /**
+     * Does a server environment exist in the config?
+     *
+     * @param string $environment
+     * @return bool
+     */
+    public function hasServerEnvironment(string $environment): bool
+    {
+        return !empty($this->getServerEnvironment($environment));
+    }
+
+    /**
+     * Return a configured server by its defined environment name.
+     *
+     * @param string $environment
+     * @return bool|array
+     */
+    public function getServerEnvironment(string $environment)
+    {
+        $environment = strtolower($environment);
+        foreach ($this->servers as $server) {
+            if ($server['environment'] === $environment) {
+                return $server;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -29,14 +29,26 @@ class ConfigTest extends TestCase
 
         $this->assertSame([
             [
+                'environment' => 'prod',
                 'url' => 'https://api.example.com',
                 'description' => 'Production'
             ],
             [
+                'environment' => 'dev',
                 'url' => 'https://api.example.local',
                 'description' => 'Development'
             ]
         ], $config->getServers());
+
+        $this->assertTrue($config->hasServerEnvironment('prod'));
+        $this->assertTrue($config->hasServerEnvironment('dev'));
+        $this->assertFalse($config->hasServerEnvironment('local'));
+
+        $this->assertSame([
+            'environment' => 'prod',
+            'url' => 'https://api.example.com',
+            'description' => 'Production'
+        ], $config->getServerEnvironment('prod'));
 
         $this->assertSame('1.0', $config->getFirstApiVersion());
         $this->assertSame('1.1.2', $config->getDefaultApiVersion());
@@ -254,8 +266,8 @@ XML;
         if (strpos($provider, 'servers.') === false) {
             $servers = <<<XML
 <servers>
-    <server url="https://api.example.com" description="Production" />
-    <server url="https://api.example.local" description="Development" />
+    <server environment="prod" url="https://api.example.com" description="Production" />
+    <server environment="dev" url="https://api.example.local" description="Development" />
 </servers>
 XML;
         }

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -17,8 +17,8 @@
     </info>
 
     <servers>
-        <server url="https://api.example.com" description="Production" />
-        <server url="https://api.example.local" description="Development" />
+        <server environment="prod" url="https://api.example.com" description="Production" />
+        <server environment="dev" url="https://api.example.local" description="Development" />
     </servers>
 
     <versions>


### PR DESCRIPTION
### Added
* [ ] Adding `x-mill-path-template` for outputting the raw path template to the specification. Can be helpful if you want to utilize [RFC 6570](https://tools.ietf.org/html/rfc6570) templates in your specification usage.
* [ ] A new `environment` attribute on `server` config entries.
* [ ] New `--environment` flag on `./bin/mill compile` that lets you compile OpenAPI specifications for specifically configured server environments.

### Changed
* [ ] Renaming `x-mill-deprecated` to `deprecated`.
* [ ] Renaming `x-mill-vendortags` to `x-mill-vendor-tags`.