### PR TITLE
Making the TagReducer match prefix matching a little less generous.

### DIFF
--- a/src/Compiler/Specification/OpenApi/TagReducer.php
+++ b/src/Compiler/Specification/OpenApi/TagReducer.php
@@ -45,7 +45,7 @@ class TagReducer
             function (array $spec_tag) use ($tag, $match_prefix_only): bool {
                 $spec_tag = strtolower($spec_tag['name']);
 
-                return $spec_tag === $tag || ($match_prefix_only && strpos($spec_tag, $tag . '\\') !== false);
+                return $spec_tag === $tag || ($match_prefix_only && current(explode('\\', $tag)) === $spec_tag);
             }
         );
 


### PR DESCRIPTION
This fixes a bug in the `TagReducer` where if you passed it a group like `apps` it would match `api apps\core` because it contained `apps\`.