### PR TITLE
Retiring the need for resources to have `@api-label` annotations.

### DIFF
--- a/docs/reference-api-data.md
+++ b/docs/reference-api-data.md
@@ -99,7 +99,7 @@ $representation = [
                 'options' => ['GET'],
 
                 /**
-                 * @api-label total (number) - Total number of items on
+                 * @api-data total (number) - Total number of items on
                  *     this connection.
                  */
                 'total' => $user->getAlbums()->total

--- a/docs/reference-api-label.md
+++ b/docs/reference-api-label.md
@@ -3,7 +3,7 @@ id: api-label
 title: @api-label
 ---
 
-A short description of what the resource, or resource action handles.
+A short description of what a representation, or resource action action, handles.
 
 ## Syntax
 ```php
@@ -21,13 +21,15 @@ A short description of what the resource, or resource action handles.
 | description | × | Description of what resource, or resource action handles. |
 
 ## Examples
-On a resource:
+On a representation:
 
 ```php
 /**
- * @api-label Videos
+ * Data representation for a specific movie.
+ *
+ * @api-label Movie
  */
-class Controller
+class Movie extends Representation
 {
     ...
 }

--- a/docs/reference-resources.md
+++ b/docs/reference-resources.md
@@ -5,4 +5,3 @@ title: "Resources"
 
 | @annotation | Description |
 | :--- | :--- |
-| [`@api-label`](reference-api-label.md) | Short description of what the resource handles. |

--- a/docs/writing-documentation.md
+++ b/docs/writing-documentation.md
@@ -6,47 +6,7 @@ title: Documenting your API
 ## Resources
 Resources are a collection of actions (endpoints). These can generally be referred to as a "controller" in a standard MVC application structure.
 
-Documenting a resource is easy:
-
-```php
-<?php
-namespace MyApplication;
-
-/**
- * @api-label Search
- */
-class UsersController extends \MyApplication\Controller
-{
-    ...
-}
-
-```
-
-Here, you can see that we're using the [`@api-label`](reference-api-label.md) annotation to denote that this controller primarily handles "Search" actions.
-
-If you'd also like to include a full Markdown representation (or anything else, really) description along with this resource for your compiled documentation, you can do so by adding that content into the docblock:
-
-```php
-<?php
-namespace MyApplication;
-
-/**
- * Ham tri-tip labore tongue esse pastrami ipsum shank ullamco boudin pig
- * sausage. Sunt landjaeger id, venison incididunt ex pork belly ut eu.
- * Chuck frankfurter tenderloin sed ipsum turducken. Alcatra esse rump,
- * culpa laboris sausage ut dolor filet mignon frankfurter meatloaf strip
- * steak excepteur. Lorem tempor kevin eiusmod doner dolore ipsum ribeye
- * boudin dolore duis culpa non anim est. Capicola ea velit salami.
- * Leberkas capicola beef excepteur, aliquip brisket occaecat drumstick
- * elit short loin.
- *
- * @api-label Search
- */
-class UsersController extends \MyApplication\Controller
-{
-    ...
-}
-```
+As long as a resource contains resource actions, there is nothing you need to do to document a resource. Resource action documentation will handle everything automatically.
 
 ## Resource Actions
 A resource action (endpoint) is something that you can execute from your API.
@@ -56,9 +16,6 @@ Mill is currently a bit opinionated in how it expects the names of your action m
 Documenting a resource action is easy, however:
 
 ```php
-/**
- * @api-label Search
- */
 class UsersController extends \MyApplication\Controller
 {
     /**

--- a/resources/examples/Showtimes/Controllers/Movie.php
+++ b/resources/examples/Showtimes/Controllers/Movie.php
@@ -1,13 +1,6 @@
 <?php
 namespace Mill\Examples\Showtimes\Controllers;
 
-/**
- * Information on a specific movie.
- *
- * These actions will allow you to pull information on a specific movie.
- *
- * @api-label Movies
- */
 class Movie
 {
     /**

--- a/resources/examples/Showtimes/Controllers/Movies.php
+++ b/resources/examples/Showtimes/Controllers/Movies.php
@@ -1,9 +1,6 @@
 <?php
 namespace Mill\Examples\Showtimes\Controllers;
 
-/**
- * @api-label Movies
- */
 class Movies
 {
     /**

--- a/resources/examples/Showtimes/Controllers/Theater.php
+++ b/resources/examples/Showtimes/Controllers/Theater.php
@@ -1,13 +1,6 @@
 <?php
 namespace Mill\Examples\Showtimes\Controllers;
 
-/**
- * Information on a specific movie theater.
- *
- * These actions will allow you to pull information on a specific movie theater.
- *
- * @api-label Movie Theaters
- */
 class Theater
 {
     /**

--- a/resources/examples/Showtimes/Controllers/Theaters.php
+++ b/resources/examples/Showtimes/Controllers/Theaters.php
@@ -1,9 +1,6 @@
 <?php
 namespace Mill\Examples\Showtimes\Controllers;
 
-/**
- * @api-label Movie Theaters
- */
 class Theaters
 {
     /**

--- a/resources/examples/Showtimes/compiled/1.0/apiblueprint/api.apib
+++ b/resources/examples/Showtimes/compiled/1.0/apiblueprint/api.apib
@@ -5,9 +5,6 @@ This is the API Blueprint file for Mill unit test API, Showtimes.
 
 # Group Movies
 ## Movies [/movie/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -32,9 +29,6 @@ sem malesuada magna mollis euismod.
     + Attributes (Error)
 
 ## Movies [/movies/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -59,9 +53,6 @@ sem malesuada magna mollis euismod.
     + Attributes (Error)
 
 ## Movies [/movies]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get movies. [GET]
 Returns all movies for a specific location.
@@ -111,10 +102,18 @@ This action requires a bearer token with the `create` scope.
     + Attributes (Error)
 
 # Group Theaters
-## Movie Theaters [/theaters/{id}]
-Information on a specific movie theater.
+## Theaters [/theaters/{id}]
 
-These actions will allow you to pull information on a specific movie theater.
+### Delete a movie theater. [DELETE]
+Delete a movie theater.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie theater. [GET]
 Return information on a specific movie theater.
@@ -148,21 +147,7 @@ This action requires a bearer token with the `create` scope.
 + Response 404 (application/json)
     + Attributes (Error)
 
-### Delete a movie theater. [DELETE]
-Delete a movie theater.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Theater ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
-## Movie Theaters [/theaters]
-Information on a specific movie theater.
-
-These actions will allow you to pull information on a specific movie theater.
+## Theaters [/theaters]
 
 ### Get movie theaters. [GET]
 Returns all movie theatres for a specific location.

--- a/resources/examples/Showtimes/compiled/1.0/apiblueprint/resources/Movies.apib
+++ b/resources/examples/Showtimes/compiled/1.0/apiblueprint/resources/Movies.apib
@@ -1,8 +1,5 @@
 # Group Movies
 ## Movies [/movie/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -27,9 +24,6 @@ sem malesuada magna mollis euismod.
     + Attributes (Error)
 
 ## Movies [/movies/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -54,9 +48,6 @@ sem malesuada magna mollis euismod.
     + Attributes (Error)
 
 ## Movies [/movies]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get movies. [GET]
 Returns all movies for a specific location.

--- a/resources/examples/Showtimes/compiled/1.0/apiblueprint/resources/Theaters.apib
+++ b/resources/examples/Showtimes/compiled/1.0/apiblueprint/resources/Theaters.apib
@@ -1,8 +1,16 @@
 # Group Theaters
-## Movie Theaters [/theaters/{id}]
-Information on a specific movie theater.
+## Theaters [/theaters/{id}]
 
-These actions will allow you to pull information on a specific movie theater.
+### Delete a movie theater. [DELETE]
+Delete a movie theater.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie theater. [GET]
 Return information on a specific movie theater.
@@ -36,21 +44,7 @@ This action requires a bearer token with the `create` scope.
 + Response 404 (application/json)
     + Attributes (Error)
 
-### Delete a movie theater. [DELETE]
-Delete a movie theater.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Theater ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
-## Movie Theaters [/theaters]
-Information on a specific movie theater.
-
-These actions will allow you to pull information on a specific movie theater.
+## Theaters [/theaters]
 
 ### Get movie theaters. [GET]
 Returns all movie theatres for a specific location.

--- a/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
@@ -285,6 +285,36 @@ paths:
             - create
       x-mill-path-template: /theaters
   '/theaters/{id}':
+    delete:
+      summary: 'Delete a movie theater.'
+      description: 'Delete a movie theater.'
+      operationId: deleteTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
@@ -384,36 +414,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-    delete:
-      summary: 'Delete a movie theater.'
-      description: 'Delete a movie theater.'
-      operationId: deleteTheater
-      tags:
-        - Theaters
-      parameters:
-        -
-          description: 'Theater ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie theater could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Theaters.yaml
@@ -96,6 +96,36 @@ paths:
             - create
       x-mill-path-template: /theaters
   '/theaters/{id}':
+    delete:
+      summary: 'Delete a movie theater.'
+      description: 'Delete a movie theater.'
+      operationId: deleteTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
@@ -195,36 +225,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-    delete:
-      summary: 'Delete a movie theater.'
-      description: 'Delete a movie theater.'
-      operationId: deleteTheater
-      tags:
-        - Theaters
-      parameters:
-        -
-          description: 'Theater ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie theater could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/api.apib
+++ b/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/api.apib
@@ -5,9 +5,6 @@ This is the API Blueprint file for Mill unit test API, Showtimes.
 
 # Group Movies
 ## Movies [/movie/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -32,9 +29,17 @@ sem malesuada magna mollis euismod.
     + Attributes (Error)
 
 ## Movies [/movies/{id}]
-Information on a specific movie.
 
-These actions will allow you to pull information on a specific movie.
+### Delete a movie. [DELETE]
+Delete a movie.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -100,21 +105,7 @@ This action requires a bearer token with the `edit` scope.
 + Response 404 (application/json)
     + Attributes (Error)
 
-### Delete a movie. [DELETE]
-Delete a movie.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Movie ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
 ## Movies [/movies]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get movies. [GET]
 Returns all movies for a specific location.
@@ -167,10 +158,18 @@ This action requires a bearer token with the `create` scope.
     + Attributes (Error)
 
 # Group Theaters
-## Movie Theaters [/theaters/{id}]
-Information on a specific movie theater.
+## Theaters [/theaters/{id}]
 
-These actions will allow you to pull information on a specific movie theater.
+### Delete a movie theater. [DELETE]
+Delete a movie theater.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie theater. [GET]
 Return information on a specific movie theater.
@@ -204,21 +203,7 @@ This action requires a bearer token with the `create` scope.
 + Response 404 (application/json)
     + Attributes (Error)
 
-### Delete a movie theater. [DELETE]
-Delete a movie theater.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Theater ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
-## Movie Theaters [/theaters]
-Information on a specific movie theater.
-
-These actions will allow you to pull information on a specific movie theater.
+## Theaters [/theaters]
 
 ### Get movie theaters. [GET]
 Returns all movie theatres for a specific location.

--- a/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/resources/Movies.apib
+++ b/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/resources/Movies.apib
@@ -1,8 +1,5 @@
 # Group Movies
 ## Movies [/movie/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -27,9 +24,17 @@ sem malesuada magna mollis euismod.
     + Attributes (Error)
 
 ## Movies [/movies/{id}]
-Information on a specific movie.
 
-These actions will allow you to pull information on a specific movie.
+### Delete a movie. [DELETE]
+Delete a movie.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -95,21 +100,7 @@ This action requires a bearer token with the `edit` scope.
 + Response 404 (application/json)
     + Attributes (Error)
 
-### Delete a movie. [DELETE]
-Delete a movie.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Movie ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
 ## Movies [/movies]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get movies. [GET]
 Returns all movies for a specific location.

--- a/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/resources/Theaters.apib
+++ b/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/resources/Theaters.apib
@@ -1,8 +1,16 @@
 # Group Theaters
-## Movie Theaters [/theaters/{id}]
-Information on a specific movie theater.
+## Theaters [/theaters/{id}]
 
-These actions will allow you to pull information on a specific movie theater.
+### Delete a movie theater. [DELETE]
+Delete a movie theater.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie theater. [GET]
 Return information on a specific movie theater.
@@ -36,21 +44,7 @@ This action requires a bearer token with the `create` scope.
 + Response 404 (application/json)
     + Attributes (Error)
 
-### Delete a movie theater. [DELETE]
-Delete a movie theater.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Theater ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
-## Movie Theaters [/theaters]
-Information on a specific movie theater.
-
-These actions will allow you to pull information on a specific movie theater.
+## Theaters [/theaters]
 
 ### Get movie theaters. [GET]
 Returns all movie theatres for a specific location.

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
@@ -189,6 +189,38 @@ paths:
             - create
       x-mill-path-template: /movies
   '/movies/{id}':
+    delete:
+      summary: 'Delete a movie.'
+      description: 'Delete a movie.'
+      operationId: deleteMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /movies/+id
+      x-mill-vendor-tags:
+        - 'tag:DELETE_CONTENT'
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
@@ -334,38 +366,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-    delete:
-      summary: 'Delete a movie.'
-      description: 'Delete a movie.'
-      operationId: deleteMovie
-      tags:
-        - Movies
-      parameters:
-        -
-          description: 'Movie ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /movies/+id
-      x-mill-vendor-tags:
-        - 'tag:DELETE_CONTENT'
-      x-mill-visibility-private: true
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -445,6 +445,36 @@ paths:
             - create
       x-mill-path-template: /theaters
   '/theaters/{id}':
+    delete:
+      summary: 'Delete a movie theater.'
+      description: 'Delete a movie theater.'
+      operationId: deleteTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
@@ -544,36 +574,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-    delete:
-      summary: 'Delete a movie theater.'
-      description: 'Delete a movie theater.'
-      operationId: deleteTheater
-      tags:
-        - Theaters
-      parameters:
-        -
-          description: 'Theater ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie theater could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
@@ -187,6 +187,38 @@ paths:
             - create
       x-mill-path-template: /movies
   '/movies/{id}':
+    delete:
+      summary: 'Delete a movie.'
+      description: 'Delete a movie.'
+      operationId: deleteMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /movies/+id
+      x-mill-vendor-tags:
+        - 'tag:DELETE_CONTENT'
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
@@ -332,38 +364,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-    delete:
-      summary: 'Delete a movie.'
-      description: 'Delete a movie.'
-      operationId: deleteMovie
-      tags:
-        - Movies
-      parameters:
-        -
-          description: 'Movie ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /movies/+id
-      x-mill-vendor-tags:
-        - 'tag:DELETE_CONTENT'
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Theaters.yaml
@@ -96,6 +96,36 @@ paths:
             - create
       x-mill-path-template: /theaters
   '/theaters/{id}':
+    delete:
+      summary: 'Delete a movie theater.'
+      description: 'Delete a movie theater.'
+      operationId: deleteTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
@@ -195,36 +225,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-    delete:
-      summary: 'Delete a movie theater.'
-      description: 'Delete a movie theater.'
-      operationId: deleteTheater
-      tags:
-        - Theaters
-      parameters:
-        -
-          description: 'Theater ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie theater could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.2/apiblueprint/api.apib
+++ b/resources/examples/Showtimes/compiled/1.1.2/apiblueprint/api.apib
@@ -5,9 +5,6 @@ This is the API Blueprint file for Mill unit test API, Showtimes.
 
 # Group Movies
 ## Movies [/movie/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -32,9 +29,17 @@ sem malesuada magna mollis euismod.
     + Attributes (Error)
 
 ## Movies [/movies/{id}]
-Information on a specific movie.
 
-These actions will allow you to pull information on a specific movie.
+### Delete a movie. [DELETE]
+Delete a movie.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -100,21 +105,7 @@ This action requires a bearer token with the `edit` scope.
 + Response 404 (application/mill.example.movie+json)
     + Attributes (Error)
 
-### Delete a movie. [DELETE]
-Delete a movie.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Movie ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
 ## Movies [/movies]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get movies. [GET]
 Returns all movies for a specific location.
@@ -167,10 +158,18 @@ This action requires a bearer token with the `create` scope.
     + Attributes (Error)
 
 # Group Theaters
-## Movie Theaters [/theaters/{id}]
-Information on a specific movie theater.
+## Theaters [/theaters/{id}]
 
-These actions will allow you to pull information on a specific movie theater.
+### Delete a movie theater. [DELETE]
+Delete a movie theater.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie theater. [GET]
 Return information on a specific movie theater.
@@ -202,21 +201,7 @@ This action requires a bearer token with the `create` scope.
 + Response 404 (application/mill.example.theater+json)
     + Attributes (Error)
 
-### Delete a movie theater. [DELETE]
-Delete a movie theater.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Theater ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
-## Movie Theaters [/theaters]
-Information on a specific movie theater.
-
-These actions will allow you to pull information on a specific movie theater.
+## Theaters [/theaters]
 
 ### Get movie theaters. [GET]
 Returns all movie theatres for a specific location.

--- a/resources/examples/Showtimes/compiled/1.1.2/apiblueprint/resources/Movies.apib
+++ b/resources/examples/Showtimes/compiled/1.1.2/apiblueprint/resources/Movies.apib
@@ -1,8 +1,5 @@
 # Group Movies
 ## Movies [/movie/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -27,9 +24,17 @@ sem malesuada magna mollis euismod.
     + Attributes (Error)
 
 ## Movies [/movies/{id}]
-Information on a specific movie.
 
-These actions will allow you to pull information on a specific movie.
+### Delete a movie. [DELETE]
+Delete a movie.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -95,21 +100,7 @@ This action requires a bearer token with the `edit` scope.
 + Response 404 (application/mill.example.movie+json)
     + Attributes (Error)
 
-### Delete a movie. [DELETE]
-Delete a movie.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Movie ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
 ## Movies [/movies]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get movies. [GET]
 Returns all movies for a specific location.

--- a/resources/examples/Showtimes/compiled/1.1.2/apiblueprint/resources/Theaters.apib
+++ b/resources/examples/Showtimes/compiled/1.1.2/apiblueprint/resources/Theaters.apib
@@ -1,8 +1,16 @@
 # Group Theaters
-## Movie Theaters [/theaters/{id}]
-Information on a specific movie theater.
+## Theaters [/theaters/{id}]
 
-These actions will allow you to pull information on a specific movie theater.
+### Delete a movie theater. [DELETE]
+Delete a movie theater.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie theater. [GET]
 Return information on a specific movie theater.
@@ -34,21 +42,7 @@ This action requires a bearer token with the `create` scope.
 + Response 404 (application/mill.example.theater+json)
     + Attributes (Error)
 
-### Delete a movie theater. [DELETE]
-Delete a movie theater.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Theater ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
-## Movie Theaters [/theaters]
-Information on a specific movie theater.
-
-These actions will allow you to pull information on a specific movie theater.
+## Theaters [/theaters]
 
 ### Get movie theaters. [GET]
 Returns all movie theatres for a specific location.

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
@@ -189,6 +189,38 @@ paths:
             - create
       x-mill-path-template: /movies
   '/movies/{id}':
+    delete:
+      summary: 'Delete a movie.'
+      description: 'Delete a movie.'
+      operationId: deleteMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /movies/+id
+      x-mill-vendor-tags:
+        - 'tag:DELETE_CONTENT'
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
@@ -334,38 +366,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-    delete:
-      summary: 'Delete a movie.'
-      description: 'Delete a movie.'
-      operationId: deleteMovie
-      tags:
-        - Movies
-      parameters:
-        -
-          description: 'Movie ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /movies/+id
-      x-mill-vendor-tags:
-        - 'tag:DELETE_CONTENT'
-      x-mill-visibility-private: true
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -445,6 +445,36 @@ paths:
             - create
       x-mill-path-template: /theaters
   '/theaters/{id}':
+    delete:
+      summary: 'Delete a movie theater.'
+      description: 'Delete a movie theater.'
+      operationId: deleteTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
@@ -538,36 +568,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-    delete:
-      summary: 'Delete a movie theater.'
-      description: 'Delete a movie theater.'
-      operationId: deleteTheater
-      tags:
-        - Theaters
-      parameters:
-        -
-          description: 'Theater ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie theater could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
@@ -187,6 +187,38 @@ paths:
             - create
       x-mill-path-template: /movies
   '/movies/{id}':
+    delete:
+      summary: 'Delete a movie.'
+      description: 'Delete a movie.'
+      operationId: deleteMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /movies/+id
+      x-mill-vendor-tags:
+        - 'tag:DELETE_CONTENT'
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
@@ -332,38 +364,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-    delete:
-      summary: 'Delete a movie.'
-      description: 'Delete a movie.'
-      operationId: deleteMovie
-      tags:
-        - Movies
-      parameters:
-        -
-          description: 'Movie ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /movies/+id
-      x-mill-vendor-tags:
-        - 'tag:DELETE_CONTENT'
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Theaters.yaml
@@ -96,6 +96,36 @@ paths:
             - create
       x-mill-path-template: /theaters
   '/theaters/{id}':
+    delete:
+      summary: 'Delete a movie theater.'
+      description: 'Delete a movie theater.'
+      operationId: deleteTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
@@ -189,36 +219,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-    delete:
-      summary: 'Delete a movie theater.'
-      description: 'Delete a movie theater.'
-      operationId: deleteTheater
-      tags:
-        - Theaters
-      parameters:
-        -
-          description: 'Theater ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie theater could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/api.apib
+++ b/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/api.apib
@@ -5,9 +5,6 @@ This is the API Blueprint file for Mill unit test API, Showtimes.
 
 # Group Movies
 ## Movies [/movie/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -36,9 +33,6 @@ sem malesuada magna mollis euismod.
     + Attributes (Error)
 
 ## Movies [/movies/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -119,9 +113,6 @@ This action requires a bearer token with the `edit` scope.
     + Attributes (Error)
 
 ## Movies [/movies]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get movies. [GET]
 Returns all movies for a specific location.
@@ -175,10 +166,18 @@ This action requires a bearer token with the `create` scope.
     + Attributes (Error)
 
 # Group Theaters
-## Movie Theaters [/theaters/{id}]
-Information on a specific movie theater.
+## Theaters [/theaters/{id}]
 
-These actions will allow you to pull information on a specific movie theater.
+### Delete a movie theater. [DELETE]
+Delete a movie theater.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie theater. [GET]
 Return information on a specific movie theater.
@@ -210,21 +209,7 @@ This action requires a bearer token with the `create` scope.
 + Response 404 (application/mill.example.theater+json)
     + Attributes (Error)
 
-### Delete a movie theater. [DELETE]
-Delete a movie theater.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Theater ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
-## Movie Theaters [/theaters]
-Information on a specific movie theater.
-
-These actions will allow you to pull information on a specific movie theater.
+## Theaters [/theaters]
 
 ### Get movie theaters. [GET]
 Returns all movie theatres for a specific location.

--- a/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/resources/Movies.apib
+++ b/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/resources/Movies.apib
@@ -1,8 +1,5 @@
 # Group Movies
 ## Movies [/movie/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -31,9 +28,6 @@ sem malesuada magna mollis euismod.
     + Attributes (Error)
 
 ## Movies [/movies/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -114,9 +108,6 @@ This action requires a bearer token with the `edit` scope.
     + Attributes (Error)
 
 ## Movies [/movies]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get movies. [GET]
 Returns all movies for a specific location.

--- a/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/resources/Theaters.apib
+++ b/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/resources/Theaters.apib
@@ -1,8 +1,16 @@
 # Group Theaters
-## Movie Theaters [/theaters/{id}]
-Information on a specific movie theater.
+## Theaters [/theaters/{id}]
 
-These actions will allow you to pull information on a specific movie theater.
+### Delete a movie theater. [DELETE]
+Delete a movie theater.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie theater. [GET]
 Return information on a specific movie theater.
@@ -34,21 +42,7 @@ This action requires a bearer token with the `create` scope.
 + Response 404 (application/mill.example.theater+json)
     + Attributes (Error)
 
-### Delete a movie theater. [DELETE]
-Delete a movie theater.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Theater ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
-## Movie Theaters [/theaters]
-Information on a specific movie theater.
-
-These actions will allow you to pull information on a specific movie theater.
+## Theaters [/theaters]
 
 ### Get movie theaters. [GET]
 Returns all movie theatres for a specific location.

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
@@ -427,6 +427,36 @@ paths:
             - create
       x-mill-path-template: /theaters
   '/theaters/{id}':
+    delete:
+      summary: 'Delete a movie theater.'
+      description: 'Delete a movie theater.'
+      operationId: deleteTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
@@ -520,36 +550,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-    delete:
-      summary: 'Delete a movie theater.'
-      description: 'Delete a movie theater.'
-      operationId: deleteTheater
-      tags:
-        - Theaters
-      parameters:
-        -
-          description: 'Theater ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie theater could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Theaters.yaml
@@ -96,6 +96,36 @@ paths:
             - create
       x-mill-path-template: /theaters
   '/theaters/{id}':
+    delete:
+      summary: 'Delete a movie theater.'
+      description: 'Delete a movie theater.'
+      operationId: deleteTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
@@ -189,36 +219,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-    delete:
-      summary: 'Delete a movie theater.'
-      description: 'Delete a movie theater.'
-      operationId: deleteTheater
-      tags:
-        - Theaters
-      parameters:
-        -
-          description: 'Theater ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie theater could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1/apiblueprint/api.apib
+++ b/resources/examples/Showtimes/compiled/1.1/apiblueprint/api.apib
@@ -5,9 +5,6 @@ This is the API Blueprint file for Mill unit test API, Showtimes.
 
 # Group Movies
 ## Movies [/movie/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -32,9 +29,17 @@ sem malesuada magna mollis euismod.
     + Attributes (Error)
 
 ## Movies [/movies/{id}]
-Information on a specific movie.
 
-These actions will allow you to pull information on a specific movie.
+### Delete a movie. [DELETE]
+Delete a movie.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -99,21 +104,7 @@ This action requires a bearer token with the `edit` scope.
 + Response 404 (application/json)
     + Attributes (Error)
 
-### Delete a movie. [DELETE]
-Delete a movie.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Movie ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
 ## Movies [/movies]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get movies. [GET]
 Returns all movies for a specific location.
@@ -166,10 +157,18 @@ This action requires a bearer token with the `create` scope.
     + Attributes (Error)
 
 # Group Theaters
-## Movie Theaters [/theaters/{id}]
-Information on a specific movie theater.
+## Theaters [/theaters/{id}]
 
-These actions will allow you to pull information on a specific movie theater.
+### Delete a movie theater. [DELETE]
+Delete a movie theater.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie theater. [GET]
 Return information on a specific movie theater.
@@ -203,21 +202,7 @@ This action requires a bearer token with the `create` scope.
 + Response 404 (application/json)
     + Attributes (Error)
 
-### Delete a movie theater. [DELETE]
-Delete a movie theater.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Theater ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
-## Movie Theaters [/theaters]
-Information on a specific movie theater.
-
-These actions will allow you to pull information on a specific movie theater.
+## Theaters [/theaters]
 
 ### Get movie theaters. [GET]
 Returns all movie theatres for a specific location.

--- a/resources/examples/Showtimes/compiled/1.1/apiblueprint/resources/Movies.apib
+++ b/resources/examples/Showtimes/compiled/1.1/apiblueprint/resources/Movies.apib
@@ -1,8 +1,5 @@
 # Group Movies
 ## Movies [/movie/{id}]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -27,9 +24,17 @@ sem malesuada magna mollis euismod.
     + Attributes (Error)
 
 ## Movies [/movies/{id}]
-Information on a specific movie.
 
-These actions will allow you to pull information on a specific movie.
+### Delete a movie. [DELETE]
+Delete a movie.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie. [GET]
 Return information on a specific movie.
@@ -94,21 +99,7 @@ This action requires a bearer token with the `edit` scope.
 + Response 404 (application/json)
     + Attributes (Error)
 
-### Delete a movie. [DELETE]
-Delete a movie.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Movie ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
 ## Movies [/movies]
-Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.
 
 ### Get movies. [GET]
 Returns all movies for a specific location.

--- a/resources/examples/Showtimes/compiled/1.1/apiblueprint/resources/Theaters.apib
+++ b/resources/examples/Showtimes/compiled/1.1/apiblueprint/resources/Theaters.apib
@@ -1,8 +1,16 @@
 # Group Theaters
-## Movie Theaters [/theaters/{id}]
-Information on a specific movie theater.
+## Theaters [/theaters/{id}]
 
-These actions will allow you to pull information on a specific movie theater.
+### Delete a movie theater. [DELETE]
+Delete a movie theater.
+
+This action requires a bearer token with the `delete` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 204 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
 
 ### Get a single movie theater. [GET]
 Return information on a specific movie theater.
@@ -36,21 +44,7 @@ This action requires a bearer token with the `create` scope.
 + Response 404 (application/json)
     + Attributes (Error)
 
-### Delete a movie theater. [DELETE]
-Delete a movie theater.
-
-This action requires a bearer token with the `delete` scope.
-
-+ Parameters
-    - `id` (number, required) - Theater ID
-+ Response 204 (application/json)
-+ Response 404 (application/json)
-    + Attributes (Error)
-
-## Movie Theaters [/theaters]
-Information on a specific movie theater.
-
-These actions will allow you to pull information on a specific movie theater.
+## Theaters [/theaters]
 
 ### Get movie theaters. [GET]
 Returns all movie theatres for a specific location.

--- a/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
@@ -189,6 +189,38 @@ paths:
             - create
       x-mill-path-template: /movies
   '/movies/{id}':
+    delete:
+      summary: 'Delete a movie.'
+      description: 'Delete a movie.'
+      operationId: deleteMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /movies/+id
+      x-mill-vendor-tags:
+        - 'tag:DELETE_CONTENT'
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
@@ -330,38 +362,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-    delete:
-      summary: 'Delete a movie.'
-      description: 'Delete a movie.'
-      operationId: deleteMovie
-      tags:
-        - Movies
-      parameters:
-        -
-          description: 'Movie ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /movies/+id
-      x-mill-vendor-tags:
-        - 'tag:DELETE_CONTENT'
-      x-mill-visibility-private: true
   /theaters:
     get:
       summary: 'Get movie theaters.'
@@ -441,6 +441,36 @@ paths:
             - create
       x-mill-path-template: /theaters
   '/theaters/{id}':
+    delete:
+      summary: 'Delete a movie theater.'
+      description: 'Delete a movie theater.'
+      operationId: deleteTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
@@ -540,36 +570,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-    delete:
-      summary: 'Delete a movie theater.'
-      description: 'Delete a movie theater.'
-      operationId: deleteTheater
-      tags:
-        - Theaters
-      parameters:
-        -
-          description: 'Theater ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie theater could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
@@ -187,6 +187,38 @@ paths:
             - create
       x-mill-path-template: /movies
   '/movies/{id}':
+    delete:
+      summary: 'Delete a movie.'
+      description: 'Delete a movie.'
+      operationId: deleteMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /movies/+id
+      x-mill-vendor-tags:
+        - 'tag:DELETE_CONTENT'
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie.'
       description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
@@ -328,38 +360,6 @@ paths:
           oauth2:
             - edit
       x-mill-path-template: /movies/+id
-    delete:
-      summary: 'Delete a movie.'
-      description: 'Delete a movie.'
-      operationId: deleteMovie
-      tags:
-        - Movies
-      parameters:
-        -
-          description: 'Movie ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /movies/+id
-      x-mill-vendor-tags:
-        - 'tag:DELETE_CONTENT'
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Theaters.yaml
@@ -96,6 +96,36 @@ paths:
             - create
       x-mill-path-template: /theaters
   '/theaters/{id}':
+    delete:
+      summary: 'Delete a movie theater.'
+      description: 'Delete a movie theater.'
+      operationId: deleteTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        204:
+          description: 'Standard request.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - delete
+      x-mill-path-template: /theaters/+id
+      x-mill-visibility-private: true
     get:
       summary: 'Get a single movie theater.'
       description: 'Return information on a specific movie theater.'
@@ -195,36 +225,6 @@ paths:
           oauth2:
             - create
       x-mill-path-template: /theaters/+id
-    delete:
-      summary: 'Delete a movie theater.'
-      description: 'Delete a movie theater.'
-      operationId: deleteTheater
-      tags:
-        - Theaters
-      parameters:
-        -
-          description: 'Theater ID'
-          in: path
-          name: id
-          required: true
-          schema:
-            type: number
-            example: '1234'
-      responses:
-        204:
-          description: 'Standard request.'
-        404:
-          description: 'If the movie theater could not be found.'
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/error'
-      security:
-        -
-          oauth2:
-            - delete
-      x-mill-path-template: /theaters/+id
-      x-mill-visibility-private: true
 components:
   securitySchemes:
     bearer:

--- a/src/Compiler/ErrorMap.php
+++ b/src/Compiler/ErrorMap.php
@@ -31,29 +31,27 @@ class ErrorMap extends Compiler
                     $group = array_shift($parts);
                 }
 
-                foreach ($data['resources'] as $resource_name => $resource) {
-                    /** @var Action\Documentation $action */
-                    foreach ($resource['actions'] as $identifier => $action) {
-                        /** @var ReturnAnnotation|ErrorAnnotation $response */
-                        foreach ($action->getResponses() as $response) {
-                            if (!$response instanceof ErrorAnnotation) {
-                                continue;
-                            }
-
-                            $error_code = $response->getErrorCode();
-                            if (empty($error_code)) {
-                                continue;
-                            }
-
-                            $path = $action->getPath();
-                            $this->error_map[$version][$group][$error_code][] = [
-                                'path' => $path->getCleanPath(),
-                                'method' => $action->getMethod(),
-                                'http_code' => $response->getHttpCode(),
-                                'error_code' => $error_code,
-                                'description' => $response->getDescription()
-                            ];
+                /** @var Action\Documentation $action */
+                foreach ($data['actions'] as $identifier => $action) {
+                    /** @var ReturnAnnotation|ErrorAnnotation $response */
+                    foreach ($action->getResponses() as $response) {
+                        if (!$response instanceof ErrorAnnotation) {
+                            continue;
                         }
+
+                        $error_code = $response->getErrorCode();
+                        if (empty($error_code)) {
+                            continue;
+                        }
+
+                        $path = $action->getPath();
+                        $this->error_map[$version][$group][$error_code][] = [
+                            'path' => $path->getCleanPath(),
+                            'method' => $action->getMethod(),
+                            'http_code' => $response->getHttpCode(),
+                            'error_code' => $error_code,
+                            'description' => $response->getDescription()
+                        ];
                     }
                 }
             }

--- a/src/Compiler/Specification/ApiBlueprint.php
+++ b/src/Compiler/Specification/ApiBlueprint.php
@@ -47,49 +47,45 @@ class ApiBlueprint extends Compiler\Specification
                 $contents .= $this->line();
 
                 // Sort the resources so they're alphabetical.
-                ksort($data['resources']);
+                ksort($data['actions']);
 
                 $resource_contents = [];
 
-                /** @var array $resource */
-                foreach ($data['resources'] as $identifier => $resource) {
-                    /** @var Action\Documentation $action */
-                    foreach ($resource['actions'] as $action) {
-                        $resource_key = sprintf('%s [%s]', $identifier, $action->getPath()->getCleanPath());
-                        if (!isset($resource_contents[$resource_key])) {
-                            $resource_contents[$resource_key] = [
-                                'description' => $resource['description'],
-                                'actions' => []
-                            ];
-                        }
-
-                        $action_contents = '';
-
-                        $description = $action->getDescription();
-                        if (!empty($description)) {
-                            $action_contents .= $description;
-                            $action_contents .= $this->line(2);
-                        }
-
-                        $action_contents .= $this->processScopes($action);
-                        $action_contents .= $this->processParameters($action);
-                        $action_contents .= $this->processRequest($action);
-
-                        $coded_responses = [];
-                        /** @var ReturnAnnotation|ErrorAnnotation $response */
-                        foreach ($action->getResponses() as $response) {
-                            $coded_responses[$response->getHttpCode()][] = $response;
-                        }
-
-                        ksort($coded_responses);
-
-                        foreach ($coded_responses as $http_code => $responses) {
-                            $action_contents .= $this->processResponses($action, $http_code, $responses);
-                        }
-
-                        $action_key = sprintf('%s [%s]', $action->getLabel(), $action->getMethod());
-                        $resource_contents[$resource_key]['actions'][$action_key] = $action_contents;
+                /** @var Action\Documentation $action */
+                foreach ($data['actions'] as $identifier => $action) {
+                    $resource_key = sprintf('%s [%s]', $group, $action->getPath()->getCleanPath());
+                    if (!isset($resource_contents[$resource_key])) {
+                        $resource_contents[$resource_key] = [
+                            'actions' => []
+                        ];
                     }
+
+                    $action_contents = '';
+
+                    $description = $action->getDescription();
+                    if (!empty($description)) {
+                        $action_contents .= $description;
+                        $action_contents .= $this->line(2);
+                    }
+
+                    $action_contents .= $this->processScopes($action);
+                    $action_contents .= $this->processParameters($action);
+                    $action_contents .= $this->processRequest($action);
+
+                    $coded_responses = [];
+                    /** @var ReturnAnnotation|ErrorAnnotation $response */
+                    foreach ($action->getResponses() as $response) {
+                        $coded_responses[$response->getHttpCode()][] = $response;
+                    }
+
+                    ksort($coded_responses);
+
+                    foreach ($coded_responses as $http_code => $responses) {
+                        $action_contents .= $this->processResponses($action, $http_code, $responses);
+                    }
+
+                    $action_key = sprintf('%s [%s]', $action->getLabel(), $action->getMethod());
+                    $resource_contents[$resource_key]['actions'][$action_key] = $action_contents;
                 }
 
                 // Since there are instances where the same resource might be used with multiple endpoints, and on the
@@ -100,11 +96,6 @@ class ApiBlueprint extends Compiler\Specification
                 foreach ($resource_contents as $identifier => $resource) {
                     $contents .= sprintf('## %s', $identifier);
                     $contents .= $this->line();
-
-                    if (!is_null($resource['description'])) {
-                        $contents .= $resource['description'];
-                        $contents .= $this->line();
-                    }
 
                     foreach ($resource['actions'] as $action_identifier => $markdown) {
                         $contents .= $this->line();

--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -74,53 +74,50 @@ class OpenApi extends Compiler\Specification
                 }
 
                 // Sort the resources so they're alphabetical.
-                ksort($data['resources']);
+                ksort($data['actions']);
 
-                /** @var array $resource */
-                foreach ($data['resources'] as $identifier => $resource) {
-                    /** @var Action\Documentation $action */
-                    foreach ($resource['actions'] as $action) {
-                        $path = $action->getPath();
-                        $method = strtolower($action->getMethod());
-                        $identifier = $path->getCleanPath();
-                        if (!isset($specification['paths'][$identifier])) {
-                            $specification['paths'][$identifier] = [];
-                        }
-
-                        $schema = [
-                            'deprecated' => $path->isDeprecated(),
-                            'summary' => $action->getLabel(),
-                            'description' => $action->getDescription(),
-                            'operationId' => $action->getOperationId(),
-                            'tags' => [
-                                $group
-                            ],
-                            'parameters' => $this->processParameters($action),
-                            'requestBody' => $this->processRequest($action),
-                            'responses' => $this->processResponses($action),
-                            'security' => $this->processSecurity($action)
-                        ];
-
-                        $schema += $this->processExtensions($action, $path);
-
-                        foreach ([
-                            'deprecated',
-                            'description',
-                            'parameters',
-                            'requestBody',
-                            'security',
-                            'x-mill-path-aliased',
-                            'x-mill-path-aliases',
-                            'x-mill-vendor-tags',
-                            'x-mill-visibility-private'
-                        ] as $key) {
-                            if (empty($schema[$key])) {
-                                unset($schema[$key]);
-                            }
-                        }
-
-                        $specification['paths'][$identifier][$method] = $schema;
+                /** @var Action\Documentation $action */
+                foreach ($data['actions'] as $identifier => $action) {
+                    $path = $action->getPath();
+                    $method = strtolower($action->getMethod());
+                    $identifier = $path->getCleanPath();
+                    if (!isset($specification['paths'][$identifier])) {
+                        $specification['paths'][$identifier] = [];
                     }
+
+                    $schema = [
+                        'deprecated' => $path->isDeprecated(),
+                        'summary' => $action->getLabel(),
+                        'description' => $action->getDescription(),
+                        'operationId' => $action->getOperationId(),
+                        'tags' => [
+                            $group
+                        ],
+                        'parameters' => $this->processParameters($action),
+                        'requestBody' => $this->processRequest($action),
+                        'responses' => $this->processResponses($action),
+                        'security' => $this->processSecurity($action)
+                    ];
+
+                    $schema += $this->processExtensions($action, $path);
+
+                    foreach ([
+                        'deprecated',
+                        'description',
+                        'parameters',
+                        'requestBody',
+                        'security',
+                        'x-mill-path-aliased',
+                        'x-mill-path-aliases',
+                        'x-mill-vendor-tags',
+                        'x-mill-visibility-private'
+                    ] as $key) {
+                        if (empty($schema[$key])) {
+                            unset($schema[$key]);
+                        }
+                    }
+
+                    $specification['paths'][$identifier][$method] = $schema;
                 }
             }
 

--- a/src/Parser/Resource/Documentation.php
+++ b/src/Parser/Resource/Documentation.php
@@ -15,12 +15,6 @@ class Documentation implements Arrayable
     /** @var array Array of parsed method documentation for the current resource. */
     protected $methods = [];
 
-    /** @var string Short description/label/title of the resource. */
-    protected $label;
-
-    /** @var null|string Fuller description of what this resource handles. This should normally consist of Markdown. */
-    protected $description = null;
-
     /** @var Parser Current Parser instance. */
     protected $parser;
 
@@ -37,13 +31,11 @@ class Documentation implements Arrayable
      * Parse the instance class into actionable annotations and documentation.
      *
      * @return Documentation
-     * @throws MultipleAnnotationsException
-     * @throws RequiredAnnotationException
      * @throws \Mill\Exceptions\Resource\UnsupportedDecoratorException
      */
     public function parse(): self
     {
-        $annotations = $this->parser->getAnnotations();
+        /*$annotations = $this->parser->getAnnotations();
 
         if (!isset($annotations['label'])) {
             throw RequiredAnnotationException::create('label', $this->class);
@@ -51,15 +43,15 @@ class Documentation implements Arrayable
             throw MultipleAnnotationsException::create('label', $this->class);
         }
 
-        /** @var \Mill\Parser\Annotations\LabelAnnotation $annotation */
+        /** @var \Mill\Parser\Annotations\LabelAnnotation $annotation
         $annotation = reset($annotations['label']);
         $this->label = $annotation->getLabel();
 
         if (!empty($annotations['description'])) {
-            /** @var \Mill\Parser\Annotations\DescriptionAnnotation $annotation */
+            /** @var \Mill\Parser\Annotations\DescriptionAnnotation $annotation
             $annotation = reset($annotations['description']);
             $this->description = $annotation->getDescription();
-        }
+        }*/
 
         return $this;
     }
@@ -157,8 +149,6 @@ class Documentation implements Arrayable
     {
         $data = [
             'class' => $this->class,
-            'description' => $this->description,
-            'label' => $this->label,
             'methods' => []
         ];
 

--- a/tests/Parser/Resource/DocumentationTest.php
+++ b/tests/Parser/Resource/DocumentationTest.php
@@ -34,8 +34,6 @@ class DocumentationTest extends TestCase
         $class_docs = $docs->toArray();
 
         $this->assertSame($class_docs['class'], $class);
-        $this->assertSame($expected['label'], $class_docs['label']);
-        $this->assertSame($expected['description'], $class_docs['description']);
 
         foreach ($expected['methods.available'] as $method) {
             $this->assertInternalType('array', $class_docs['methods'][$method]);
@@ -96,10 +94,6 @@ class DocumentationTest extends TestCase
                 'class' => '\Mill\Examples\Showtimes\Controllers\Movie',
                 'expected' => [
                     'methods.size' => 3,
-                    'label' => 'Movies',
-                    'description' => 'Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.',
                     'methods.available' => [
                         'GET',
                         'PATCH',
@@ -114,10 +108,10 @@ These actions will allow you to pull information on a specific movie.',
     public function providerDocumentationFailsOnBadClasses(): array
     {
         return [
-            'missing-required-label-annotation' => [
+            /*'missing-required-label-annotation' => [
                 'docblock' => '/**
                   *
-                  */',
+                  *',
                 'expected.exception' => '\Mill\Exceptions\Annotations\RequiredAnnotationException',
                 'expected.exception.asserts' => [
                     'getAnnotation' => 'label'
@@ -127,12 +121,12 @@ These actions will allow you to pull information on a specific movie.',
                 'docblock' => '/**
                   * @api-label Something
                   * @api-label Something else
-                  */',
+                  *',
                 'expected.exception' => '\Mill\Exceptions\Annotations\MultipleAnnotationsException',
                 'expected.exception.asserts' => [
                     'getAnnotation' => 'label'
                 ]
-            ]
+            ]*/
         ];
     }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -13,19 +13,7 @@ class ParserTest extends TestCase
         $class = '\Mill\Examples\Showtimes\Controllers\Movie';
         $docs = (new Parser($class))->getAnnotations();
 
-        $this->assertCount(2, $docs);
-        $this->assertCount(1, $docs['description']);
-        $this->assertCount(1, $docs['label']);
-
-        /** @var \Mill\Parser\Annotations\LabelAnnotation $annotation */
-        $annotation = $docs['label'][0];
-        $this->assertSame('Movies', $annotation->toArray()['label']);
-
-        /** @var \Mill\Parser\Annotations\DescriptionAnnotation $annotation */
-        $annotation = $docs['description'][0];
-        $this->assertSame('Information on a specific movie.
-
-These actions will allow you to pull information on a specific movie.', $annotation->toArray()['description']);
+        $this->assertCount(0, $docs);
     }
 
     /**


### PR DESCRIPTION
It was only ever utilized within API Blueprint generation, and in such a poor way that the need for it was really unnecessary.

`@api-group` is a much better way to denote what an action is apart of anyways.