### PR TITLE
Fixing some OAS quirks on parameters with subtypes.

### DIFF
--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -632,6 +632,16 @@ class OpenApi extends Compiler\Specification
                 PathParamAnnotation::PAYLOAD_FORMAT,
                 QueryParamAnnotation::PAYLOAD_FORMAT
             ])) {
+                // Fix up any quirks left behind on processing these data models because we can't have a `schema`
+                // element present with `items` and/or `properties`.
+                if (isset($spec['items'])) {
+                    $spec['schema']['items'] = $spec['items'];
+                    unset($spec['items']);
+                } elseif (isset($spec['properties'])) {
+                    $spec['schema']['properties'] = $spec['properties'];
+                    unset($spec['properties']);
+                }
+
                 $schema[] = $spec;
             } else {
                 $schema[$field_name] = $spec;


### PR DESCRIPTION
Fixing some quirks where annotations like the following would be compiled into an OAS that doesn't validate:

```
@api-queryParam:private category_uris (array<uri>) - Array of category URI's to pull videos for.
```

```
description: 'Array of category URI''s to pull videos for.'
in: query
items:
  type: string
name: category_uris
required: false
schema:
  type: array
```