### PR TITLE
Various OAS fixes

### DIFF
--- a/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
@@ -52,6 +52,7 @@ paths:
                 $ref: '#/components/schemas/error'
       x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
+      x-mill-visibility-private: true
   /movies:
     get:
       summary: 'Get movies.'
@@ -83,7 +84,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
@@ -172,7 +172,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -207,7 +206,6 @@ paths:
       x-mill-path-aliases:
         - '/movie/{id}'
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -239,7 +237,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
@@ -287,7 +284,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
   '/theaters/{id}':
     get:
       summary: 'Get a single movie theater.'
@@ -320,7 +316,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
@@ -389,7 +384,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
@@ -419,6 +413,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
@@ -50,6 +50,7 @@ paths:
                 $ref: '#/components/schemas/error'
       x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
+      x-mill-visibility-private: true
   /movies:
     get:
       summary: 'Get movies.'
@@ -81,7 +82,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
@@ -170,7 +170,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -205,7 +204,6 @@ paths:
       x-mill-path-aliases:
         - '/movie/{id}'
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Theaters.yaml
@@ -48,7 +48,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
@@ -96,7 +95,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
   '/theaters/{id}':
     get:
       summary: 'Get a single movie theater.'
@@ -129,7 +127,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
@@ -198,7 +195,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
@@ -228,6 +224,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
@@ -52,6 +52,7 @@ paths:
                 $ref: '#/components/schemas/error'
       x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
+      x-mill-visibility-private: true
   /movies:
     get:
       summary: 'Get movies.'
@@ -90,7 +91,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
@@ -188,7 +188,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -223,7 +222,6 @@ paths:
       x-mill-path-aliases:
         - '/movie/{id}'
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
       description: 'Update a movies data.'
@@ -336,7 +334,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie.'
       description: 'Delete a movie.'
@@ -368,6 +365,7 @@ paths:
       x-mill-path-template: /movies/+id
       x-mill-vendor-tags:
         - 'tag:DELETE_CONTENT'
+      x-mill-visibility-private: true
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -399,7 +397,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
@@ -447,7 +444,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
   '/theaters/{id}':
     get:
       summary: 'Get a single movie theater.'
@@ -480,7 +476,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
@@ -549,7 +544,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
@@ -579,6 +573,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
@@ -50,6 +50,7 @@ paths:
                 $ref: '#/components/schemas/error'
       x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
+      x-mill-visibility-private: true
   /movies:
     get:
       summary: 'Get movies.'
@@ -88,7 +89,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
@@ -186,7 +186,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -221,7 +220,6 @@ paths:
       x-mill-path-aliases:
         - '/movie/{id}'
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
       description: 'Update a movies data.'
@@ -334,7 +332,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie.'
       description: 'Delete a movie.'
@@ -366,6 +363,7 @@ paths:
       x-mill-path-template: /movies/+id
       x-mill-vendor-tags:
         - 'tag:DELETE_CONTENT'
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Theaters.yaml
@@ -48,7 +48,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
@@ -96,7 +95,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
   '/theaters/{id}':
     get:
       summary: 'Get a single movie theater.'
@@ -129,7 +127,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
@@ -198,7 +195,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
@@ -228,6 +224,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
@@ -52,6 +52,7 @@ paths:
                 $ref: '#/components/schemas/error'
       x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
+      x-mill-visibility-private: true
   /movies:
     get:
       summary: 'Get movies.'
@@ -90,7 +91,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
@@ -188,7 +188,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -223,7 +222,6 @@ paths:
       x-mill-path-aliases:
         - '/movie/{id}'
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
       description: 'Update a movies data.'
@@ -336,7 +334,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie.'
       description: 'Delete a movie.'
@@ -368,6 +365,7 @@ paths:
       x-mill-path-template: /movies/+id
       x-mill-vendor-tags:
         - 'tag:DELETE_CONTENT'
+      x-mill-visibility-private: true
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -399,7 +397,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
@@ -447,7 +444,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
   '/theaters/{id}':
     get:
       summary: 'Get a single movie theater.'
@@ -480,7 +476,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
@@ -543,7 +538,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
@@ -573,6 +567,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
@@ -50,6 +50,7 @@ paths:
                 $ref: '#/components/schemas/error'
       x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
+      x-mill-visibility-private: true
   /movies:
     get:
       summary: 'Get movies.'
@@ -88,7 +89,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
@@ -186,7 +186,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -221,7 +220,6 @@ paths:
       x-mill-path-aliases:
         - '/movie/{id}'
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
       description: 'Update a movies data.'
@@ -334,7 +332,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie.'
       description: 'Delete a movie.'
@@ -366,6 +363,7 @@ paths:
       x-mill-path-template: /movies/+id
       x-mill-vendor-tags:
         - 'tag:DELETE_CONTENT'
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Theaters.yaml
@@ -48,7 +48,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
@@ -96,7 +95,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
   '/theaters/{id}':
     get:
       summary: 'Get a single movie theater.'
@@ -129,7 +127,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
@@ -192,7 +189,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
@@ -222,6 +218,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
@@ -52,6 +52,7 @@ paths:
                 $ref: '#/components/schemas/error'
       x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
+      x-mill-visibility-private: true
   /movies:
     get:
       summary: 'Get movies.'
@@ -90,7 +91,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
@@ -190,7 +190,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -225,7 +224,6 @@ paths:
       x-mill-path-aliases:
         - '/movie/{id}'
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
       description: 'Update a movies data.'
@@ -350,7 +348,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -382,7 +379,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
@@ -430,7 +426,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
   '/theaters/{id}':
     get:
       summary: 'Get a single movie theater.'
@@ -463,7 +458,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
@@ -526,7 +520,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
@@ -556,6 +549,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
@@ -50,6 +50,7 @@ paths:
                 $ref: '#/components/schemas/error'
       x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
+      x-mill-visibility-private: true
   /movies:
     get:
       summary: 'Get movies.'
@@ -88,7 +89,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
@@ -188,7 +188,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -223,7 +222,6 @@ paths:
       x-mill-path-aliases:
         - '/movie/{id}'
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
       description: 'Update a movies data.'
@@ -348,7 +346,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Theaters.yaml
@@ -48,7 +48,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
@@ -96,7 +95,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
   '/theaters/{id}':
     get:
       summary: 'Get a single movie theater.'
@@ -129,7 +127,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
@@ -192,7 +189,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
@@ -222,6 +218,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
@@ -52,6 +52,7 @@ paths:
                 $ref: '#/components/schemas/error'
       x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
+      x-mill-visibility-private: true
   /movies:
     get:
       summary: 'Get movies.'
@@ -90,7 +91,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
@@ -188,7 +188,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -223,7 +222,6 @@ paths:
       x-mill-path-aliases:
         - '/movie/{id}'
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
       description: 'Update a movies data.'
@@ -332,7 +330,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie.'
       description: 'Delete a movie.'
@@ -364,6 +361,7 @@ paths:
       x-mill-path-template: /movies/+id
       x-mill-vendor-tags:
         - 'tag:DELETE_CONTENT'
+      x-mill-visibility-private: true
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -395,7 +393,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
@@ -443,7 +440,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
   '/theaters/{id}':
     get:
       summary: 'Get a single movie theater.'
@@ -476,7 +472,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
@@ -545,7 +540,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
@@ -575,6 +569,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
@@ -50,6 +50,7 @@ paths:
                 $ref: '#/components/schemas/error'
       x-mill-path-aliased: true
       x-mill-path-template: /movie/+id
+      x-mill-visibility-private: true
   /movies:
     get:
       summary: 'Get movies.'
@@ -88,7 +89,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie.'
       description: 'Create a new movie.'
@@ -186,7 +186,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /movies
-      x-mill-visibility-private: true
   '/movies/{id}':
     get:
       summary: 'Get a single movie.'
@@ -221,7 +220,6 @@ paths:
       x-mill-path-aliases:
         - '/movie/{id}'
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie.'
       description: 'Update a movies data.'
@@ -330,7 +328,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie.'
       description: 'Delete a movie.'
@@ -362,6 +359,7 @@ paths:
       x-mill-path-template: /movies/+id
       x-mill-vendor-tags:
         - 'tag:DELETE_CONTENT'
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Theaters.yaml
@@ -48,7 +48,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
     post:
       summary: 'Create a movie theater.'
       description: 'Create a new movie theater.'
@@ -96,7 +95,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters
-      x-mill-visibility-private: true
   '/theaters/{id}':
     get:
       summary: 'Get a single movie theater.'
@@ -129,7 +127,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/error'
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     patch:
       summary: 'Update a movie theater.'
       description: 'Update a movie theaters'' data.'
@@ -198,7 +195,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
     delete:
       summary: 'Delete a movie theater.'
       description: 'Delete a movie theater.'
@@ -228,6 +224,7 @@ paths:
           oauth2:
             - delete
       x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -456,7 +456,7 @@ class OpenApi extends Compiler\Specification
             ),
             'x-mill-path-template' => $path->getPath(),
             'x-mill-vendor-tags' => $this->processVendorTags($action),
-            'x-mill-visibility-private' => $path->isVisible()
+            'x-mill-visibility-private' => !$path->isVisible()
         ];
 
         return $schema;

--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -672,6 +672,12 @@ class OpenApi extends Compiler\Specification
                     continue;
                 } elseif ($property['required']) {
                     $required[] = $name;
+
+                    // If the required property at this level is an array, then it contains nested properties that are
+                    // required for this current property. Don't remove it.
+                    if (is_array($property['required'])) {
+                        continue;
+                    }
                 }
 
                 unset($properties[$name]['required']);


### PR DESCRIPTION
* [ ] Reversing the bit on the `x-mill-visibility-private` extension. https://github.com/vimeo/mill/issues/178
* [ ] No longer removing nested property declarations in data models.
  - This fixes a bug where if `upload.approach` was required, `upload` would be declared as `required`, but not `upload.approach` in the OAS. Now with this, both `upload` and `approach` are noted as being required.