### PR TITLE
Adding vendor tag and private doc filters to the Compile command.

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -19,6 +19,8 @@ class Command extends \Symfony\Component\Console\Command\Command
      */
     protected function configure()
     {
+        parent::configure();
+
         $this->addOption(
             'config',
             null,

--- a/src/Command/BaseCompiler.php
+++ b/src/Command/BaseCompiler.php
@@ -1,0 +1,74 @@
+<?php
+namespace Mill\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class BaseCompiler extends \Mill\Command
+{
+    /** @var string $output_dir */
+    protected $output_dir;
+
+    /** @var bool */
+    protected $private_docs;
+
+    /** @var null|array */
+    protected $vendor_tags = null;
+
+    /**
+     * @return void
+     */
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->addOption(
+            'private',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            "Flag designating if you want to include documentation that's marked as private.",
+            true
+        );
+
+        $this->addOption(
+            'vendor_tag',
+            null,
+            InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
+            'The name of a vendor tag if you want to incorporate documentation that includes vendor tag-bound ' .
+                'annotations documentation.'
+        );
+
+        $this->addArgument('output', InputArgument::REQUIRED, 'Directory to output into.');
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        parent::execute($input, $output);
+
+        /** @var array|null $vendor_tags */
+        $vendor_tags = $input->getOption('vendor_tag');
+        $this->vendor_tags = (!empty($vendor_tags)) ? $vendor_tags : null;
+
+        /** @var string $output_dir */
+        $output_dir = $input->getArgument('output');
+        $this->output_dir = realpath($output_dir);
+
+        $private_docs = $input->getOption('private');
+        if (is_bool($private_docs) && $private_docs === true) {
+            $this->private_docs = true;
+        } elseif (is_string($private_docs) && strtolower($private_docs) == 'true') {
+            $this->private_docs = true;
+        } else {
+            $this->private_docs = false;
+        }
+
+        return 0;
+    }
+}

--- a/src/Command/Changelog.php
+++ b/src/Command/Changelog.php
@@ -1,14 +1,11 @@
 <?php
 namespace Mill\Command;
 
-use Mill\Config;
 use Mill\Compiler;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class Changelog extends \Mill\Command
+class Changelog extends BaseCompiler
 {
     /**
      * @return void
@@ -18,26 +15,7 @@ class Changelog extends \Mill\Command
         parent::configure();
 
         $this->setName('changelog')
-            ->setDescription('Compiles a changelog from your API documentation.')
-            ->addOption(
-                'private',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Flag designating if you want to compile a changelog that includes private documentation.',
-                true
-            )
-            ->addOption(
-                'vendor_tag',
-                null,
-                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-                'The name of a vendor tag if you want to compile a changelog that includes vendor tag-bound ' .
-                    'documentation.'
-            )
-            ->addArgument(
-                'output',
-                InputArgument::REQUIRED,
-                'Directory to output your compiled `changelog.md` file in.'
-            );
+            ->setDescription('Compiles a changelog from your API documentation.');
     }
 
     /**
@@ -50,34 +28,17 @@ class Changelog extends \Mill\Command
     {
         parent::execute($input, $output);
 
-        /** @var array|null $vendor_tags */
-        $vendor_tags = $input->getOption('vendor_tag');
-        $vendor_tags = (!empty($vendor_tags)) ? $vendor_tags : null;
-
-        /** @var string $output_dir */
-        $output_dir = $input->getArgument('output');
-        $output_dir = realpath($output_dir);
-
-        $private_docs = $input->getOption('private');
-        if (is_bool($private_docs) && $private_docs === true) {
-            $private_docs = true;
-        } elseif (is_string($private_docs) && strtolower($private_docs) == 'true') {
-            $private_docs = true;
-        } else {
-            $private_docs = false;
-        }
-
         /** @var \League\Flysystem\Filesystem $filesystem */
         $filesystem = $this->container['filesystem'];
 
         $output->writeln('<comment>Compiling a changelog...</comment>');
 
         $changelog = new Compiler\Changelog($this->app);
-        $changelog->setLoadPrivateDocs($private_docs);
-        $changelog->setLoadVendorTagDocs($vendor_tags);
+        $changelog->setLoadPrivateDocs($this->private_docs);
+        $changelog->setLoadVendorTagDocs($this->vendor_tags);
         $markdown = $changelog->toMarkdown();
 
-        $filesystem->put($output_dir . DIRECTORY_SEPARATOR . 'changelog.md', trim($markdown));
+        $filesystem->put($this->output_dir . DIRECTORY_SEPARATOR . 'changelog.md', trim($markdown));
 
         $output->writeln(['', '<success>Done!</success>']);
 

--- a/src/Command/ErrorMap.php
+++ b/src/Command/ErrorMap.php
@@ -4,12 +4,11 @@ namespace Mill\Command;
 use Mill\Compiler;
 use Mill\Exceptions\Version\UnrecognizedSchemaException;
 use Mill\Parser\Version;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ErrorMap extends \Mill\Command
+class ErrorMap extends BaseCompiler
 {
     /**
      * @return void
@@ -34,22 +33,7 @@ class ErrorMap extends \Mill\Command
                 'Compile just the configured default API version documentation. `defaultApiVersion` in your ' .
                     '`mill.xml` file.',
                 false
-            )
-            ->addOption(
-                'private',
-                null,
-                InputOption::VALUE_OPTIONAL,
-                'Flag designating if you want to compile an error map that includes private error documentation.',
-                true
-            )
-            ->addOption(
-                'vendor_tag',
-                null,
-                InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
-                'The name of a vendor tag if you want to compile an error map that includes vendor tag-bound error' .
-                    'documentation.'
-            )
-            ->addArgument('output', InputArgument::REQUIRED, 'Directory to output your compiled `errors.md` file in.');
+            );
     }
 
     /**
@@ -63,23 +47,6 @@ class ErrorMap extends \Mill\Command
         parent::execute($input, $output);
 
         $version = $input->getOption('constraint');
-
-        /** @var array|null $vendor_tags */
-        $vendor_tags = $input->getOption('vendor_tag');
-        $vendor_tags = (!empty($vendor_tags)) ? $vendor_tags : null;
-
-        /** @var string $output_dir */
-        $output_dir = $input->getArgument('output');
-        $output_dir = realpath($output_dir);
-
-        $private_docs = $input->getOption('private');
-        if (is_bool($private_docs) && $private_docs === true) {
-            $private_docs = true;
-        } elseif (is_string($private_docs) && strtolower($private_docs) == 'true') {
-            $private_docs = true;
-        } else {
-            $private_docs = false;
-        }
 
         if ($input->getOption('default')) {
             $version = $this->container['config']->getDefaultApiVersion();
@@ -101,15 +68,15 @@ class ErrorMap extends \Mill\Command
         $output->writeln('<comment>Compiling an error map...</comment>');
 
         $error_map = new Compiler\ErrorMap($this->app, $version);
-        $error_map->setLoadPrivateDocs($private_docs);
-        $error_map->setLoadVendorTagDocs($vendor_tags);
+        $error_map->setLoadPrivateDocs($this->private_docs);
+        $error_map->setLoadVendorTagDocs($this->vendor_tags);
         $markdown = $error_map->toMarkdown();
 
         foreach ($markdown as $version => $content) {
             $output->writeLn('<comment> - API version: ' . $version . '</comment>');
 
             $filesystem->put(
-                $output_dir . DIRECTORY_SEPARATOR . $version . DIRECTORY_SEPARATOR . 'errors.md',
+                $this->output_dir . DIRECTORY_SEPARATOR . $version . DIRECTORY_SEPARATOR . 'errors.md',
                 trim($content)
             );
         }


### PR DESCRIPTION
This brings the `compile` command to public/private/vendor tag filter parity with the `changelog` command.

Resolves #198 