### PR TITLE
Fixing a bug where the FQN parser would see `::class` as a class name.

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1048,12 +1048,12 @@ class Config
                         break;
 
                     case T_CLASS:
-                        for ($j=$i+1; $j<count($tokens); $j++) {
-                            if ($tokens[$j] === '{') {
-                                $class = $tokens[$i+2][1];
-                            }
-                        }
+                        $class = $tokens[$i+2][1];
                         break;
+                }
+
+                if (!empty($namespace) && !empty($class)) {
+                    break;
                 }
             }
 


### PR DESCRIPTION
This fixes a bug in the FQN parser where it would sometimes interpret lines that contained `ClassName::class` as the name of a resource or representation we're loading.