### PR TITLE
Addition of OpenAPI path alias extensions

### DIFF
--- a/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
@@ -50,6 +50,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
   /movies:
     get:
@@ -203,6 +204,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliases:
+        - '/movie/{id}'
       x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
   /theaters:

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
@@ -48,6 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
   /movies:
     get:
@@ -201,6 +202,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliases:
+        - '/movie/{id}'
       x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
 components:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
@@ -50,6 +50,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
   /movies:
     get:
@@ -219,6 +220,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliases:
+        - '/movie/{id}'
       x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
@@ -48,6 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
   /movies:
     get:
@@ -217,6 +218,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliases:
+        - '/movie/{id}'
       x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
@@ -50,6 +50,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
   /movies:
     get:
@@ -219,6 +220,8 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliases:
+        - '/movie/{id}'
       x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
@@ -48,6 +48,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
   /movies:
     get:
@@ -217,6 +218,8 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliases:
+        - '/movie/{id}'
       x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
@@ -50,6 +50,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
   /movies:
     get:
@@ -221,6 +222,8 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliases:
+        - '/movie/{id}'
       x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
@@ -48,6 +48,7 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
   /movies:
     get:
@@ -219,6 +220,8 @@ paths:
             application/mill.example.movie+json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliases:
+        - '/movie/{id}'
       x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
@@ -50,6 +50,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
   /movies:
     get:
@@ -219,6 +220,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliases:
+        - '/movie/{id}'
       x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
@@ -48,6 +48,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
   /movies:
     get:
@@ -217,6 +218,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/error'
+      x-mill-path-aliases:
+        - '/movie/{id}'
       x-mill-path-template: /movies/+id
       x-mill-visibility-private: true
     patch:

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -105,13 +105,6 @@ class Compiler
                         continue;
                     }
 
-                    $is_aliased = $path->isAliased();
-
-                    // We're always going to be compiling documentation for this path, regardless if it's an alias or
-                    // not, so let's strip any awareness of that.
-                    $path->setAliased(false);
-                    $path->setAliases([]);
-
                     $resource_label = $annotations['label'];
                     if (!isset($resources[$group]['resources'][$resource_label])) {
                         $resources[$group]['resources'][$resource_label] = [
@@ -137,7 +130,7 @@ class Compiler
                     $action->setPathParams($params);
                     $action->filterAnnotationsForVisibility($this->load_private_docs, $this->load_vendor_tag_docs);
 
-                    if ($is_aliased) {
+                    if ($path->isAliased()) {
                         $action->incrementOperationId(++$aliases);
                     }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -5,6 +5,7 @@ use gossi\docblock\Docblock;
 use gossi\docblock\tags\UnknownTag;
 use Mill\Exceptions\Resource\UnsupportedDecoratorException;
 use Mill\Parser\Annotation;
+use Mill\Parser\Annotations\PathAnnotation;
 use Mill\Parser\MSON;
 use Mill\Parser\Version;
 use ReflectionClass;
@@ -218,7 +219,9 @@ class Parser
                         break;
 
                     case 'alias':
-                        $annotation->setAliased(true);
+                        if ($annotation instanceof PathAnnotation) {
+                            $annotation->setAliased(true);
+                        }
                         break;
 
                     default:

--- a/src/Parser/Annotation.php
+++ b/src/Parser/Annotation.php
@@ -52,12 +52,6 @@ abstract class Annotation implements Arrayable
     /** @var array Array of all authentication scopes required for this annotation. */
     protected $scopes = [];
 
-    /** @var array<Annotation> Array of all available aliases for this annotation. */
-    protected $aliases = [];
-
-    /** @var bool Flag designating that this annotation is aliased or not. */
-    protected $aliased = false;
-
     /** @var array Array of parsed data from this annotation. */
     protected $parsed_data = [];
 
@@ -354,50 +348,6 @@ abstract class Annotation implements Arrayable
     {
         $this->deprecated = $deprecated;
         return $this;
-    }
-
-    /**
-     * Is this annotation an alias?
-     *
-     * @return bool
-     */
-    public function isAliased(): bool
-    {
-        return $this->aliased;
-    }
-
-    /**
-     * Set if this annotation is an alias or not.
-     *
-     * @param bool $aliased
-     * @return Annotation
-     */
-    public function setAliased(bool $aliased): self
-    {
-        $this->aliased = $aliased;
-        return $this;
-    }
-
-    /**
-     * Set any aliases to this annotation.
-     *
-     * @param array $aliases
-     * @return Annotation
-     */
-    public function setAliases(array $aliases): self
-    {
-        $this->aliases = $aliases;
-        return $this;
-    }
-
-    /**
-     * Get all available aliases for this annotation.
-     *
-     * @return array<Annotation>
-     */
-    public function getAliases(): array
-    {
-        return $this->aliases;
     }
 
     /**

--- a/src/Parser/Annotations/PathAnnotation.php
+++ b/src/Parser/Annotations/PathAnnotation.php
@@ -16,6 +16,12 @@ class PathAnnotation extends Annotation
     /** @var string URI path that this annotation represents. */
     protected $path;
 
+    /** @var array<PathAnnotation> Array of all available aliases for this annotation. */
+    protected $aliases = [];
+
+    /** @var bool Flag designating that this annotation is aliased or not. */
+    protected $aliased = false;
+
     /**
      * {@inheritdoc}
      */
@@ -79,6 +85,50 @@ class PathAnnotation extends Annotation
     public function doesPathHaveParam(PathParamAnnotation $param): bool
     {
         return strpos($this->getCleanPath(), '{' . $param->getField() . '}') !== false;
+    }
+
+    /**
+     * Is this annotation an alias?
+     *
+     * @return bool
+     */
+    public function isAliased(): bool
+    {
+        return $this->aliased;
+    }
+
+    /**
+     * Set if this annotation is an alias or not.
+     *
+     * @param bool $aliased
+     * @return PathAnnotation
+     */
+    public function setAliased(bool $aliased): self
+    {
+        $this->aliased = $aliased;
+        return $this;
+    }
+
+    /**
+     * Set any aliases to this annotation.
+     *
+     * @param array $aliases
+     * @return PathAnnotation
+     */
+    public function setAliases(array $aliases): self
+    {
+        $this->aliases = $aliases;
+        return $this;
+    }
+
+    /**
+     * Get all available aliases for this annotation.
+     *
+     * @return array<PathAnnotation>
+     */
+    public function getAliases(): array
+    {
+        return $this->aliases;
     }
 
     /**

--- a/src/Parser/Resource/Action/Documentation.php
+++ b/src/Parser/Resource/Action/Documentation.php
@@ -414,13 +414,17 @@ class Documentation implements Arrayable
         }
 
         if (empty($paths)) {
-            throw new \Exception(
-                sprintf(
-                    'There were zero non-aliased paths detected in this %s::%s.',
-                    $this->getClass(),
-                    $this->getMethod()
-                )
-            );
+            if (count($this->getPaths()) > 1) {
+                throw new \Exception(
+                    sprintf(
+                        'There were zero non-aliased paths detected in this %s::%s.',
+                        $this->getClass(),
+                        $this->getMethod()
+                    )
+                );
+            }
+
+            $paths = $this->getPaths();
         }
 
         return array_shift($paths);

--- a/tests/Parser/Annotations/ContentTypeAnnotationTest.php
+++ b/tests/Parser/Annotations/ContentTypeAnnotationTest.php
@@ -37,8 +37,6 @@ class ContentTypeAnnotationTest extends AnnotationTest
         } else {
             $this->assertFalse($annotation->getVersion());
         }
-
-        $this->assertEmpty($annotation->getAliases());
     }
 
     public function providerAnnotation(): array

--- a/tests/Parser/Annotations/DescriptionAnnotationTest.php
+++ b/tests/Parser/Annotations/DescriptionAnnotationTest.php
@@ -29,7 +29,6 @@ class DescriptionAnnotationTest extends AnnotationTest
         $this->assertSame($expected, $annotation->toArray());
         $this->assertEmpty($annotation->getVendorTags());
         $this->assertFalse($annotation->getVersion());
-        $this->assertEmpty($annotation->getAliases());
     }
 
     public function providerAnnotation(): array

--- a/tests/Parser/Annotations/ErrorAnnotationTest.php
+++ b/tests/Parser/Annotations/ErrorAnnotationTest.php
@@ -56,8 +56,6 @@ class ErrorAnnotationTest extends AnnotationTest
         } else {
             $this->assertFalse($annotation->getVersion());
         }
-
-        $this->assertEmpty($annotation->getAliases());
     }
 
     public function providerAnnotation(): array

--- a/tests/Parser/Annotations/GroupAnnotationTest.php
+++ b/tests/Parser/Annotations/GroupAnnotationTest.php
@@ -29,7 +29,6 @@ class GroupAnnotationTest extends AnnotationTest
         $this->assertSame($expected, $annotation->toArray());
         $this->assertEmpty($annotation->getVendorTags());
         $this->assertFalse($annotation->getVersion());
-        $this->assertEmpty($annotation->getAliases());
     }
 
     public function providerAnnotation(): array

--- a/tests/Parser/Annotations/LabelAnnotationTest.php
+++ b/tests/Parser/Annotations/LabelAnnotationTest.php
@@ -29,7 +29,6 @@ class LabelAnnotationTest extends AnnotationTest
         $this->assertSame($expected, $annotation->toArray());
         $this->assertEmpty($annotation->getVendorTags());
         $this->assertFalse($annotation->getVersion());
-        $this->assertEmpty($annotation->getAliases());
     }
 
     public function providerAnnotation(): array

--- a/tests/Parser/Annotations/MaxVersionAnnotationTest.php
+++ b/tests/Parser/Annotations/MaxVersionAnnotationTest.php
@@ -30,7 +30,6 @@ class MaxVersionAnnotationTest extends AnnotationTest
         $this->assertSame($expected, $annotation->toArray());
         $this->assertEmpty($annotation->getVendorTags());
         $this->assertFalse($annotation->getVersion());
-        $this->assertEmpty($annotation->getAliases());
     }
 
     public function providerAnnotation(): array

--- a/tests/Parser/Annotations/MinVersionAnnotationTest.php
+++ b/tests/Parser/Annotations/MinVersionAnnotationTest.php
@@ -30,7 +30,6 @@ class MinVersionAnnotationTest extends AnnotationTest
         $this->assertSame($expected, $annotation->toArray());
         $this->assertEmpty($annotation->getVendorTags());
         $this->assertFalse($annotation->getVersion());
-        $this->assertEmpty($annotation->getAliases());
     }
 
     public function providerAnnotation(): array

--- a/tests/Parser/Annotations/ParamAnnotationTest.php
+++ b/tests/Parser/Annotations/ParamAnnotationTest.php
@@ -65,8 +65,6 @@ class ParamAnnotationTest extends AnnotationTest
         } else {
             $this->assertFalse($annotation->getVersion());
         }
-
-        $this->assertEmpty($annotation->getAliases());
     }
 
     public function providerAnnotation(): array

--- a/tests/Parser/Annotations/PathParamAnnotationTest.php
+++ b/tests/Parser/Annotations/PathParamAnnotationTest.php
@@ -35,7 +35,6 @@ class PathParamAnnotationTest extends AnnotationTest
         $this->assertSame($expected['description'], $annotation->getDescription());
         $this->assertEmpty($annotation->getVendorTags());
         $this->assertFalse($annotation->getVersion());
-        $this->assertEmpty($annotation->getAliases());
     }
 
     public function providerAnnotation(): array

--- a/tests/Parser/Annotations/ReturnAnnotationTest.php
+++ b/tests/Parser/Annotations/ReturnAnnotationTest.php
@@ -44,8 +44,6 @@ class ReturnAnnotationTest extends AnnotationTest
         } else {
             $this->assertFalse($annotation->getVersion());
         }
-
-        $this->assertEmpty($annotation->getAliases());
     }
 
     public function providerAnnotation(): array

--- a/tests/Parser/Annotations/ScopeAnnotationTest.php
+++ b/tests/Parser/Annotations/ScopeAnnotationTest.php
@@ -32,7 +32,6 @@ class ScopeAnnotationTest extends AnnotationTest
         $this->assertSame($expected['description'], $annotation->getDescription());
         $this->assertEmpty($annotation->getVendorTags());
         $this->assertFalse($annotation->getVersion());
-        $this->assertEmpty($annotation->getAliases());
     }
 
     public function providerAnnotation(): array

--- a/tests/Parser/Annotations/VendorTagAnnotationTest.php
+++ b/tests/Parser/Annotations/VendorTagAnnotationTest.php
@@ -30,7 +30,6 @@ class VendorTagAnnotationTest extends AnnotationTest
         $this->assertSame($expected, $annotation->toArray());
         $this->assertSame($expected['vendor_tag'], $annotation->getVendorTag());
         $this->assertFalse($annotation->getVersion());
-        $this->assertEmpty($annotation->getAliases());
     }
 
     public function providerAnnotation(): array


### PR DESCRIPTION
This adds `x-mill-path-aliased` and `x-mill-path-aliases` extensions to compiled OpenAPI specs.