### PR TITLE
Adding `required` flag support on `@api-data` annotations.

### DIFF
--- a/docs/reference-api-data.md
+++ b/docs/reference-api-data.md
@@ -68,7 +68,7 @@ $representation = [
     ...
 
     /**
-     * @api-data uri (uri) - The canonical relative URI for the user.
+     * @api-data uri (uri, required) - The canonical relative URI for the user.
      */
     'uri' => sprintf('/users/%d', $user->id),
 
@@ -99,7 +99,7 @@ $representation = [
                 'options' => ['GET'],
 
                 /**
-                 * @api-data total (number) - Total number of items on
+                 * @api-data total (number, nullable) - Total number of items on
                  *     this connection.
                  */
                 'total' => $user->getAlbums()->total

--- a/resources/examples/Showtimes/Representations/CodedError.php
+++ b/resources/examples/Showtimes/Representations/CodedError.php
@@ -12,12 +12,12 @@ class CodedError extends Representation
     {
         return [
             /**
-             * @api-data error (string) - User-friendly error message
+             * @api-data error (string, required) - User-friendly error message
              */
             'error' => $error,
 
             /**
-             * @api-data error_code (number) - Error code
+             * @api-data error_code (number, required) - Error code
              */
             'error_code' => $error_code
         ];

--- a/resources/examples/Showtimes/Representations/Error.php
+++ b/resources/examples/Showtimes/Representations/Error.php
@@ -10,7 +10,7 @@ class Error extends Representation
     {
         return [
             /**
-             * @api-data error (string) - User-friendly error message
+             * @api-data error (string, required) - User-friendly error message
              */
             'error' => $error
         ];

--- a/resources/examples/Showtimes/Representations/Movie.php
+++ b/resources/examples/Showtimes/Representations/Movie.php
@@ -12,34 +12,34 @@ class Movie extends Representation
 
     public function create()
     {
-        return [
+        $response = [
             /**
-             * @api-data uri (uri) - Movie URI
+             * @api-data uri (uri, required) - Movie URI
              */
             'uri' => $this->movie->uri,
 
             /**
-             * @api-data id (number) - Unique ID
+             * @api-data id (number, required) - Unique ID
              */
             'id' => $this->movie->id,
 
             /**
-             * @api-data name (string) - Name
+             * @api-data name (string, required) - Name
              */
             'name' => $this->movie->name,
 
             /**
-             * @api-data description (string) - Description
+             * @api-data description (string, nullable) - Description
              */
-            'description' => $this->movie->description,
+            'description' => $this->movie->description ?: null,
 
             /**
-             * @api-data runtime (string) - Runtime
+             * @api-data runtime (string, required) - Runtime
              */
             'runtime' => $this->movie->runtime,
 
             /**
-             * @api-data content_rating (enum) - MPAA rating
+             * @api-data content_rating (enum, required) - MPAA rating
              *      + Members
              *          - `G`
              *          - `PG`
@@ -53,35 +53,35 @@ class Movie extends Representation
             'rating' => $this->movie->rating,
 
             /**
-             * @api-data genres (array<uri>) - Genres
+             * @api-data genres (array<uri>, required) - Genres
              */
             'genres' => $this->movie->getGenres(),
 
             /**
-             * @api-data director (\Mill\Examples\Showtimes\Representations\Person) - Director
+             * @api-data director (\Mill\Examples\Showtimes\Representations\Person, required) - Director
              * @api-scope public
              */
             'director' => $this->movie->director,
 
             /**
-             * @api-data cast (array<\Mill\Examples\Showtimes\Representations\Person>) - Cast
+             * @api-data cast (array<\Mill\Examples\Showtimes\Representations\Person>, required) - Cast
              * @api-scope public
              */
             'cast' => $this->movie->getCast(),
 
             /**
-             * @api-data kid_friendly `0` (boolean) - Kid friendly?
+             * @api-data kid_friendly `0` (boolean, required) - Kid friendly?
              */
             'kid_friendly' => $this->movie->is_kid_friendly,
 
             /**
-             * @api-data theaters (array<\Mill\Examples\Showtimes\Representations\Theater>) - Theaters the movie is
-             *      currently showing in
+             * @api-data theaters (array<\Mill\Examples\Showtimes\Representations\Theater>, required) - Theaters the
+             *      movie is currently showing in
              */
             'theaters' => $this->movie->getTheaters(),
 
             /**
-             * @api-data showtimes (array) - Non-theater specific showtimes
+             * @api-data showtimes (array, required) - Non-theater specific showtimes
              */
             'showtimes' => $this->getShowtimes(),
 
@@ -94,22 +94,26 @@ class Movie extends Representation
             'external_urls' => $this->getExternalUrls(),
 
             /**
-             * @api-data external_urls.imdb (string) - IMDB URL
+             * @api-data external_urls.imdb (string, required) - IMDB URL
              */
             'imdb' => $this->movie->imdb,
 
             /**
-             * @api-data rotten_tomatoes_score (number) - Rotten Tomatoes score
+             * @api-data rotten_tomatoes_score (number, required) - Rotten Tomatoes score
              */
-            'rotten_tomatoes_score' => $this->rotten_tomatoes_score,
-
-            'purchase' => [
-                /**
-                 * @api-data purchase.url (string) - URL to purchase the film.
-                 */
-                'url' => $this->purchase->digital->url,
-            ]
+            'rotten_tomatoes_score' => $this->rotten_tomatoes_score
         ];
+
+        if ($this->movie->is_for_sale) {
+            $response['purchase'] = [
+                /**
+                 * @api-data purchase.url (string, nullable) - URL to purchase the film.
+                 */
+                'url' => $this->purchase->digital->url ?: null,
+            ];
+        }
+
+        return $response;
     }
 
     /**
@@ -119,12 +123,12 @@ class Movie extends Representation
     {
         return [
             /**
-             * @api-data trailer (string) - Trailer URL
+             * @api-data trailer (string, required) - Trailer URL
              */
             'trailer' => $this->movie->trailer,
 
             /**
-             * @api-data tickets (string, tag:BUY_TICKETS) - Tickets URL
+             * @api-data tickets (string, required, tag:BUY_TICKETS) - Tickets URL
              * @api-version <1.1.3
              */
             'tickets' => $this->movie->tickets_url

--- a/resources/examples/Showtimes/compiled/1.0/apiblueprint/api.apib
+++ b/resources/examples/Showtimes/compiled/1.0/apiblueprint/api.apib
@@ -177,15 +177,15 @@ This action requires a bearer token with the `create` scope.
 
 # Data Structures
 ## Coded error
-- `error` (string) - User-friendly error message
-- `error_code` (number) - Error code
+- `error` (string, required) - User-friendly error message
+- `error_code` (number, required) - Error code
 
 ## Error
-- `error` (string) - User-friendly error message
+- `error` (string, required) - User-friendly error message
 
 ## Movie
-- `cast` (array[Person]) - Cast. This data requires a bearer token with the `public` scope.
-- `content_rating`: `G` (enum[string]) - MPAA rating
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
     + Members
         + `G`
         + `NC-17`
@@ -195,19 +195,19 @@ This action requires a bearer token with the `create` scope.
         + `R`
         + `UR`
         + `X`
-- `description` (string) - Description
-- `director` (Person) - Director. This data requires a bearer token with the `public` scope.
-- `genres` (array[string]) - Genres
-- `id` (number) - Unique ID
-- `kid_friendly`: `false` (boolean) - Kid friendly?
-- `name` (string) - Name
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
 - `purchase` (object)
-    - `url` (string) - URL to purchase the film.
-- `rotten_tomatoes_score` (number) - Rotten Tomatoes score
-- `runtime` (string) - Runtime
-- `showtimes` (array) - Non-theater specific showtimes
-- `theaters` (array[Theater]) - Theaters the movie is currently showing in
-- `uri` (string) - Movie URI
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array, required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI
 
 ## Person
 - `id` (number) - Unique ID

--- a/resources/examples/Showtimes/compiled/1.0/apiblueprint/representations/Coded error.apib
+++ b/resources/examples/Showtimes/compiled/1.0/apiblueprint/representations/Coded error.apib
@@ -1,3 +1,3 @@
 ## Coded error
-- `error` (string) - User-friendly error message
-- `error_code` (number) - Error code
+- `error` (string, required) - User-friendly error message
+- `error_code` (number, required) - Error code

--- a/resources/examples/Showtimes/compiled/1.0/apiblueprint/representations/Error.apib
+++ b/resources/examples/Showtimes/compiled/1.0/apiblueprint/representations/Error.apib
@@ -1,2 +1,2 @@
 ## Error
-- `error` (string) - User-friendly error message
+- `error` (string, required) - User-friendly error message

--- a/resources/examples/Showtimes/compiled/1.0/apiblueprint/representations/Movie.apib
+++ b/resources/examples/Showtimes/compiled/1.0/apiblueprint/representations/Movie.apib
@@ -1,6 +1,6 @@
 ## Movie
-- `cast` (array[Person]) - Cast. This data requires a bearer token with the `public` scope.
-- `content_rating`: `G` (enum[string]) - MPAA rating
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
     + Members
         + `G`
         + `NC-17`
@@ -10,16 +10,16 @@
         + `R`
         + `UR`
         + `X`
-- `description` (string) - Description
-- `director` (Person) - Director. This data requires a bearer token with the `public` scope.
-- `genres` (array[string]) - Genres
-- `id` (number) - Unique ID
-- `kid_friendly`: `false` (boolean) - Kid friendly?
-- `name` (string) - Name
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
 - `purchase` (object)
-    - `url` (string) - URL to purchase the film.
-- `rotten_tomatoes_score` (number) - Rotten Tomatoes score
-- `runtime` (string) - Runtime
-- `showtimes` (array) - Non-theater specific showtimes
-- `theaters` (array[Theater]) - Theaters the movie is currently showing in
-- `uri` (string) - Movie URI
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array, required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI

--- a/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
@@ -448,12 +448,19 @@ components:
         error_code:
           description: 'Error code'
           type: number
+      required:
+        - error
+        - error_code
+      type: object
     error:
       title: Error
       properties:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -477,6 +484,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -502,6 +510,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -523,6 +532,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -538,6 +561,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -569,6 +593,7 @@ components:
         website:
           description: Website
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
@@ -235,6 +235,9 @@ components:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -258,6 +261,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -283,6 +287,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -304,6 +309,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -319,6 +338,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -350,6 +370,7 @@ components:
         website:
           description: Website
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Theaters.yaml
@@ -259,12 +259,19 @@ components:
         error_code:
           description: 'Error code'
           type: number
+      required:
+        - error
+        - error_code
+      type: object
     error:
       title: Error
       properties:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -288,6 +295,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -313,6 +321,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -334,6 +343,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -349,6 +372,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -380,6 +404,7 @@ components:
         website:
           description: Website
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/api.apib
+++ b/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/api.apib
@@ -233,15 +233,15 @@ This action requires a bearer token with the `create` scope.
 
 # Data Structures
 ## Coded error
-- `error` (string) - User-friendly error message
-- `error_code` (number) - Error code
+- `error` (string, required) - User-friendly error message
+- `error_code` (number, required) - Error code
 
 ## Error
-- `error` (string) - User-friendly error message
+- `error` (string, required) - User-friendly error message
 
 ## Movie
-- `cast` (array[Person]) - Cast. This data requires a bearer token with the `public` scope.
-- `content_rating`: `G` (enum[string]) - MPAA rating
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
     + Members
         + `G`
         + `NC-17`
@@ -251,24 +251,24 @@ This action requires a bearer token with the `create` scope.
         + `R`
         + `UR`
         + `X`
-- `description` (string) - Description
-- `director` (Person) - Director. This data requires a bearer token with the `public` scope.
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
 - `external_urls` (array) - External URLs. This data requires a bearer token with the `public` scope.
      - (object)
-        - `imdb` (string) - IMDB URL. This data requires a bearer token with the `public` scope.
-        - `tickets` (string) - Tickets URL. This data requires a bearer token with the `public` scope.
-        - `trailer` (string) - Trailer URL. This data requires a bearer token with the `public` scope.
-- `genres` (array[string]) - Genres
-- `id` (number) - Unique ID
-- `kid_friendly`: `false` (boolean) - Kid friendly?
-- `name` (string) - Name
+        - `imdb` (string, required) - IMDB URL. This data requires a bearer token with the `public` scope.
+        - `tickets` (string, required) - Tickets URL. This data requires a bearer token with the `public` scope.
+        - `trailer` (string, required) - Trailer URL. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
 - `purchase` (object)
-    - `url` (string) - URL to purchase the film.
-- `rotten_tomatoes_score` (number) - Rotten Tomatoes score
-- `runtime` (string) - Runtime
-- `showtimes` (array) - Non-theater specific showtimes
-- `theaters` (array[Theater]) - Theaters the movie is currently showing in
-- `uri` (string) - Movie URI
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array, required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI
 
 ## Person
 - `id` (number) - Unique ID

--- a/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/representations/Coded error.apib
+++ b/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/representations/Coded error.apib
@@ -1,3 +1,3 @@
 ## Coded error
-- `error` (string) - User-friendly error message
-- `error_code` (number) - Error code
+- `error` (string, required) - User-friendly error message
+- `error_code` (number, required) - Error code

--- a/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/representations/Error.apib
+++ b/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/representations/Error.apib
@@ -1,2 +1,2 @@
 ## Error
-- `error` (string) - User-friendly error message
+- `error` (string, required) - User-friendly error message

--- a/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/representations/Movie.apib
+++ b/resources/examples/Showtimes/compiled/1.1.1/apiblueprint/representations/Movie.apib
@@ -1,6 +1,6 @@
 ## Movie
-- `cast` (array[Person]) - Cast. This data requires a bearer token with the `public` scope.
-- `content_rating`: `G` (enum[string]) - MPAA rating
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
     + Members
         + `G`
         + `NC-17`
@@ -10,21 +10,21 @@
         + `R`
         + `UR`
         + `X`
-- `description` (string) - Description
-- `director` (Person) - Director. This data requires a bearer token with the `public` scope.
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
 - `external_urls` (array) - External URLs. This data requires a bearer token with the `public` scope.
      - (object)
-        - `imdb` (string) - IMDB URL. This data requires a bearer token with the `public` scope.
-        - `tickets` (string) - Tickets URL. This data requires a bearer token with the `public` scope.
-        - `trailer` (string) - Trailer URL. This data requires a bearer token with the `public` scope.
-- `genres` (array[string]) - Genres
-- `id` (number) - Unique ID
-- `kid_friendly`: `false` (boolean) - Kid friendly?
-- `name` (string) - Name
+        - `imdb` (string, required) - IMDB URL. This data requires a bearer token with the `public` scope.
+        - `tickets` (string, required) - Tickets URL. This data requires a bearer token with the `public` scope.
+        - `trailer` (string, required) - Trailer URL. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
 - `purchase` (object)
-    - `url` (string) - URL to purchase the film.
-- `rotten_tomatoes_score` (number) - Rotten Tomatoes score
-- `runtime` (string) - Runtime
-- `showtimes` (array) - Non-theater specific showtimes
-- `theaters` (array[Theater]) - Theaters the movie is currently showing in
-- `uri` (string) - Movie URI
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array, required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
@@ -608,12 +608,19 @@ components:
         error_code:
           description: 'Error code'
           type: number
+      required:
+        - error
+        - error_code
+      type: object
     error:
       title: Error
       properties:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -637,6 +644,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -659,6 +667,10 @@ components:
               trailer:
                 description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
                 type: string
+            required:
+              - imdb
+              - tickets
+              - trailer
           type: array
         genres:
           description: Genres
@@ -679,6 +691,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -700,6 +713,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -715,6 +742,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -743,6 +771,7 @@ components:
         uri:
           description: 'Theater URI'
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
@@ -395,6 +395,9 @@ components:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -418,6 +421,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -440,6 +444,10 @@ components:
               trailer:
                 description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
                 type: string
+            required:
+              - imdb
+              - tickets
+              - trailer
           type: array
         genres:
           description: Genres
@@ -460,6 +468,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -481,6 +490,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -496,6 +519,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -524,6 +548,7 @@ components:
         uri:
           description: 'Theater URI'
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Theaters.yaml
@@ -259,12 +259,19 @@ components:
         error_code:
           description: 'Error code'
           type: number
+      required:
+        - error
+        - error_code
+      type: object
     error:
       title: Error
       properties:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -288,6 +295,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -310,6 +318,10 @@ components:
               trailer:
                 description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
                 type: string
+            required:
+              - imdb
+              - tickets
+              - trailer
           type: array
         genres:
           description: Genres
@@ -330,6 +342,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -351,6 +364,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -366,6 +393,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -394,6 +422,7 @@ components:
         uri:
           description: 'Theater URI'
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.1.2/apiblueprint/api.apib
+++ b/resources/examples/Showtimes/compiled/1.1.2/apiblueprint/api.apib
@@ -231,11 +231,11 @@ This action requires a bearer token with the `create` scope.
 
 # Data Structures
 ## Error
-- `error` (string) - User-friendly error message
+- `error` (string, required) - User-friendly error message
 
 ## Movie
-- `cast` (array[Person]) - Cast. This data requires a bearer token with the `public` scope.
-- `content_rating`: `G` (enum[string]) - MPAA rating
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
     + Members
         + `G`
         + `NC-17`
@@ -245,24 +245,24 @@ This action requires a bearer token with the `create` scope.
         + `R`
         + `UR`
         + `X`
-- `description` (string) - Description
-- `director` (Person) - Director. This data requires a bearer token with the `public` scope.
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
 - `external_urls` (array) - External URLs. This data requires a bearer token with the `public` scope.
      - (object)
-        - `imdb` (string) - IMDB URL. This data requires a bearer token with the `public` scope.
-        - `tickets` (string) - Tickets URL. This data requires a bearer token with the `public` scope.
-        - `trailer` (string) - Trailer URL. This data requires a bearer token with the `public` scope.
-- `genres` (array[string]) - Genres
-- `id` (number) - Unique ID
-- `kid_friendly`: `false` (boolean) - Kid friendly?
-- `name` (string) - Name
+        - `imdb` (string, required) - IMDB URL. This data requires a bearer token with the `public` scope.
+        - `tickets` (string, required) - Tickets URL. This data requires a bearer token with the `public` scope.
+        - `trailer` (string, required) - Trailer URL. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
 - `purchase` (object)
-    - `url` (string) - URL to purchase the film.
-- `rotten_tomatoes_score` (number) - Rotten Tomatoes score
-- `runtime` (string) - Runtime
-- `showtimes` (array) - Non-theater specific showtimes
-- `theaters` (array[Theater]) - Theaters the movie is currently showing in
-- `uri` (string) - Movie URI
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array, required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI
 
 ## Person
 - `id` (number) - Unique ID

--- a/resources/examples/Showtimes/compiled/1.1.2/apiblueprint/representations/Error.apib
+++ b/resources/examples/Showtimes/compiled/1.1.2/apiblueprint/representations/Error.apib
@@ -1,2 +1,2 @@
 ## Error
-- `error` (string) - User-friendly error message
+- `error` (string, required) - User-friendly error message

--- a/resources/examples/Showtimes/compiled/1.1.2/apiblueprint/representations/Movie.apib
+++ b/resources/examples/Showtimes/compiled/1.1.2/apiblueprint/representations/Movie.apib
@@ -1,6 +1,6 @@
 ## Movie
-- `cast` (array[Person]) - Cast. This data requires a bearer token with the `public` scope.
-- `content_rating`: `G` (enum[string]) - MPAA rating
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
     + Members
         + `G`
         + `NC-17`
@@ -10,21 +10,21 @@
         + `R`
         + `UR`
         + `X`
-- `description` (string) - Description
-- `director` (Person) - Director. This data requires a bearer token with the `public` scope.
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
 - `external_urls` (array) - External URLs. This data requires a bearer token with the `public` scope.
      - (object)
-        - `imdb` (string) - IMDB URL. This data requires a bearer token with the `public` scope.
-        - `tickets` (string) - Tickets URL. This data requires a bearer token with the `public` scope.
-        - `trailer` (string) - Trailer URL. This data requires a bearer token with the `public` scope.
-- `genres` (array[string]) - Genres
-- `id` (number) - Unique ID
-- `kid_friendly`: `false` (boolean) - Kid friendly?
-- `name` (string) - Name
+        - `imdb` (string, required) - IMDB URL. This data requires a bearer token with the `public` scope.
+        - `tickets` (string, required) - Tickets URL. This data requires a bearer token with the `public` scope.
+        - `trailer` (string, required) - Trailer URL. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
 - `purchase` (object)
-    - `url` (string) - URL to purchase the film.
-- `rotten_tomatoes_score` (number) - Rotten Tomatoes score
-- `runtime` (string) - Runtime
-- `showtimes` (array) - Non-theater specific showtimes
-- `theaters` (array[Theater]) - Theaters the movie is currently showing in
-- `uri` (string) - Movie URI
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array, required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
@@ -599,6 +599,9 @@ components:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -622,6 +625,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -644,6 +648,10 @@ components:
               trailer:
                 description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
                 type: string
+            required:
+              - imdb
+              - tickets
+              - trailer
           type: array
         genres:
           description: Genres
@@ -664,6 +672,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -685,6 +694,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -700,6 +723,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -728,6 +752,7 @@ components:
         uri:
           description: 'Theater URI'
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
@@ -395,6 +395,9 @@ components:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -418,6 +421,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -440,6 +444,10 @@ components:
               trailer:
                 description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
                 type: string
+            required:
+              - imdb
+              - tickets
+              - trailer
           type: array
         genres:
           description: Genres
@@ -460,6 +468,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -481,6 +490,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -496,6 +519,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -524,6 +548,7 @@ components:
         uri:
           description: 'Theater URI'
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Theaters.yaml
@@ -250,6 +250,9 @@ components:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -273,6 +276,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -295,6 +299,10 @@ components:
               trailer:
                 description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
                 type: string
+            required:
+              - imdb
+              - tickets
+              - trailer
           type: array
         genres:
           description: Genres
@@ -315,6 +323,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -336,6 +345,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -351,6 +374,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -379,6 +403,7 @@ components:
         uri:
           description: 'Theater URI'
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/api.apib
+++ b/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/api.apib
@@ -239,15 +239,15 @@ This action requires a bearer token with the `create` scope.
 
 # Data Structures
 ## Coded error
-- `error` (string) - User-friendly error message
-- `error_code` (number) - Error code
+- `error` (string, required) - User-friendly error message
+- `error_code` (number, required) - Error code
 
 ## Error
-- `error` (string) - User-friendly error message
+- `error` (string, required) - User-friendly error message
 
 ## Movie
-- `cast` (array[Person]) - Cast. This data requires a bearer token with the `public` scope.
-- `content_rating`: `G` (enum[string]) - MPAA rating
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
     + Members
         + `G`
         + `NC-17`
@@ -257,23 +257,23 @@ This action requires a bearer token with the `create` scope.
         + `R`
         + `UR`
         + `X`
-- `description` (string) - Description
-- `director` (Person) - Director. This data requires a bearer token with the `public` scope.
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
 - `external_urls` (array) - External URLs. This data requires a bearer token with the `public` scope.
      - (object)
-        - `imdb` (string) - IMDB URL. This data requires a bearer token with the `public` scope.
-        - `trailer` (string) - Trailer URL. This data requires a bearer token with the `public` scope.
-- `genres` (array[string]) - Genres
-- `id` (number) - Unique ID
-- `kid_friendly`: `false` (boolean) - Kid friendly?
-- `name` (string) - Name
+        - `imdb` (string, required) - IMDB URL. This data requires a bearer token with the `public` scope.
+        - `trailer` (string, required) - Trailer URL. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
 - `purchase` (object)
-    - `url` (string) - URL to purchase the film.
-- `rotten_tomatoes_score` (number) - Rotten Tomatoes score
-- `runtime` (string) - Runtime
-- `showtimes` (array) - Non-theater specific showtimes
-- `theaters` (array[Theater]) - Theaters the movie is currently showing in
-- `uri` (string) - Movie URI
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array, required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI
 
 ## Person
 - `id` (number) - Unique ID

--- a/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/representations/Coded error.apib
+++ b/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/representations/Coded error.apib
@@ -1,3 +1,3 @@
 ## Coded error
-- `error` (string) - User-friendly error message
-- `error_code` (number) - Error code
+- `error` (string, required) - User-friendly error message
+- `error_code` (number, required) - Error code

--- a/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/representations/Error.apib
+++ b/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/representations/Error.apib
@@ -1,2 +1,2 @@
 ## Error
-- `error` (string) - User-friendly error message
+- `error` (string, required) - User-friendly error message

--- a/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/representations/Movie.apib
+++ b/resources/examples/Showtimes/compiled/1.1.3/apiblueprint/representations/Movie.apib
@@ -1,6 +1,6 @@
 ## Movie
-- `cast` (array[Person]) - Cast. This data requires a bearer token with the `public` scope.
-- `content_rating`: `G` (enum[string]) - MPAA rating
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
     + Members
         + `G`
         + `NC-17`
@@ -10,20 +10,20 @@
         + `R`
         + `UR`
         + `X`
-- `description` (string) - Description
-- `director` (Person) - Director. This data requires a bearer token with the `public` scope.
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
 - `external_urls` (array) - External URLs. This data requires a bearer token with the `public` scope.
      - (object)
-        - `imdb` (string) - IMDB URL. This data requires a bearer token with the `public` scope.
-        - `trailer` (string) - Trailer URL. This data requires a bearer token with the `public` scope.
-- `genres` (array[string]) - Genres
-- `id` (number) - Unique ID
-- `kid_friendly`: `false` (boolean) - Kid friendly?
-- `name` (string) - Name
+        - `imdb` (string, required) - IMDB URL. This data requires a bearer token with the `public` scope.
+        - `trailer` (string, required) - Trailer URL. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
 - `purchase` (object)
-    - `url` (string) - URL to purchase the film.
-- `rotten_tomatoes_score` (number) - Rotten Tomatoes score
-- `runtime` (string) - Runtime
-- `showtimes` (array) - Non-theater specific showtimes
-- `theaters` (array[Theater]) - Theaters the movie is currently showing in
-- `uri` (string) - Movie URI
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array, required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
@@ -584,12 +584,19 @@ components:
         error_code:
           description: 'Error code'
           type: number
+      required:
+        - error
+        - error_code
+      type: object
     error:
       title: Error
       properties:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -613,6 +620,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -630,6 +638,9 @@ components:
               trailer:
                 description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
                 type: string
+            required:
+              - imdb
+              - trailer
           type: array
         genres:
           description: Genres
@@ -650,6 +661,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -671,6 +683,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -686,6 +712,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -714,6 +741,7 @@ components:
         uri:
           description: 'Theater URI'
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
@@ -380,12 +380,19 @@ components:
         error_code:
           description: 'Error code'
           type: number
+      required:
+        - error
+        - error_code
+      type: object
     error:
       title: Error
       properties:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -409,6 +416,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -426,6 +434,9 @@ components:
               trailer:
                 description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
                 type: string
+            required:
+              - imdb
+              - trailer
           type: array
         genres:
           description: Genres
@@ -446,6 +457,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -467,6 +479,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -482,6 +508,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -510,6 +537,7 @@ components:
         uri:
           description: 'Theater URI'
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Theaters.yaml
@@ -250,6 +250,9 @@ components:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -273,6 +276,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -290,6 +294,9 @@ components:
               trailer:
                 description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
                 type: string
+            required:
+              - imdb
+              - trailer
           type: array
         genres:
           description: Genres
@@ -310,6 +317,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -331,6 +339,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -346,6 +368,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -374,6 +397,7 @@ components:
         uri:
           description: 'Theater URI'
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.1/apiblueprint/api.apib
+++ b/resources/examples/Showtimes/compiled/1.1/apiblueprint/api.apib
@@ -232,15 +232,15 @@ This action requires a bearer token with the `create` scope.
 
 # Data Structures
 ## Coded error
-- `error` (string) - User-friendly error message
-- `error_code` (number) - Error code
+- `error` (string, required) - User-friendly error message
+- `error_code` (number, required) - Error code
 
 ## Error
-- `error` (string) - User-friendly error message
+- `error` (string, required) - User-friendly error message
 
 ## Movie
-- `cast` (array[Person]) - Cast. This data requires a bearer token with the `public` scope.
-- `content_rating`: `G` (enum[string]) - MPAA rating
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
     + Members
         + `G`
         + `NC-17`
@@ -250,24 +250,24 @@ This action requires a bearer token with the `create` scope.
         + `R`
         + `UR`
         + `X`
-- `description` (string) - Description
-- `director` (Person) - Director. This data requires a bearer token with the `public` scope.
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
 - `external_urls` (array) - External URLs. This data requires a bearer token with the `public` scope.
      - (object)
-        - `imdb` (string) - IMDB URL. This data requires a bearer token with the `public` scope.
-        - `tickets` (string) - Tickets URL. This data requires a bearer token with the `public` scope.
-        - `trailer` (string) - Trailer URL. This data requires a bearer token with the `public` scope.
-- `genres` (array[string]) - Genres
-- `id` (number) - Unique ID
-- `kid_friendly`: `false` (boolean) - Kid friendly?
-- `name` (string) - Name
+        - `imdb` (string, required) - IMDB URL. This data requires a bearer token with the `public` scope.
+        - `tickets` (string, required) - Tickets URL. This data requires a bearer token with the `public` scope.
+        - `trailer` (string, required) - Trailer URL. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
 - `purchase` (object)
-    - `url` (string) - URL to purchase the film.
-- `rotten_tomatoes_score` (number) - Rotten Tomatoes score
-- `runtime` (string) - Runtime
-- `showtimes` (array) - Non-theater specific showtimes
-- `theaters` (array[Theater]) - Theaters the movie is currently showing in
-- `uri` (string) - Movie URI
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array, required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI
 
 ## Person
 - `id` (number) - Unique ID

--- a/resources/examples/Showtimes/compiled/1.1/apiblueprint/representations/Coded error.apib
+++ b/resources/examples/Showtimes/compiled/1.1/apiblueprint/representations/Coded error.apib
@@ -1,3 +1,3 @@
 ## Coded error
-- `error` (string) - User-friendly error message
-- `error_code` (number) - Error code
+- `error` (string, required) - User-friendly error message
+- `error_code` (number, required) - Error code

--- a/resources/examples/Showtimes/compiled/1.1/apiblueprint/representations/Error.apib
+++ b/resources/examples/Showtimes/compiled/1.1/apiblueprint/representations/Error.apib
@@ -1,2 +1,2 @@
 ## Error
-- `error` (string) - User-friendly error message
+- `error` (string, required) - User-friendly error message

--- a/resources/examples/Showtimes/compiled/1.1/apiblueprint/representations/Movie.apib
+++ b/resources/examples/Showtimes/compiled/1.1/apiblueprint/representations/Movie.apib
@@ -1,6 +1,6 @@
 ## Movie
-- `cast` (array[Person]) - Cast. This data requires a bearer token with the `public` scope.
-- `content_rating`: `G` (enum[string]) - MPAA rating
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
     + Members
         + `G`
         + `NC-17`
@@ -10,21 +10,21 @@
         + `R`
         + `UR`
         + `X`
-- `description` (string) - Description
-- `director` (Person) - Director. This data requires a bearer token with the `public` scope.
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
 - `external_urls` (array) - External URLs. This data requires a bearer token with the `public` scope.
      - (object)
-        - `imdb` (string) - IMDB URL. This data requires a bearer token with the `public` scope.
-        - `tickets` (string) - Tickets URL. This data requires a bearer token with the `public` scope.
-        - `trailer` (string) - Trailer URL. This data requires a bearer token with the `public` scope.
-- `genres` (array[string]) - Genres
-- `id` (number) - Unique ID
-- `kid_friendly`: `false` (boolean) - Kid friendly?
-- `name` (string) - Name
+        - `imdb` (string, required) - IMDB URL. This data requires a bearer token with the `public` scope.
+        - `tickets` (string, required) - Tickets URL. This data requires a bearer token with the `public` scope.
+        - `trailer` (string, required) - Trailer URL. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
 - `purchase` (object)
-    - `url` (string) - URL to purchase the film.
-- `rotten_tomatoes_score` (number) - Rotten Tomatoes score
-- `runtime` (string) - Runtime
-- `showtimes` (array) - Non-theater specific showtimes
-- `theaters` (array[Theater]) - Theaters the movie is currently showing in
-- `uri` (string) - Movie URI
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array, required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI

--- a/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
@@ -604,12 +604,19 @@ components:
         error_code:
           description: 'Error code'
           type: number
+      required:
+        - error
+        - error_code
+      type: object
     error:
       title: Error
       properties:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -633,6 +640,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -655,6 +663,10 @@ components:
               trailer:
                 description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
                 type: string
+            required:
+              - imdb
+              - tickets
+              - trailer
           type: array
         genres:
           description: Genres
@@ -675,6 +687,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -696,6 +709,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -711,6 +738,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -739,6 +767,7 @@ components:
         uri:
           description: 'Theater URI'
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
@@ -391,6 +391,9 @@ components:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -414,6 +417,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -436,6 +440,10 @@ components:
               trailer:
                 description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
                 type: string
+            required:
+              - imdb
+              - tickets
+              - trailer
           type: array
         genres:
           description: Genres
@@ -456,6 +464,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -477,6 +486,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -492,6 +515,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -520,6 +544,7 @@ components:
         uri:
           description: 'Theater URI'
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Theaters.yaml
@@ -259,12 +259,19 @@ components:
         error_code:
           description: 'Error code'
           type: number
+      required:
+        - error
+        - error_code
+      type: object
     error:
       title: Error
       properties:
         error:
           description: 'User-friendly error message'
           type: string
+      required:
+        - error
+      type: object
     movie:
       title: Movie
       properties:
@@ -288,6 +295,7 @@ components:
           type: string
         description:
           description: Description
+          nullable: true
           type: string
         director:
           allOf:
@@ -310,6 +318,10 @@ components:
               trailer:
                 description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
                 type: string
+            required:
+              - imdb
+              - tickets
+              - trailer
           type: array
         genres:
           description: Genres
@@ -330,6 +342,7 @@ components:
           properties:
             url:
               description: 'URL to purchase the film.'
+              nullable: true
               type: string
           type: object
         rotten_tomatoes_score:
@@ -351,6 +364,20 @@ components:
         uri:
           description: 'Movie URI'
           type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
     person:
       title: Person
       properties:
@@ -366,6 +393,7 @@ components:
         uri:
           description: 'Person URI'
           type: string
+      type: object
     theater:
       title: Theater
       properties:
@@ -394,6 +422,7 @@ components:
         uri:
           description: 'Theater URI'
           type: string
+      type: object
 security:
   -
     oauth2:

--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -134,12 +134,17 @@ class OpenApi extends Compiler\Specification
                         continue;
                     }
 
+                    $properties = $this->processDataModel(DataAnnotation::PAYLOAD_FORMAT, [
+                        'properties' => $fields
+                    ]);
+
                     $schema_name = $representation->getLabel();
                     $identifier = $this->getReferenceName($schema_name);
                     $specification['components']['schemas'][$identifier] = [
-                        'title' => $schema_name,
-                        'properties' => $this->processDataModel(DataAnnotation::PAYLOAD_FORMAT, $fields)
+                        'title' => $schema_name
                     ];
+
+                    $specification['components']['schemas'][$identifier] += $properties['properties'];
                 }
 
                 ksort($specification['components']['schemas']);
@@ -598,10 +603,6 @@ class OpenApi extends Compiler\Specification
 
                 unset($spec['name']);
                 unset($spec['in']);
-
-                if ($payload_format === DataAnnotation::PAYLOAD_FORMAT) {
-                    unset($spec['required']);
-                }
             }
 
             // Process any exploded dot notation children of this field.
@@ -639,8 +640,8 @@ class OpenApi extends Compiler\Specification
                 }
             }
 
-            // Request body requirement definitions need to be separate from the item schema.
-            if ($payload_format === ParamAnnotation::PAYLOAD_FORMAT) {
+            // Request body and response schema requirement definitions need to be separate from the item schema.
+            if (in_array($payload_format, [DataAnnotation::PAYLOAD_FORMAT, ParamAnnotation::PAYLOAD_FORMAT])) {
                 $spec = $this->extractRequiredFields($spec);
             }
 

--- a/src/Parser/Annotations/DataAnnotation.php
+++ b/src/Parser/Annotations/DataAnnotation.php
@@ -19,6 +19,7 @@ class DataAnnotation extends Annotation
         'description',
         'identifier',
         'nullable',
+        'required',
         'sample_data',
         'subtype',
         'type',
@@ -36,6 +37,9 @@ class DataAnnotation extends Annotation
 
     /** @var false|string Subtype of the type of data that this represents. */
     protected $subtype = false;
+
+    /** @var bool Flag designating if this data is always expected to be available (required). */
+    protected $required = false;
 
     /** @var bool Flag designating if this data is nullable. */
     protected $nullable = false;
@@ -67,6 +71,7 @@ class DataAnnotation extends Annotation
             'sample_data' => $mson->getSampleData(),
             'type' => $mson->getType(),
             'subtype' => $mson->getSubtype(),
+            'required' => $mson->isRequired(),
             'nullable' => $mson->isNullable(),
             'vendor_tags' => $mson->getVendorTags(),
             'description' => $mson->getDescription(),
@@ -115,6 +120,7 @@ class DataAnnotation extends Annotation
 
         $this->values = $this->optional('values');
         $this->vendor_tags = $this->optional('vendor_tags');
+        $this->required = $this->optional('required');
         $this->nullable = $this->optional('nullable');
     }
 
@@ -163,6 +169,24 @@ class DataAnnotation extends Annotation
     public function setIdentifierPrefix(string $prefix): self
     {
         $this->identifier = $prefix . '.' . $this->identifier;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRequired(): bool
+    {
+        return $this->required;
+    }
+
+    /**
+     * @param bool $required
+     * @return DataAnnotation
+     */
+    public function setRequired(bool $required): self
+    {
+        $this->required = $required;
         return $this;
     }
 

--- a/tests/Parser/Annotations/DataAnnotationTest.php
+++ b/tests/Parser/Annotations/DataAnnotationTest.php
@@ -53,7 +53,7 @@ class DataAnnotationTest extends AnnotationTest
         return [
             '_complete' => [
                 'content' => '/**
-                  * @api-data content_rating `G` (enum, nullable, tag:MOVIE_RATINGS) - MPAA rating
+                  * @api-data content_rating `G` (enum, required, nullable, tag:MOVIE_RATINGS) - MPAA rating
                   *  + Members
                   *    - `G`
                   *    - `PG`
@@ -71,6 +71,7 @@ class DataAnnotationTest extends AnnotationTest
                     'description' => 'MPAA rating',
                     'identifier' => 'content_rating',
                     'nullable' => true,
+                    'required' => true,
                     'sample_data' => 'G',
                     'scopes' => [
                         [
@@ -105,6 +106,7 @@ class DataAnnotationTest extends AnnotationTest
                     'description' => 'MPAA rating',
                     'identifier' => 'content_rating',
                     'nullable' => false,
+                    'required' => false,
                     'sample_data' => false,
                     'scopes' => [],
                     'subtype' => false,
@@ -124,6 +126,7 @@ class DataAnnotationTest extends AnnotationTest
                     'description' => 'MPAA rating',
                     'identifier' => 'content_rating',
                     'nullable' => false,
+                    'required' => false,
                     'sample_data' => false,
                     'scopes' => [],
                     'subtype' => false,
@@ -142,6 +145,7 @@ class DataAnnotationTest extends AnnotationTest
                     'description' => 'URL to purchase tickets',
                     'identifier' => 'tickets.url',
                     'nullable' => true,
+                    'required' => false,
                     'sample_data' => false,
                     'scopes' => [],
                     'subtype' => false,
@@ -169,6 +173,7 @@ class DataAnnotationTest extends AnnotationTest
                     'description' => 'MPAA rating',
                     'identifier' => 'content_rating',
                     'nullable' => false,
+                    'required' => false,
                     'sample_data' => 'G',
                     'scopes' => [],
                     'subtype' => false,
@@ -187,6 +192,25 @@ class DataAnnotationTest extends AnnotationTest
                     'version' => false
                 ]
             ],
+            'required' => [
+                'content' => '/**
+                  * @api-data tickets.url (string, required) - URL to purchase tickets
+                  */',
+                'version' => null,
+                'expected' => [
+                    'description' => 'URL to purchase tickets',
+                    'identifier' => 'tickets.url',
+                    'nullable' => false,
+                    'required' => true,
+                    'sample_data' => false,
+                    'scopes' => [],
+                    'subtype' => false,
+                    'type' => 'string',
+                    'values' => [],
+                    'vendor_tags' => [],
+                    'version' => false
+                ]
+            ],
             'scoped' => [
                 'content' => '/**
                   * @api-data tickets.url (string) - URL to purchase tickets
@@ -197,6 +221,7 @@ class DataAnnotationTest extends AnnotationTest
                     'description' => 'URL to purchase tickets',
                     'identifier' => 'tickets.url',
                     'nullable' => false,
+                    'required' => false,
                     'sample_data' => false,
                     'scopes' => [
                         [
@@ -220,6 +245,7 @@ class DataAnnotationTest extends AnnotationTest
                     'description' => 'URL to purchase tickets',
                     'identifier' => 'tickets.url',
                     'nullable' => false,
+                    'required' => false,
                     'sample_data' => false,
                     'scopes' => [],
                     'subtype' => false,
@@ -240,6 +266,7 @@ class DataAnnotationTest extends AnnotationTest
                     'description' => 'Is this user a staff member?',
                     'identifier' => 'is_staff',
                     'nullable' => false,
+                    'required' => false,
                     'sample_data' => '0',
                     'scopes' => [],
                     'subtype' => false,

--- a/tests/Parser/Representation/DocumentationTest.php
+++ b/tests/Parser/Representation/DocumentationTest.php
@@ -73,6 +73,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Cast',
                             'identifier' => 'cast',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [
                                 [
@@ -90,6 +91,7 @@ class DocumentationTest extends TestCase
                             'description' => 'MPAA rating',
                             'identifier' => 'content_rating',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => 'G',
                             'scopes' => [],
                             'subtype' => false,
@@ -110,7 +112,8 @@ class DocumentationTest extends TestCase
                         'description' => [
                             'description' => 'Description',
                             'identifier' => 'description',
-                            'nullable' => false,
+                            'nullable' => true,
+                            'required' => false,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -123,6 +126,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Director',
                             'identifier' => 'director',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [
                                 [
@@ -140,6 +144,7 @@ class DocumentationTest extends TestCase
                             'description' => 'External URLs',
                             'identifier' => 'external_urls',
                             'nullable' => false,
+                            'required' => false,
                             'sample_data' => false,
                             'scopes' => [
                                 [
@@ -157,6 +162,7 @@ class DocumentationTest extends TestCase
                             'description' => 'IMDB URL',
                             'identifier' => 'external_urls.imdb',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [
                                 [
@@ -174,6 +180,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Tickets URL',
                             'identifier' => 'external_urls.tickets',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [
                                 [
@@ -193,6 +200,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Trailer URL',
                             'identifier' => 'external_urls.trailer',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [
                                 [
@@ -210,6 +218,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Genres',
                             'identifier' => 'genres',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => 'uri',
@@ -222,6 +231,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Unique ID',
                             'identifier' => 'id',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -234,6 +244,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Kid friendly?',
                             'identifier' => 'kid_friendly',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => '0',
                             'scopes' => [],
                             'subtype' => false,
@@ -246,6 +257,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Name',
                             'identifier' => 'name',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -257,7 +269,8 @@ class DocumentationTest extends TestCase
                         'purchase.url' => [
                             'description' => 'URL to purchase the film.',
                             'identifier' => 'purchase.url',
-                            'nullable' => false,
+                            'nullable' => true,
+                            'required' => false,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -270,6 +283,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Rotten Tomatoes score',
                             'identifier' => 'rotten_tomatoes_score',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -282,6 +296,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Runtime',
                             'identifier' => 'runtime',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -294,6 +309,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Non-theater specific showtimes',
                             'identifier' => 'showtimes',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -306,6 +322,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Theaters the movie is currently showing in',
                             'identifier' => 'theaters',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => '\Mill\Examples\Showtimes\Representations\Theater',
@@ -318,6 +335,7 @@ class DocumentationTest extends TestCase
                             'description' => 'Movie URI',
                             'identifier' => 'uri',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -333,6 +351,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'Cast',
                                 'identifier' => 'cast',
                                 'nullable' => false,
+                                'required' => true,
                                 'sample_data' => false,
                                 'scopes' => [
                                     [
@@ -352,6 +371,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'MPAA rating',
                                 'identifier' => 'content_rating',
                                 'nullable' => false,
+                                'required' => true,
                                 'sample_data' => 'G',
                                 'scopes' => [],
                                 'subtype' => false,
@@ -374,7 +394,8 @@ class DocumentationTest extends TestCase
                             '__NESTED_DATA__' => [
                                 'description' => 'Description',
                                 'identifier' => 'description',
-                                'nullable' => false,
+                                'nullable' => true,
+                                'required' => false,
                                 'sample_data' => false,
                                 'scopes' => [],
                                 'subtype' => false,
@@ -389,6 +410,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'Director',
                                 'identifier' => 'director',
                                 'nullable' => false,
+                                'required' => true,
                                 'sample_data' => false,
                                 'scopes' => [
                                     [
@@ -408,6 +430,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'External URLs',
                                 'identifier' => 'external_urls',
                                 'nullable' => false,
+                                'required' => false,
                                 'sample_data' => false,
                                 'scopes' => [
                                     [
@@ -426,6 +449,7 @@ class DocumentationTest extends TestCase
                                     'description' => 'IMDB URL',
                                     'identifier' => 'external_urls.imdb',
                                     'nullable' => false,
+                                    'required' => true,
                                     'sample_data' => false,
                                     'scopes' => [
                                         [
@@ -445,6 +469,7 @@ class DocumentationTest extends TestCase
                                     'description' => 'Tickets URL',
                                     'identifier' => 'external_urls.tickets',
                                     'nullable' => false,
+                                    'required' => true,
                                     'sample_data' => false,
                                     'scopes' => [
                                         [
@@ -466,6 +491,7 @@ class DocumentationTest extends TestCase
                                     'description' => 'Trailer URL',
                                     'identifier' => 'external_urls.trailer',
                                     'nullable' => false,
+                                    'required' => true,
                                     'sample_data' => false,
                                     'scopes' => [
                                         [
@@ -486,6 +512,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'Genres',
                                 'identifier' => 'genres',
                                 'nullable' => false,
+                                'required' => true,
                                 'sample_data' => false,
                                 'scopes' => [],
                                 'subtype' => 'uri',
@@ -500,6 +527,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'Unique ID',
                                 'identifier' => 'id',
                                 'nullable' => false,
+                                'required' => true,
                                 'sample_data' => false,
                                 'scopes' => [],
                                 'subtype' => false,
@@ -514,6 +542,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'Kid friendly?',
                                 'identifier' => 'kid_friendly',
                                 'nullable' => false,
+                                'required' => true,
                                 'sample_data' => '0',
                                 'scopes' => [],
                                 'subtype' => false,
@@ -528,6 +557,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'Name',
                                 'identifier' => 'name',
                                 'nullable' => false,
+                                'required' => true,
                                 'sample_data' => false,
                                 'scopes' => [],
                                 'subtype' => false,
@@ -542,7 +572,8 @@ class DocumentationTest extends TestCase
                                 '__NESTED_DATA__' => [
                                     'description' => 'URL to purchase the film.',
                                     'identifier' => 'purchase.url',
-                                    'nullable' => false,
+                                    'nullable' => true,
+                                    'required' => false,
                                     'sample_data' => false,
                                     'scopes' => [],
                                     'subtype' => false,
@@ -558,6 +589,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'Rotten Tomatoes score',
                                 'identifier' => 'rotten_tomatoes_score',
                                 'nullable' => false,
+                                'required' => true,
                                 'sample_data' => false,
                                 'scopes' => [],
                                 'subtype' => false,
@@ -572,6 +604,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'Runtime',
                                 'identifier' => 'runtime',
                                 'nullable' => false,
+                                'required' => true,
                                 'sample_data' => false,
                                 'scopes' => [],
                                 'subtype' => false,
@@ -586,6 +619,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'Non-theater specific showtimes',
                                 'identifier' => 'showtimes',
                                 'nullable' => false,
+                                'required' => true,
                                 'sample_data' => false,
                                 'scopes' => [],
                                 'subtype' => false,
@@ -600,6 +634,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'Theaters the movie is currently showing in',
                                 'identifier' => 'theaters',
                                 'nullable' => false,
+                                'required' => true,
                                 'sample_data' => false,
                                 'scopes' => [],
                                 'subtype' => '\Mill\Examples\Showtimes\Representations\Theater',
@@ -614,6 +649,7 @@ class DocumentationTest extends TestCase
                                 'description' => 'Movie URI',
                                 'identifier' => 'uri',
                                 'nullable' => false,
+                                'required' => true,
                                 'sample_data' => false,
                                 'scopes' => [],
                                 'subtype' => false,

--- a/tests/Parser/Representation/RepresentationParserTest.php
+++ b/tests/Parser/Representation/RepresentationParserTest.php
@@ -188,6 +188,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Cast',
                             'identifier' => 'cast',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [
                                 [
@@ -205,6 +206,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'MPAA rating',
                             'identifier' => 'content_rating',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => 'G',
                             'scopes' => [],
                             'subtype' => false,
@@ -225,7 +227,8 @@ class RepresentationParserTest extends TestCase
                         'description' => [
                             'description' => 'Description',
                             'identifier' => 'description',
-                            'nullable' => false,
+                            'nullable' => true,
+                            'required' => false,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -238,6 +241,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Director',
                             'identifier' => 'director',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [
                                 [
@@ -255,6 +259,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'External URLs',
                             'identifier' => 'external_urls',
                             'nullable' => false,
+                            'required' => false,
                             'sample_data' => false,
                             'scopes' => [
                                 [
@@ -272,6 +277,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'IMDB URL',
                             'identifier' => 'external_urls.imdb',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [
                                 [
@@ -289,6 +295,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Tickets URL',
                             'identifier' => 'external_urls.tickets',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [
                                 [
@@ -308,6 +315,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Trailer URL',
                             'identifier' => 'external_urls.trailer',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [
                                 [
@@ -325,6 +333,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Genres',
                             'identifier' => 'genres',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => 'uri',
@@ -337,6 +346,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Unique ID',
                             'identifier' => 'id',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -349,6 +359,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Kid friendly?',
                             'identifier' => 'kid_friendly',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => '0',
                             'scopes' => [],
                             'subtype' => false,
@@ -361,6 +372,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Name',
                             'identifier' => 'name',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -372,7 +384,8 @@ class RepresentationParserTest extends TestCase
                         'purchase.url' => [
                             'description' => 'URL to purchase the film.',
                             'identifier' => 'purchase.url',
-                            'nullable' => false,
+                            'nullable' => true,
+                            'required' => false,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -385,6 +398,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Rotten Tomatoes score',
                             'identifier' => 'rotten_tomatoes_score',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -397,6 +411,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Runtime',
                             'identifier' => 'runtime',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -409,6 +424,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Non-theater specific showtimes',
                             'identifier' => 'showtimes',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,
@@ -421,6 +437,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Theaters the movie is currently showing in',
                             'identifier' => 'theaters',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => '\Mill\Examples\Showtimes\Representations\Theater',
@@ -433,6 +450,7 @@ class RepresentationParserTest extends TestCase
                             'description' => 'Movie URI',
                             'identifier' => 'uri',
                             'nullable' => false,
+                            'required' => true,
                             'sample_data' => false,
                             'scopes' => [],
                             'subtype' => false,


### PR DESCRIPTION
This adds `required|optional` flag support to `@api-data` annotations. This was previously documented as supported, but it wasn't actually. 

These flags are also now cascading into compiled OpenAPI and API Blueprint specifications.