### PR TITLE
Fixing a bug in OAS compilation where arrays with subtypes were compiled as strings

### DIFF
--- a/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
@@ -457,7 +457,7 @@ components:
         cast:
           description: 'Cast. This data requires a bearer token with the `public` scope.'
           items:
-            type: string
+            $ref: '#/components/schemas/person'
           type: array
         content_rating:
           description: 'MPAA rating'
@@ -515,7 +515,7 @@ components:
         theaters:
           description: 'Theaters the movie is currently showing in'
           items:
-            type: string
+            $ref: '#/components/schemas/theater'
           type: array
         uri:
           description: 'Movie URI'
@@ -545,7 +545,7 @@ components:
         movies:
           description: 'Movies currently playing'
           items:
-            type: string
+            $ref: '#/components/schemas/movie'
           type: array
         name:
           description: Name

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
@@ -239,7 +239,7 @@ components:
         cast:
           description: 'Cast. This data requires a bearer token with the `public` scope.'
           items:
-            type: string
+            $ref: '#/components/schemas/person'
           type: array
         content_rating:
           description: 'MPAA rating'
@@ -297,7 +297,7 @@ components:
         theaters:
           description: 'Theaters the movie is currently showing in'
           items:
-            type: string
+            $ref: '#/components/schemas/theater'
           type: array
         uri:
           description: 'Movie URI'
@@ -315,6 +315,36 @@ components:
           type: string
         uri:
           description: 'Person URI'
+          type: string
+    theater:
+      properties:
+        address:
+          description: Address
+          type: string
+        id:
+          description: 'Unique ID'
+          type: number
+        movies:
+          description: 'Movies currently playing'
+          items:
+            $ref: '#/components/schemas/movie'
+          type: array
+        name:
+          description: Name
+          type: string
+        phone_number:
+          description: 'Phone number'
+          type: string
+        showtimes:
+          description: 'Non-movie specific showtimes'
+          items:
+            type: string
+          type: array
+        uri:
+          description: 'Theater URI'
+          type: string
+        website:
+          description: Website
           type: string
 security:
   -

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Theaters.yaml
@@ -263,6 +263,88 @@ components:
         error:
           description: 'User-friendly error message'
           type: string
+    movie:
+      properties:
+        cast:
+          description: 'Cast. This data requires a bearer token with the `public` scope.'
+          items:
+            $ref: '#/components/schemas/person'
+          type: array
+        content_rating:
+          description: 'MPAA rating'
+          enum:
+            - G
+            - NC-17
+            - NR
+            - PG
+            - PG-13
+            - R
+            - UR
+            - X
+          example: G
+          type: string
+        description:
+          description: Description
+          type: string
+        director:
+          allOf:
+            -
+              $ref: '#/components/schemas/person'
+          description: 'Director. This data requires a bearer token with the `public` scope.'
+        genres:
+          description: Genres
+          items:
+            type: string
+          type: array
+        id:
+          description: 'Unique ID'
+          type: number
+        kid_friendly:
+          description: 'Kid friendly?'
+          example: 'false'
+          type: boolean
+        name:
+          description: Name
+          type: string
+        purchase:
+          properties:
+            url:
+              description: 'URL to purchase the film.'
+              type: string
+          type: object
+        rotten_tomatoes_score:
+          description: 'Rotten Tomatoes score'
+          type: number
+        runtime:
+          description: Runtime
+          type: string
+        showtimes:
+          description: 'Non-theater specific showtimes'
+          items:
+            type: string
+          type: array
+        theaters:
+          description: 'Theaters the movie is currently showing in'
+          items:
+            $ref: '#/components/schemas/theater'
+          type: array
+        uri:
+          description: 'Movie URI'
+          type: string
+    person:
+      properties:
+        id:
+          description: 'Unique ID'
+          type: number
+        imdb:
+          description: 'IMDB URL'
+          type: string
+        name:
+          description: Name
+          type: string
+        uri:
+          description: 'Person URI'
+          type: string
     theater:
       properties:
         address:
@@ -274,7 +356,7 @@ components:
         movies:
           description: 'Movies currently playing'
           items:
-            type: string
+            $ref: '#/components/schemas/movie'
           type: array
         name:
           description: Name

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
@@ -617,7 +617,7 @@ components:
         cast:
           description: 'Cast. This data requires a bearer token with the `public` scope.'
           items:
-            type: string
+            $ref: '#/components/schemas/person'
           type: array
         content_rating:
           description: 'MPAA rating'
@@ -692,7 +692,7 @@ components:
         theaters:
           description: 'Theaters the movie is currently showing in'
           items:
-            type: string
+            $ref: '#/components/schemas/theater'
           type: array
         uri:
           description: 'Movie URI'
@@ -722,7 +722,7 @@ components:
         movies:
           description: 'Movies currently playing'
           items:
-            type: string
+            $ref: '#/components/schemas/movie'
           type: array
         name:
           description: Name

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
@@ -399,7 +399,7 @@ components:
         cast:
           description: 'Cast. This data requires a bearer token with the `public` scope.'
           items:
-            type: string
+            $ref: '#/components/schemas/person'
           type: array
         content_rating:
           description: 'MPAA rating'
@@ -474,7 +474,7 @@ components:
         theaters:
           description: 'Theaters the movie is currently showing in'
           items:
-            type: string
+            $ref: '#/components/schemas/theater'
           type: array
         uri:
           description: 'Movie URI'
@@ -492,6 +492,33 @@ components:
           type: string
         uri:
           description: 'Person URI'
+          type: string
+    theater:
+      properties:
+        address:
+          description: Address
+          type: string
+        id:
+          description: 'Unique ID'
+          type: number
+        movies:
+          description: 'Movies currently playing'
+          items:
+            $ref: '#/components/schemas/movie'
+          type: array
+        name:
+          description: Name
+          type: string
+        phone_number:
+          description: 'Phone number'
+          type: string
+        showtimes:
+          description: 'Non-movie specific showtimes'
+          items:
+            type: string
+          type: array
+        uri:
+          description: 'Theater URI'
           type: string
 security:
   -

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Theaters.yaml
@@ -263,6 +263,105 @@ components:
         error:
           description: 'User-friendly error message'
           type: string
+    movie:
+      properties:
+        cast:
+          description: 'Cast. This data requires a bearer token with the `public` scope.'
+          items:
+            $ref: '#/components/schemas/person'
+          type: array
+        content_rating:
+          description: 'MPAA rating'
+          enum:
+            - G
+            - NC-17
+            - NR
+            - PG
+            - PG-13
+            - R
+            - UR
+            - X
+          example: G
+          type: string
+        description:
+          description: Description
+          type: string
+        director:
+          allOf:
+            -
+              $ref: '#/components/schemas/person'
+          description: 'Director. This data requires a bearer token with the `public` scope.'
+        external_urls:
+          description: 'External URLs. This data requires a bearer token with the `public` scope.'
+          items:
+            type: object
+            properties:
+              imdb:
+                description: 'IMDB URL. This data requires a bearer token with the `public` scope.'
+                type: string
+              tickets:
+                description: 'Tickets URL. This data requires a bearer token with the `public` scope.'
+                type: string
+                x-mill-vendor-tags:
+                  - 'tag:BUY_TICKETS'
+              trailer:
+                description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
+                type: string
+          type: array
+        genres:
+          description: Genres
+          items:
+            type: string
+          type: array
+        id:
+          description: 'Unique ID'
+          type: number
+        kid_friendly:
+          description: 'Kid friendly?'
+          example: 'false'
+          type: boolean
+        name:
+          description: Name
+          type: string
+        purchase:
+          properties:
+            url:
+              description: 'URL to purchase the film.'
+              type: string
+          type: object
+        rotten_tomatoes_score:
+          description: 'Rotten Tomatoes score'
+          type: number
+        runtime:
+          description: Runtime
+          type: string
+        showtimes:
+          description: 'Non-theater specific showtimes'
+          items:
+            type: string
+          type: array
+        theaters:
+          description: 'Theaters the movie is currently showing in'
+          items:
+            $ref: '#/components/schemas/theater'
+          type: array
+        uri:
+          description: 'Movie URI'
+          type: string
+    person:
+      properties:
+        id:
+          description: 'Unique ID'
+          type: number
+        imdb:
+          description: 'IMDB URL'
+          type: string
+        name:
+          description: Name
+          type: string
+        uri:
+          description: 'Person URI'
+          type: string
     theater:
       properties:
         address:
@@ -274,7 +373,7 @@ components:
         movies:
           description: 'Movies currently playing'
           items:
-            type: string
+            $ref: '#/components/schemas/movie'
           type: array
         name:
           description: Name

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
@@ -611,7 +611,7 @@ components:
         cast:
           description: 'Cast. This data requires a bearer token with the `public` scope.'
           items:
-            type: string
+            $ref: '#/components/schemas/person'
           type: array
         content_rating:
           description: 'MPAA rating'
@@ -686,7 +686,7 @@ components:
         theaters:
           description: 'Theaters the movie is currently showing in'
           items:
-            type: string
+            $ref: '#/components/schemas/theater'
           type: array
         uri:
           description: 'Movie URI'
@@ -716,7 +716,7 @@ components:
         movies:
           description: 'Movies currently playing'
           items:
-            type: string
+            $ref: '#/components/schemas/movie'
           type: array
         name:
           description: Name

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
@@ -399,7 +399,7 @@ components:
         cast:
           description: 'Cast. This data requires a bearer token with the `public` scope.'
           items:
-            type: string
+            $ref: '#/components/schemas/person'
           type: array
         content_rating:
           description: 'MPAA rating'
@@ -474,7 +474,7 @@ components:
         theaters:
           description: 'Theaters the movie is currently showing in'
           items:
-            type: string
+            $ref: '#/components/schemas/theater'
           type: array
         uri:
           description: 'Movie URI'
@@ -492,6 +492,33 @@ components:
           type: string
         uri:
           description: 'Person URI'
+          type: string
+    theater:
+      properties:
+        address:
+          description: Address
+          type: string
+        id:
+          description: 'Unique ID'
+          type: number
+        movies:
+          description: 'Movies currently playing'
+          items:
+            $ref: '#/components/schemas/movie'
+          type: array
+        name:
+          description: Name
+          type: string
+        phone_number:
+          description: 'Phone number'
+          type: string
+        showtimes:
+          description: 'Non-movie specific showtimes'
+          items:
+            type: string
+          type: array
+        uri:
+          description: 'Theater URI'
           type: string
 security:
   -

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Theaters.yaml
@@ -249,6 +249,105 @@ components:
         error:
           description: 'User-friendly error message'
           type: string
+    movie:
+      properties:
+        cast:
+          description: 'Cast. This data requires a bearer token with the `public` scope.'
+          items:
+            $ref: '#/components/schemas/person'
+          type: array
+        content_rating:
+          description: 'MPAA rating'
+          enum:
+            - G
+            - NC-17
+            - NR
+            - PG
+            - PG-13
+            - R
+            - UR
+            - X
+          example: G
+          type: string
+        description:
+          description: Description
+          type: string
+        director:
+          allOf:
+            -
+              $ref: '#/components/schemas/person'
+          description: 'Director. This data requires a bearer token with the `public` scope.'
+        external_urls:
+          description: 'External URLs. This data requires a bearer token with the `public` scope.'
+          items:
+            type: object
+            properties:
+              imdb:
+                description: 'IMDB URL. This data requires a bearer token with the `public` scope.'
+                type: string
+              tickets:
+                description: 'Tickets URL. This data requires a bearer token with the `public` scope.'
+                type: string
+                x-mill-vendor-tags:
+                  - 'tag:BUY_TICKETS'
+              trailer:
+                description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
+                type: string
+          type: array
+        genres:
+          description: Genres
+          items:
+            type: string
+          type: array
+        id:
+          description: 'Unique ID'
+          type: number
+        kid_friendly:
+          description: 'Kid friendly?'
+          example: 'false'
+          type: boolean
+        name:
+          description: Name
+          type: string
+        purchase:
+          properties:
+            url:
+              description: 'URL to purchase the film.'
+              type: string
+          type: object
+        rotten_tomatoes_score:
+          description: 'Rotten Tomatoes score'
+          type: number
+        runtime:
+          description: Runtime
+          type: string
+        showtimes:
+          description: 'Non-theater specific showtimes'
+          items:
+            type: string
+          type: array
+        theaters:
+          description: 'Theaters the movie is currently showing in'
+          items:
+            $ref: '#/components/schemas/theater'
+          type: array
+        uri:
+          description: 'Movie URI'
+          type: string
+    person:
+      properties:
+        id:
+          description: 'Unique ID'
+          type: number
+        imdb:
+          description: 'IMDB URL'
+          type: string
+        name:
+          description: Name
+          type: string
+        uri:
+          description: 'Person URI'
+          type: string
     theater:
       properties:
         address:
@@ -260,7 +359,7 @@ components:
         movies:
           description: 'Movies currently playing'
           items:
-            type: string
+            $ref: '#/components/schemas/movie'
           type: array
         name:
           description: Name

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
@@ -593,7 +593,7 @@ components:
         cast:
           description: 'Cast. This data requires a bearer token with the `public` scope.'
           items:
-            type: string
+            $ref: '#/components/schemas/person'
           type: array
         content_rating:
           description: 'MPAA rating'
@@ -663,7 +663,7 @@ components:
         theaters:
           description: 'Theaters the movie is currently showing in'
           items:
-            type: string
+            $ref: '#/components/schemas/theater'
           type: array
         uri:
           description: 'Movie URI'
@@ -693,7 +693,7 @@ components:
         movies:
           description: 'Movies currently playing'
           items:
-            type: string
+            $ref: '#/components/schemas/movie'
           type: array
         name:
           description: Name

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
@@ -389,7 +389,7 @@ components:
         cast:
           description: 'Cast. This data requires a bearer token with the `public` scope.'
           items:
-            type: string
+            $ref: '#/components/schemas/person'
           type: array
         content_rating:
           description: 'MPAA rating'
@@ -459,7 +459,7 @@ components:
         theaters:
           description: 'Theaters the movie is currently showing in'
           items:
-            type: string
+            $ref: '#/components/schemas/theater'
           type: array
         uri:
           description: 'Movie URI'
@@ -477,6 +477,33 @@ components:
           type: string
         uri:
           description: 'Person URI'
+          type: string
+    theater:
+      properties:
+        address:
+          description: Address
+          type: string
+        id:
+          description: 'Unique ID'
+          type: number
+        movies:
+          description: 'Movies currently playing'
+          items:
+            $ref: '#/components/schemas/movie'
+          type: array
+        name:
+          description: Name
+          type: string
+        phone_number:
+          description: 'Phone number'
+          type: string
+        showtimes:
+          description: 'Non-movie specific showtimes'
+          items:
+            type: string
+          type: array
+        uri:
+          description: 'Theater URI'
           type: string
 security:
   -

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Theaters.yaml
@@ -249,6 +249,100 @@ components:
         error:
           description: 'User-friendly error message'
           type: string
+    movie:
+      properties:
+        cast:
+          description: 'Cast. This data requires a bearer token with the `public` scope.'
+          items:
+            $ref: '#/components/schemas/person'
+          type: array
+        content_rating:
+          description: 'MPAA rating'
+          enum:
+            - G
+            - NC-17
+            - NR
+            - PG
+            - PG-13
+            - R
+            - UR
+            - X
+          example: G
+          type: string
+        description:
+          description: Description
+          type: string
+        director:
+          allOf:
+            -
+              $ref: '#/components/schemas/person'
+          description: 'Director. This data requires a bearer token with the `public` scope.'
+        external_urls:
+          description: 'External URLs. This data requires a bearer token with the `public` scope.'
+          items:
+            type: object
+            properties:
+              imdb:
+                description: 'IMDB URL. This data requires a bearer token with the `public` scope.'
+                type: string
+              trailer:
+                description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
+                type: string
+          type: array
+        genres:
+          description: Genres
+          items:
+            type: string
+          type: array
+        id:
+          description: 'Unique ID'
+          type: number
+        kid_friendly:
+          description: 'Kid friendly?'
+          example: 'false'
+          type: boolean
+        name:
+          description: Name
+          type: string
+        purchase:
+          properties:
+            url:
+              description: 'URL to purchase the film.'
+              type: string
+          type: object
+        rotten_tomatoes_score:
+          description: 'Rotten Tomatoes score'
+          type: number
+        runtime:
+          description: Runtime
+          type: string
+        showtimes:
+          description: 'Non-theater specific showtimes'
+          items:
+            type: string
+          type: array
+        theaters:
+          description: 'Theaters the movie is currently showing in'
+          items:
+            $ref: '#/components/schemas/theater'
+          type: array
+        uri:
+          description: 'Movie URI'
+          type: string
+    person:
+      properties:
+        id:
+          description: 'Unique ID'
+          type: number
+        imdb:
+          description: 'IMDB URL'
+          type: string
+        name:
+          description: Name
+          type: string
+        uri:
+          description: 'Person URI'
+          type: string
     theater:
       properties:
         address:
@@ -260,7 +354,7 @@ components:
         movies:
           description: 'Movies currently playing'
           items:
-            type: string
+            $ref: '#/components/schemas/movie'
           type: array
         name:
           description: Name

--- a/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
@@ -613,7 +613,7 @@ components:
         cast:
           description: 'Cast. This data requires a bearer token with the `public` scope.'
           items:
-            type: string
+            $ref: '#/components/schemas/person'
           type: array
         content_rating:
           description: 'MPAA rating'
@@ -688,7 +688,7 @@ components:
         theaters:
           description: 'Theaters the movie is currently showing in'
           items:
-            type: string
+            $ref: '#/components/schemas/theater'
           type: array
         uri:
           description: 'Movie URI'
@@ -718,7 +718,7 @@ components:
         movies:
           description: 'Movies currently playing'
           items:
-            type: string
+            $ref: '#/components/schemas/movie'
           type: array
         name:
           description: Name

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
@@ -395,7 +395,7 @@ components:
         cast:
           description: 'Cast. This data requires a bearer token with the `public` scope.'
           items:
-            type: string
+            $ref: '#/components/schemas/person'
           type: array
         content_rating:
           description: 'MPAA rating'
@@ -470,7 +470,7 @@ components:
         theaters:
           description: 'Theaters the movie is currently showing in'
           items:
-            type: string
+            $ref: '#/components/schemas/theater'
           type: array
         uri:
           description: 'Movie URI'
@@ -488,6 +488,33 @@ components:
           type: string
         uri:
           description: 'Person URI'
+          type: string
+    theater:
+      properties:
+        address:
+          description: Address
+          type: string
+        id:
+          description: 'Unique ID'
+          type: number
+        movies:
+          description: 'Movies currently playing'
+          items:
+            $ref: '#/components/schemas/movie'
+          type: array
+        name:
+          description: Name
+          type: string
+        phone_number:
+          description: 'Phone number'
+          type: string
+        showtimes:
+          description: 'Non-movie specific showtimes'
+          items:
+            type: string
+          type: array
+        uri:
+          description: 'Theater URI'
           type: string
 security:
   -

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Theaters.yaml
@@ -263,6 +263,105 @@ components:
         error:
           description: 'User-friendly error message'
           type: string
+    movie:
+      properties:
+        cast:
+          description: 'Cast. This data requires a bearer token with the `public` scope.'
+          items:
+            $ref: '#/components/schemas/person'
+          type: array
+        content_rating:
+          description: 'MPAA rating'
+          enum:
+            - G
+            - NC-17
+            - NR
+            - PG
+            - PG-13
+            - R
+            - UR
+            - X
+          example: G
+          type: string
+        description:
+          description: Description
+          type: string
+        director:
+          allOf:
+            -
+              $ref: '#/components/schemas/person'
+          description: 'Director. This data requires a bearer token with the `public` scope.'
+        external_urls:
+          description: 'External URLs. This data requires a bearer token with the `public` scope.'
+          items:
+            type: object
+            properties:
+              imdb:
+                description: 'IMDB URL. This data requires a bearer token with the `public` scope.'
+                type: string
+              tickets:
+                description: 'Tickets URL. This data requires a bearer token with the `public` scope.'
+                type: string
+                x-mill-vendor-tags:
+                  - 'tag:BUY_TICKETS'
+              trailer:
+                description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
+                type: string
+          type: array
+        genres:
+          description: Genres
+          items:
+            type: string
+          type: array
+        id:
+          description: 'Unique ID'
+          type: number
+        kid_friendly:
+          description: 'Kid friendly?'
+          example: 'false'
+          type: boolean
+        name:
+          description: Name
+          type: string
+        purchase:
+          properties:
+            url:
+              description: 'URL to purchase the film.'
+              type: string
+          type: object
+        rotten_tomatoes_score:
+          description: 'Rotten Tomatoes score'
+          type: number
+        runtime:
+          description: Runtime
+          type: string
+        showtimes:
+          description: 'Non-theater specific showtimes'
+          items:
+            type: string
+          type: array
+        theaters:
+          description: 'Theaters the movie is currently showing in'
+          items:
+            $ref: '#/components/schemas/theater'
+          type: array
+        uri:
+          description: 'Movie URI'
+          type: string
+    person:
+      properties:
+        id:
+          description: 'Unique ID'
+          type: number
+        imdb:
+          description: 'IMDB URL'
+          type: string
+        name:
+          description: Name
+          type: string
+        uri:
+          description: 'Person URI'
+          type: string
     theater:
       properties:
         address:
@@ -274,7 +373,7 @@ components:
         movies:
           description: 'Movies currently playing'
           items:
-            type: string
+            $ref: '#/components/schemas/movie'
           type: array
         name:
           description: Name

--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -615,9 +615,23 @@ class OpenApi extends Compiler\Specification
                     $spec['items'] = $this->processDataModel($payload_format, $field);
                 }
             } elseif ($data['type'] === 'array') {
-                $spec['items'] = [
-                    'type' => 'string'
-                ];
+                // @todo Array subtypes are not yet required. https://github.com/vimeo/mill/issues/190
+                if (!empty($data['subtype'])) {
+                    $representation = $this->getRepresentation($data['subtype']);
+                    if ($representation) {
+                        $ref = '#/components/schemas/' . $this->getReferenceName($representation->getLabel());
+
+                        $spec['items']['$ref'] = $ref;
+                    } else {
+                        $spec['items'] = [
+                            'type' => 'string'
+                        ];
+                    }
+                } else {
+                    $spec['items'] = [
+                        'type' => 'string'
+                    ];
+                }
             }
 
             // Request body requirement definitions need to be separate from the item schema.

--- a/src/Compiler/Specification/OpenApi/TagReducer.php
+++ b/src/Compiler/Specification/OpenApi/TagReducer.php
@@ -97,9 +97,7 @@ class TagReducer
         $refs = [];
         foreach ($path_refs as $ref) {
             $refs[] = $ref;
-            if (!empty($linked_refs[$ref])) {
-                $refs = array_merge($refs, $linked_refs[$ref]);
-            }
+            $refs = $this->getLinkedRefs($ref, $linked_refs, $refs);
         }
 
         $refs = array_unique($refs);
@@ -112,6 +110,26 @@ class TagReducer
         }
 
         return $specification;
+    }
+
+    /**
+     * @param string $ref
+     * @param array $refs
+     * @param array $linked
+     * @return array
+     */
+    private function getLinkedRefs(string $ref, array $refs, array &$linked = []): array
+    {
+        foreach ($refs[$ref] as $linked_ref) {
+            if (in_array($linked_ref, $linked)) {
+                continue;
+            }
+
+            $linked[] = $linked_ref;
+            $linked = $this->getLinkedRefs($linked_ref, $refs, $linked);
+        }
+
+        return $linked;
     }
 
     /**


### PR DESCRIPTION
This fixes a funky bug in OAS compilation where if you defined an array in a representation as anything other than `array<string>`, like say, `array<Movie>`, it would always get compiled as an `array` with `items.type` as `string` instead of a `$ref` to the `Movie` component.