### PR TITLE
Adding a new `for_public_consumption` argument to the compiler command.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,9 +54,11 @@
     },
     "scripts": {
         "build-docs-apiblueprint": [
+            "./bin/mill compile --config=resources/examples/mill.xml --format=apiblueprint --for_public_consumption=true resources/examples/Showtimes/compiled/public/",
             "./bin/mill compile --config=resources/examples/mill.xml --format=apiblueprint resources/examples/Showtimes/compiled/"
         ],
         "build-docs-openapi": [
+            "./bin/mill compile --config=resources/examples/mill.xml --format=openapi --for_public_consumption=true resources/examples/Showtimes/compiled/public/",
             "./bin/mill compile --config=resources/examples/mill.xml --format=openapi resources/examples/Showtimes/compiled/"
         ],
         "build-changelogs": [
@@ -95,6 +97,7 @@
         "build-resources": [
             "rm -rf resources/examples/Showtimes/compiled",
             "mkdir resources/examples/Showtimes/compiled",
+            "mkdir resources/examples/Showtimes/compiled/public",
             "composer build-docs-apiblueprint",
             "composer build-docs-openapi",
             "composer build-changelogs",

--- a/resources/examples/Showtimes/compiled/public/1.0/api.apib
+++ b/resources/examples/Showtimes/compiled/public/1.0/api.apib
@@ -1,0 +1,191 @@
+FORMAT: 1A
+
+# Mill unit test API, Showtimes
+This is the API Blueprint file for Mill unit test API, Showtimes.
+
+# Group Movies
+## Movies [/movies/{id}]
+
+### Get a single movie. [GET]
+Return information on a specific movie.
+
+Donec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem
+ipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis
+mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta
+sem malesuada magna mollis euismod.
+
+```
+[
+  {"id": "fizzbuzz"}
+]
+```
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Response 200 (application/json)
+    + Attributes (Movie)
++ Response 304 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
+
+## Movies [/movies]
+
+### Get movies. [GET]
+Returns all movies for a specific location.
+
++ Request
+    + Attributes
+        - `location` (string, required) - Location you want movies for.
++ Response 200 (application/json)
+    + Attributes (array[Movie])
++ Response 400 (application/json)
+    + Attributes (Error)
+
+### Create a movie. [POST]
+Create a new movie.
+
+This action requires a bearer token with the `create` scope.
+
++ Request
+    + Attributes
+        - `cast` (array) - Array of cast members.
+             - (object)
+                - `name`: `Natasha Hovey` (string) - Cast member name.
+                - `role`: `Cheryl` (string) - Cast member role.
+        - `content_rating`: `NR` (enum[string]) - MPAA rating
+            + Members
+                + `G` - Rated G
+                + `NC-17` - Rated NC-17
+                + `NR` - Not rated
+                + `PG` - Rated PG
+                + `PG-13` - Rated PG-13
+                + `R` - Rated R
+                + `UR` - Unrated
+                + `X` - Rated X
+        - `description` (string, required) - Description, or tagline, for the movie.
+        - `director`: `Lamberto Bava` (string) - Name of the director.
+        - `genres` (array[string]) - Array of movie genres.
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
+        - `name`: `Demons` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score`: `56` (number) - Rotten Tomatoes score
+        - `runtime`: `1hr 20min` (string) - Movie runtime, in `HHhr MMmin` format.
++ Response 200 (application/json)
+    + Attributes (Movie)
++ Response 400 (application/json)
+    There are two ways that this status code can be encountered:
+         * If there is a problem with the request.
+         * If the IMDB URL could not be validated.
+    + Attributes (Error)
+
+# Group Theaters
+## Theaters [/theaters/{id}]
+
+### Get a single movie theater. [GET]
+Return information on a specific movie theater.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 200 (application/json)
+    + Attributes (Theater)
++ Response 304 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
+
+### Update a movie theater. [PATCH]
+Update a movie theaters' data.
+
+This action requires a bearer token with the `create` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Request
+    + Attributes
+        - `address`: `2548 Central Park Ave, Yonkers, NY 10710` (string, required) - Theater address
+        - `name`: `Alamo Drafthouse Cinema - Yonkers` (string, required) - Name of the theater.
+        - `phone_number`: `(914) 226-3082` (string, required) - Theater phone number
++ Response 200 (application/json)
+    + Attributes (Theater)
++ Response 400 (application/json)
+    + Attributes (Error)
++ Response 403 (application/json)
+    + Attributes (Coded error)
++ Response 404 (application/json)
+    + Attributes (Error)
+
+## Theaters [/theaters]
+
+### Get movie theaters. [GET]
+Returns all movie theatres for a specific location.
+
++ Request
+    + Attributes
+        - `location` (string, required) - Location you want theaters in.
++ Response 200 (application/json)
+    + Attributes (array[Theater])
++ Response 400 (application/json)
+    + Attributes (Error)
+
+### Create a movie theater. [POST]
+Create a new movie theater.
+
+This action requires a bearer token with the `create` scope.
+
++ Request
+    + Attributes
+        - `address`: `2548 Central Park Ave, Yonkers, NY 10710` (string, required) - Theater address
+        - `name`: `Alamo Drafthouse Cinema - Yonkers` (string, required) - Name of the theater.
+        - `phone_number`: `(914) 226-3082` (string, required) - Theater phone number
++ Response 200 (application/json)
+    + Attributes (Theater)
++ Response 400 (application/json)
+    + Attributes (Error)
+
+# Data Structures
+## Coded error
+- `error` (string, required) - User-friendly error message
+- `error_code` (number, required) - Error code
+
+## Error
+- `error` (string, required) - User-friendly error message
+
+## Movie
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
+    + Members
+        + `G`
+        + `NC-17`
+        + `NR`
+        + `PG`
+        + `PG-13`
+        + `R`
+        + `UR`
+        + `X`
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
+- `purchase` (object)
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array[string], required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI
+
+## Person
+- `id` (number, required) - Unique ID
+- `imdb` (string, required) - IMDB URL
+- `name` (string, required) - Name
+- `uri` (string, required) - Person URI
+
+## Theater
+- `address` (string, required) - Address
+- `id` (number, required) - Unique ID
+- `movies` (array[Movie], required) - Movies currently playing
+- `name` (string, required) - Name
+- `phone_number` (string, required) - Phone number
+- `showtimes` (array[string], required) - Non-movie specific showtimes
+- `uri` (string, required) - Theater URI
+- `website` (string, required) - Website

--- a/resources/examples/Showtimes/compiled/public/1.0/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.0/api.yaml
@@ -1,0 +1,544 @@
+openapi: 3.0.0
+info:
+  title: 'Mill unit test API, Showtimes'
+  version: '1.0'
+  contact:
+    name: 'Get help!'
+    email: support@example.com
+    url: 'https://developer.example.com/help'
+tags:
+  -
+    name: Movies
+  -
+    name: Theaters
+servers:
+  -
+    url: 'https://api.example.com'
+    description: Production
+  -
+    url: 'https://api.example.local'
+    description: Development
+paths:
+  /movies:
+    get:
+      summary: 'Get movies.'
+      description: 'Returns all movies for a specific location.'
+      operationId: getMovies
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Location you want movies for.'
+          in: query
+          name: location
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/movie'
+        400:
+          description: 'If the location is invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    post:
+      summary: 'Create a movie.'
+      description: 'Create a new movie.'
+      operationId: createMovie
+      tags:
+        - Movies
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cast:
+                  description: 'Array of cast members.'
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: 'Cast member name.'
+                        example: 'Natasha Hovey'
+                        type: string
+                      role:
+                        description: 'Cast member role.'
+                        example: Cheryl
+                        type: string
+                  type: array
+                content_rating:
+                  description: "MPAA rating\n\nOption descriptions:\n * `G` - Rated G\n * `NC-17` - Rated NC-17\n * `NR` - Not rated\n * `PG` - Rated PG\n * `PG-13` - Rated PG-13\n * `R` - Rated R\n * `UR` - Unrated\n * `X` - Rated X\n"
+                  enum:
+                    - G
+                    - NC-17
+                    - NR
+                    - PG
+                    - PG-13
+                    - R
+                    - UR
+                    - X
+                  example: NR
+                  type: string
+                description:
+                  description: 'Description, or tagline, for the movie.'
+                  type: string
+                director:
+                  description: 'Name of the director.'
+                  example: 'Lamberto Bava'
+                  type: string
+                genres:
+                  description: 'Array of movie genres.'
+                  items:
+                    type: string
+                  type: array
+                is_kid_friendly:
+                  description: 'Is this movie kid friendly?'
+                  type: boolean
+                name:
+                  description: 'Name of the movie.'
+                  example: Demons
+                  type: string
+                rotten_tomatoes_score:
+                  description: 'Rotten Tomatoes score'
+                  example: '56'
+                  type: number
+                runtime:
+                  description: 'Movie runtime, in `HHhr MMmin` format.'
+                  example: '1hr 20min'
+                  type: string
+              required:
+                - description
+                - name
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        400:
+          description: "There are two ways that this status code can be encountered:\n * If there is a problem with the request.\n * If the IMDB URL could not be validated."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - create
+  '/movies/{id}':
+    get:
+      summary: 'Get a single movie.'
+      description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
+      operationId: getMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        304:
+          description: 'If no content has been modified since the supplied Last-Modified header.'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+  /theaters:
+    get:
+      summary: 'Get movie theaters.'
+      description: 'Returns all movie theatres for a specific location.'
+      operationId: getTheaters
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Location you want theaters in.'
+          in: query
+          name: location
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/theater'
+        400:
+          description: 'If the location is invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    post:
+      summary: 'Create a movie theater.'
+      description: 'Create a new movie theater.'
+      operationId: createTheater
+      tags:
+        - Theaters
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                address:
+                  description: 'Theater address'
+                  example: '2548 Central Park Ave, Yonkers, NY 10710'
+                  type: string
+                name:
+                  description: 'Name of the theater.'
+                  example: 'Alamo Drafthouse Cinema - Yonkers'
+                  type: string
+                phone_number:
+                  description: 'Theater phone number'
+                  example: '(914) 226-3082'
+                  type: string
+              required:
+                - address
+                - name
+                - phone_number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        400:
+          description: 'If there is a problem with the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - create
+  '/theaters/{id}':
+    get:
+      summary: 'Get a single movie theater.'
+      description: 'Return information on a specific movie theater.'
+      operationId: getTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        304:
+          description: 'If no content has been modified since the supplied Last-Modified header.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    patch:
+      summary: 'Update a movie theater.'
+      description: 'Update a movie theaters'' data.'
+      operationId: updateTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                address:
+                  description: 'Theater address'
+                  example: '2548 Central Park Ave, Yonkers, NY 10710'
+                  type: string
+                name:
+                  description: 'Name of the theater.'
+                  example: 'Alamo Drafthouse Cinema - Yonkers'
+                  type: string
+                phone_number:
+                  description: 'Theater phone number'
+                  example: '(914) 226-3082'
+                  type: string
+              required:
+                - address
+                - name
+                - phone_number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        400:
+          description: 'If there is a problem with the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        404:
+          description: 'If the movie movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        403:
+          description: 'If something cool happened. Returns a unique error code of `1337`.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/coded-error'
+      security:
+        -
+          oauth2:
+            - create
+components:
+  securitySchemes:
+    bearer:
+      type: http
+      scheme: bearer
+      bearerFormat: bearer
+    oauth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: /oauth/authorize
+          tokenUrl: /oauth/access_token
+          scopes:
+            create: Create
+            delete: Delete
+            edit: Edit
+            public: Public
+        clientCredentials:
+          tokenUrl: /oauth/authorize/client
+          scopes:
+            create: Create
+            delete: Delete
+            edit: Edit
+            public: Public
+  schemas:
+    coded-error:
+      title: 'Coded error'
+      properties:
+        error:
+          description: 'User-friendly error message'
+          type: string
+        error_code:
+          description: 'Error code'
+          type: number
+      required:
+        - error
+        - error_code
+      type: object
+    error:
+      title: Error
+      properties:
+        error:
+          description: 'User-friendly error message'
+          type: string
+      required:
+        - error
+      type: object
+    movie:
+      title: Movie
+      properties:
+        cast:
+          description: 'Cast. This data requires a bearer token with the `public` scope.'
+          items:
+            $ref: '#/components/schemas/person'
+          type: array
+        content_rating:
+          description: 'MPAA rating'
+          enum:
+            - G
+            - NC-17
+            - NR
+            - PG
+            - PG-13
+            - R
+            - UR
+            - X
+          example: G
+          type: string
+        description:
+          description: Description
+          nullable: true
+          type: string
+        director:
+          allOf:
+            -
+              $ref: '#/components/schemas/person'
+          description: 'Director. This data requires a bearer token with the `public` scope.'
+        genres:
+          description: Genres
+          items:
+            type: string
+          type: array
+        id:
+          description: 'Unique ID'
+          type: number
+        kid_friendly:
+          description: 'Kid friendly?'
+          example: 'false'
+          type: boolean
+        name:
+          description: Name
+          type: string
+        purchase:
+          properties:
+            url:
+              description: 'URL to purchase the film.'
+              nullable: true
+              type: string
+          type: object
+        rotten_tomatoes_score:
+          description: 'Rotten Tomatoes score'
+          type: number
+        runtime:
+          description: Runtime
+          type: string
+        showtimes:
+          description: 'Non-theater specific showtimes'
+          items:
+            type: string
+          type: array
+        theaters:
+          description: 'Theaters the movie is currently showing in'
+          items:
+            $ref: '#/components/schemas/theater'
+          type: array
+        uri:
+          description: 'Movie URI'
+          type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
+    person:
+      title: Person
+      properties:
+        id:
+          description: 'Unique ID'
+          type: number
+        imdb:
+          description: 'IMDB URL'
+          type: string
+        name:
+          description: Name
+          type: string
+        uri:
+          description: 'Person URI'
+          type: string
+      required:
+        - id
+        - imdb
+        - name
+        - uri
+      type: object
+    theater:
+      title: Theater
+      properties:
+        address:
+          description: Address
+          type: string
+        id:
+          description: 'Unique ID'
+          type: number
+        movies:
+          description: 'Movies currently playing'
+          items:
+            $ref: '#/components/schemas/movie'
+          type: array
+        name:
+          description: Name
+          type: string
+        phone_number:
+          description: 'Phone number'
+          type: string
+        showtimes:
+          description: 'Non-movie specific showtimes'
+          items:
+            type: string
+          type: array
+        uri:
+          description: 'Theater URI'
+          type: string
+        website:
+          description: Website
+          type: string
+      required:
+        - address
+        - id
+        - movies
+        - name
+        - phone_number
+        - showtimes
+        - uri
+        - website
+      type: object
+security:
+  -
+    oauth2:
+      - create
+      - delete
+      - edit
+      - public

--- a/resources/examples/Showtimes/compiled/public/1.1.1/api.apib
+++ b/resources/examples/Showtimes/compiled/public/1.1.1/api.apib
@@ -1,0 +1,240 @@
+FORMAT: 1A
+
+# Mill unit test API, Showtimes
+This is the API Blueprint file for Mill unit test API, Showtimes.
+
+# Group Movies
+## Movies [/movies/{id}]
+
+### Get a single movie. [GET]
+Return information on a specific movie.
+
+Donec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem
+ipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis
+mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta
+sem malesuada magna mollis euismod.
+
+```
+[
+  {"id": "fizzbuzz"}
+]
+```
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Response 200 (application/json)
+    + Attributes (Movie)
++ Response 304 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
+
+### Update a movie. [PATCH]
+Update a movies data.
+
+This action requires a bearer token with the `edit` scope.
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Request
+    + Attributes
+        - `cast` (array) - Array of cast members.
+             - (object)
+                - `name`: `Natasha Hovey` (string) - Cast member name.
+                - `role`: `Cheryl` (string) - Cast member role.
+        - `content_rating`: `NR` (enum[string]) - MPAA rating
+            + Members
+                + `G` - Rated G
+                + `NC-17` - Rated NC-17
+                + `NR` - Not rated
+                + `PG` - Rated PG
+                + `PG-13` - Rated PG-13
+                + `R` - Rated R
+                + `UR` - Unrated
+                + `X` - Rated X
+        - `description` (string, required) - Description, or tagline, for the movie.
+        - `director`: `Lamberto Bava` (string) - Name of the director.
+        - `genres` (array[string]) - Array of movie genres.
+        - `imdb`: `https://www.imdb.com/title/tt0089013/` (string) - IMDB URL
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
+        - `name`: `Demons` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score`: `56` (number) - Rotten Tomatoes score
+        - `runtime`: `1hr 20min` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `trailer`: `https://www.youtube.com/watch?v=_cNjTdFHL8E` (string, nullable) - Trailer URL
++ Response 200 (application/json)
+    + Attributes (Movie)
++ Response 400 (application/json)
+    There are two ways that this status code can be encountered:
+         * If there is a problem with the request.
+         * If the IMDB URL could not be validated.
+    + Attributes (Error)
++ Response 404 (application/json)
+    + Attributes (Error)
+
+## Movies [/movies]
+
+### Get movies. [GET]
+Returns all movies for a specific location.
+
++ Request
+    + Attributes
+        - `location` (string, required) - Location you want movies for.
+        - `page` (number) - Page of results to pull.
++ Response 200 (application/json)
+    + Attributes (array[Movie])
++ Response 400 (application/json)
+    + Attributes (Error)
+
+### Create a movie. [POST]
+Create a new movie.
+
+This action requires a bearer token with the `create` scope.
+
++ Request
+    + Attributes
+        - `cast` (array) - Array of cast members.
+             - (object)
+                - `name`: `Natasha Hovey` (string) - Cast member name.
+                - `role`: `Cheryl` (string) - Cast member role.
+        - `content_rating`: `NR` (enum[string]) - MPAA rating
+            + Members
+                + `G` - Rated G
+                + `NC-17` - Rated NC-17
+                + `NR` - Not rated
+                + `PG` - Rated PG
+                + `PG-13` - Rated PG-13
+                + `R` - Rated R
+                + `UR` - Unrated
+                + `X` - Rated X
+        - `description` (string, required) - Description, or tagline, for the movie.
+        - `director`: `Lamberto Bava` (string) - Name of the director.
+        - `genres` (array[string]) - Array of movie genres.
+        - `imdb`: `https://www.imdb.com/title/tt0089013/` (string) - IMDB URL
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
+        - `name`: `Demons` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score`: `56` (number) - Rotten Tomatoes score
+        - `runtime`: `1hr 20min` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `trailer`: `https://www.youtube.com/watch?v=_cNjTdFHL8E` (string, nullable) - Trailer URL
++ Response 200 (application/json)
+    + Attributes (Movie)
++ Response 400 (application/json)
+    There are two ways that this status code can be encountered:
+         * If there is a problem with the request.
+         * If the IMDB URL could not be validated.
+    + Attributes (Error)
+
+# Group Theaters
+## Theaters [/theaters/{id}]
+
+### Get a single movie theater. [GET]
+Return information on a specific movie theater.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 200 (application/json)
+    + Attributes (Theater)
++ Response 304 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
+
+### Update a movie theater. [PATCH]
+Update a movie theaters' data.
+
+This action requires a bearer token with the `create` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Request
+    + Attributes
+        - `address`: `2548 Central Park Ave, Yonkers, NY 10710` (string, required) - Theater address
+        - `name`: `Alamo Drafthouse Cinema - Yonkers` (string, required) - Name of the theater.
+        - `phone_number`: `(914) 226-3082` (string, required) - Theater phone number
++ Response 200 (application/json)
+    + Attributes (Theater)
++ Response 400 (application/json)
+    + Attributes (Error)
++ Response 403 (application/json)
+    + Attributes (Coded error)
++ Response 404 (application/json)
+    + Attributes (Error)
+
+## Theaters [/theaters]
+
+### Get movie theaters. [GET]
+Returns all movie theatres for a specific location.
+
++ Request
+    + Attributes
+        - `location` (string, required) - Location you want theaters in.
++ Response 200 (application/json)
+    + Attributes (array[Theater])
++ Response 400 (application/json)
+    + Attributes (Error)
+
+### Create a movie theater. [POST]
+Create a new movie theater.
+
+This action requires a bearer token with the `create` scope.
+
++ Request
+    + Attributes
+        - `address`: `2548 Central Park Ave, Yonkers, NY 10710` (string, required) - Theater address
+        - `name`: `Alamo Drafthouse Cinema - Yonkers` (string, required) - Name of the theater.
+        - `phone_number`: `(914) 226-3082` (string, required) - Theater phone number
++ Response 200 (application/json)
+    + Attributes (Theater)
++ Response 400 (application/json)
+    + Attributes (Error)
+
+# Data Structures
+## Coded error
+- `error` (string, required) - User-friendly error message
+- `error_code` (number, required) - Error code
+
+## Error
+- `error` (string, required) - User-friendly error message
+
+## Movie
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
+    + Members
+        + `G`
+        + `NC-17`
+        + `NR`
+        + `PG`
+        + `PG-13`
+        + `R`
+        + `UR`
+        + `X`
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
+- `external_urls` (array) - External URLs. This data requires a bearer token with the `public` scope.
+     - (object)
+        - `imdb` (string, required) - IMDB URL. This data requires a bearer token with the `public` scope.
+        - `tickets` (string, required) - Tickets URL. This data requires a bearer token with the `public` scope.
+        - `trailer` (string, required) - Trailer URL. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
+- `purchase` (object)
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array[string], required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI
+
+## Person
+- `id` (number, required) - Unique ID
+- `imdb` (string, required) - IMDB URL
+- `name` (string, required) - Name
+- `uri` (string, required) - Person URI
+
+## Theater
+- `address` (string, required) - Address
+- `id` (number, required) - Unique ID
+- `movies` (array[Movie], required) - Movies currently playing
+- `name` (string, required) - Name
+- `phone_number` (string, required) - Phone number
+- `showtimes` (array[string], required) - Non-movie specific showtimes
+- `uri` (string, required) - Theater URI

--- a/resources/examples/Showtimes/compiled/public/1.1.1/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.1.1/api.yaml
@@ -1,0 +1,686 @@
+openapi: 3.0.0
+info:
+  title: 'Mill unit test API, Showtimes'
+  version: 1.1.1
+  contact:
+    name: 'Get help!'
+    email: support@example.com
+    url: 'https://developer.example.com/help'
+tags:
+  -
+    name: Movies
+  -
+    name: Theaters
+servers:
+  -
+    url: 'https://api.example.com'
+    description: Production
+  -
+    url: 'https://api.example.local'
+    description: Development
+paths:
+  /movies:
+    get:
+      summary: 'Get movies.'
+      description: 'Returns all movies for a specific location.'
+      operationId: getMovies
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Location you want movies for.'
+          in: query
+          name: location
+          required: true
+          schema:
+            type: string
+        -
+          description: 'Page of results to pull.'
+          in: query
+          name: page
+          required: false
+          schema:
+            type: number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/movie'
+        400:
+          description: 'If the location is invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    post:
+      summary: 'Create a movie.'
+      description: 'Create a new movie.'
+      operationId: createMovie
+      tags:
+        - Movies
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cast:
+                  description: 'Array of cast members.'
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: 'Cast member name.'
+                        example: 'Natasha Hovey'
+                        type: string
+                      role:
+                        description: 'Cast member role.'
+                        example: Cheryl
+                        type: string
+                  type: array
+                content_rating:
+                  description: "MPAA rating\n\nOption descriptions:\n * `G` - Rated G\n * `NC-17` - Rated NC-17\n * `NR` - Not rated\n * `PG` - Rated PG\n * `PG-13` - Rated PG-13\n * `R` - Rated R\n * `UR` - Unrated\n * `X` - Rated X\n"
+                  enum:
+                    - G
+                    - NC-17
+                    - NR
+                    - PG
+                    - PG-13
+                    - R
+                    - UR
+                    - X
+                  example: NR
+                  type: string
+                description:
+                  description: 'Description, or tagline, for the movie.'
+                  type: string
+                director:
+                  description: 'Name of the director.'
+                  example: 'Lamberto Bava'
+                  type: string
+                genres:
+                  description: 'Array of movie genres.'
+                  items:
+                    type: string
+                  type: array
+                imdb:
+                  description: 'IMDB URL'
+                  example: 'https://www.imdb.com/title/tt0089013/'
+                  type: string
+                is_kid_friendly:
+                  description: 'Is this movie kid friendly?'
+                  type: boolean
+                name:
+                  description: 'Name of the movie.'
+                  example: Demons
+                  type: string
+                rotten_tomatoes_score:
+                  description: 'Rotten Tomatoes score'
+                  example: '56'
+                  type: number
+                runtime:
+                  description: 'Movie runtime, in `HHhr MMmin` format.'
+                  example: '1hr 20min'
+                  type: string
+                trailer:
+                  description: 'Trailer URL'
+                  example: 'https://www.youtube.com/watch?v=_cNjTdFHL8E'
+                  nullable: true
+                  type: string
+              required:
+                - description
+                - name
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        400:
+          description: "There are two ways that this status code can be encountered:\n * If there is a problem with the request.\n * If the IMDB URL could not be validated."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - create
+  '/movies/{id}':
+    get:
+      summary: 'Get a single movie.'
+      description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
+      operationId: getMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        304:
+          description: 'If no content has been modified since the supplied Last-Modified header.'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    patch:
+      summary: 'Update a movie.'
+      description: 'Update a movies data.'
+      operationId: updateMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cast:
+                  description: 'Array of cast members.'
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: 'Cast member name.'
+                        example: 'Natasha Hovey'
+                        type: string
+                      role:
+                        description: 'Cast member role.'
+                        example: Cheryl
+                        type: string
+                  type: array
+                content_rating:
+                  description: "MPAA rating\n\nOption descriptions:\n * `G` - Rated G\n * `NC-17` - Rated NC-17\n * `NR` - Not rated\n * `PG` - Rated PG\n * `PG-13` - Rated PG-13\n * `R` - Rated R\n * `UR` - Unrated\n * `X` - Rated X\n"
+                  enum:
+                    - G
+                    - NC-17
+                    - NR
+                    - PG
+                    - PG-13
+                    - R
+                    - UR
+                    - X
+                  example: NR
+                  type: string
+                description:
+                  description: 'Description, or tagline, for the movie.'
+                  type: string
+                director:
+                  description: 'Name of the director.'
+                  example: 'Lamberto Bava'
+                  type: string
+                genres:
+                  description: 'Array of movie genres.'
+                  items:
+                    type: string
+                  type: array
+                imdb:
+                  description: 'IMDB URL'
+                  example: 'https://www.imdb.com/title/tt0089013/'
+                  type: string
+                is_kid_friendly:
+                  description: 'Is this movie kid friendly?'
+                  type: boolean
+                name:
+                  description: 'Name of the movie.'
+                  example: Demons
+                  type: string
+                rotten_tomatoes_score:
+                  description: 'Rotten Tomatoes score'
+                  example: '56'
+                  type: number
+                runtime:
+                  description: 'Movie runtime, in `HHhr MMmin` format.'
+                  example: '1hr 20min'
+                  type: string
+                trailer:
+                  description: 'Trailer URL'
+                  example: 'https://www.youtube.com/watch?v=_cNjTdFHL8E'
+                  nullable: true
+                  type: string
+              required:
+                - description
+                - name
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        400:
+          description: "There are two ways that this status code can be encountered:\n * If there is a problem with the request.\n * If the IMDB URL could not be validated."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - edit
+  /theaters:
+    get:
+      summary: 'Get movie theaters.'
+      description: 'Returns all movie theatres for a specific location.'
+      operationId: getTheaters
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Location you want theaters in.'
+          in: query
+          name: location
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/theater'
+        400:
+          description: 'If the location is invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    post:
+      summary: 'Create a movie theater.'
+      description: 'Create a new movie theater.'
+      operationId: createTheater
+      tags:
+        - Theaters
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                address:
+                  description: 'Theater address'
+                  example: '2548 Central Park Ave, Yonkers, NY 10710'
+                  type: string
+                name:
+                  description: 'Name of the theater.'
+                  example: 'Alamo Drafthouse Cinema - Yonkers'
+                  type: string
+                phone_number:
+                  description: 'Theater phone number'
+                  example: '(914) 226-3082'
+                  type: string
+              required:
+                - address
+                - name
+                - phone_number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        400:
+          description: 'If there is a problem with the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - create
+  '/theaters/{id}':
+    get:
+      summary: 'Get a single movie theater.'
+      description: 'Return information on a specific movie theater.'
+      operationId: getTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        304:
+          description: 'If no content has been modified since the supplied Last-Modified header.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    patch:
+      summary: 'Update a movie theater.'
+      description: 'Update a movie theaters'' data.'
+      operationId: updateTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                address:
+                  description: 'Theater address'
+                  example: '2548 Central Park Ave, Yonkers, NY 10710'
+                  type: string
+                name:
+                  description: 'Name of the theater.'
+                  example: 'Alamo Drafthouse Cinema - Yonkers'
+                  type: string
+                phone_number:
+                  description: 'Theater phone number'
+                  example: '(914) 226-3082'
+                  type: string
+              required:
+                - address
+                - name
+                - phone_number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        400:
+          description: 'If there is a problem with the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        404:
+          description: 'If the movie movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        403:
+          description: 'If something cool happened. Returns a unique error code of `1337`.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/coded-error'
+      security:
+        -
+          oauth2:
+            - create
+components:
+  securitySchemes:
+    bearer:
+      type: http
+      scheme: bearer
+      bearerFormat: bearer
+    oauth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: /oauth/authorize
+          tokenUrl: /oauth/access_token
+          scopes:
+            create: Create
+            delete: Delete
+            edit: Edit
+            public: Public
+        clientCredentials:
+          tokenUrl: /oauth/authorize/client
+          scopes:
+            create: Create
+            delete: Delete
+            edit: Edit
+            public: Public
+  schemas:
+    coded-error:
+      title: 'Coded error'
+      properties:
+        error:
+          description: 'User-friendly error message'
+          type: string
+        error_code:
+          description: 'Error code'
+          type: number
+      required:
+        - error
+        - error_code
+      type: object
+    error:
+      title: Error
+      properties:
+        error:
+          description: 'User-friendly error message'
+          type: string
+      required:
+        - error
+      type: object
+    movie:
+      title: Movie
+      properties:
+        cast:
+          description: 'Cast. This data requires a bearer token with the `public` scope.'
+          items:
+            $ref: '#/components/schemas/person'
+          type: array
+        content_rating:
+          description: 'MPAA rating'
+          enum:
+            - G
+            - NC-17
+            - NR
+            - PG
+            - PG-13
+            - R
+            - UR
+            - X
+          example: G
+          type: string
+        description:
+          description: Description
+          nullable: true
+          type: string
+        director:
+          allOf:
+            -
+              $ref: '#/components/schemas/person'
+          description: 'Director. This data requires a bearer token with the `public` scope.'
+        external_urls:
+          description: 'External URLs. This data requires a bearer token with the `public` scope.'
+          items:
+            type: object
+            properties:
+              imdb:
+                description: 'IMDB URL. This data requires a bearer token with the `public` scope.'
+                type: string
+              tickets:
+                description: 'Tickets URL. This data requires a bearer token with the `public` scope.'
+                type: string
+              trailer:
+                description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
+                type: string
+            required:
+              - imdb
+              - tickets
+              - trailer
+          type: array
+        genres:
+          description: Genres
+          items:
+            type: string
+          type: array
+        id:
+          description: 'Unique ID'
+          type: number
+        kid_friendly:
+          description: 'Kid friendly?'
+          example: 'false'
+          type: boolean
+        name:
+          description: Name
+          type: string
+        purchase:
+          properties:
+            url:
+              description: 'URL to purchase the film.'
+              nullable: true
+              type: string
+          type: object
+        rotten_tomatoes_score:
+          description: 'Rotten Tomatoes score'
+          type: number
+        runtime:
+          description: Runtime
+          type: string
+        showtimes:
+          description: 'Non-theater specific showtimes'
+          items:
+            type: string
+          type: array
+        theaters:
+          description: 'Theaters the movie is currently showing in'
+          items:
+            $ref: '#/components/schemas/theater'
+          type: array
+        uri:
+          description: 'Movie URI'
+          type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
+    person:
+      title: Person
+      properties:
+        id:
+          description: 'Unique ID'
+          type: number
+        imdb:
+          description: 'IMDB URL'
+          type: string
+        name:
+          description: Name
+          type: string
+        uri:
+          description: 'Person URI'
+          type: string
+      required:
+        - id
+        - imdb
+        - name
+        - uri
+      type: object
+    theater:
+      title: Theater
+      properties:
+        address:
+          description: Address
+          type: string
+        id:
+          description: 'Unique ID'
+          type: number
+        movies:
+          description: 'Movies currently playing'
+          items:
+            $ref: '#/components/schemas/movie'
+          type: array
+        name:
+          description: Name
+          type: string
+        phone_number:
+          description: 'Phone number'
+          type: string
+        showtimes:
+          description: 'Non-movie specific showtimes'
+          items:
+            type: string
+          type: array
+        uri:
+          description: 'Theater URI'
+          type: string
+      required:
+        - address
+        - id
+        - movies
+        - name
+        - phone_number
+        - showtimes
+        - uri
+      type: object
+security:
+  -
+    oauth2:
+      - create
+      - delete
+      - edit
+      - public

--- a/resources/examples/Showtimes/compiled/public/1.1.2/api.apib
+++ b/resources/examples/Showtimes/compiled/public/1.1.2/api.apib
@@ -1,0 +1,234 @@
+FORMAT: 1A
+
+# Mill unit test API, Showtimes
+This is the API Blueprint file for Mill unit test API, Showtimes.
+
+# Group Movies
+## Movies [/movies/{id}]
+
+### Get a single movie. [GET]
+Return information on a specific movie.
+
+Donec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem
+ipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis
+mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta
+sem malesuada magna mollis euismod.
+
+```
+[
+  {"id": "fizzbuzz"}
+]
+```
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Response 200 (application/mill.example.movie+json)
+    + Attributes (Movie)
++ Response 304 (application/mill.example.movie+json)
++ Response 404 (application/mill.example.movie+json)
+    + Attributes (Error)
+
+### Update a movie. [PATCH]
+Update a movies data.
+
+This action requires a bearer token with the `edit` scope.
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Request
+    + Attributes
+        - `cast` (array) - Array of cast members.
+             - (object)
+                - `name`: `Natasha Hovey` (string) - Cast member name.
+                - `role`: `Cheryl` (string) - Cast member role.
+        - `content_rating`: `NR` (enum[string]) - MPAA rating
+            + Members
+                + `G` - Rated G
+                + `NC-17` - Rated NC-17
+                + `NR` - Not rated
+                + `PG` - Rated PG
+                + `PG-13` - Rated PG-13
+                + `R` - Rated R
+                + `UR` - Unrated
+                + `X` - Rated X
+        - `description` (string, required) - Description, or tagline, for the movie.
+        - `director`: `Lamberto Bava` (string) - Name of the director.
+        - `genres` (array[string]) - Array of movie genres.
+        - `imdb`: `https://www.imdb.com/title/tt0089013/` (string) - IMDB URL
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
+        - `name`: `Demons` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score`: `56` (number) - Rotten Tomatoes score
+        - `runtime`: `1hr 20min` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `trailer`: `https://www.youtube.com/watch?v=_cNjTdFHL8E` (string, nullable) - Trailer URL
++ Response 200 (application/mill.example.movie+json)
+    + Attributes (Movie)
++ Response 400 (application/mill.example.movie+json)
+    There are two ways that this status code can be encountered:
+         * If there is a problem with the request.
+         * If the IMDB URL could not be validated.
+    + Attributes (Error)
++ Response 404 (application/mill.example.movie+json)
+    + Attributes (Error)
+
+## Movies [/movies]
+
+### Get movies. [GET]
+Returns all movies for a specific location.
+
++ Request
+    + Attributes
+        - `location` (string, required) - Location you want movies for.
+        - `page` (number) - Page of results to pull.
++ Response 200 (application/mill.example.movie+json)
+    + Attributes (array[Movie])
++ Response 400 (application/mill.example.movie+json)
+    + Attributes (Error)
+
+### Create a movie. [POST]
+Create a new movie.
+
+This action requires a bearer token with the `create` scope.
+
++ Request
+    + Attributes
+        - `cast` (array) - Array of cast members.
+             - (object)
+                - `name`: `Natasha Hovey` (string) - Cast member name.
+                - `role`: `Cheryl` (string) - Cast member role.
+        - `content_rating`: `NR` (enum[string]) - MPAA rating
+            + Members
+                + `G` - Rated G
+                + `NC-17` - Rated NC-17
+                + `NR` - Not rated
+                + `PG` - Rated PG
+                + `PG-13` - Rated PG-13
+                + `R` - Rated R
+                + `UR` - Unrated
+                + `X` - Rated X
+        - `description` (string, required) - Description, or tagline, for the movie.
+        - `director`: `Lamberto Bava` (string) - Name of the director.
+        - `genres` (array[string]) - Array of movie genres.
+        - `imdb`: `https://www.imdb.com/title/tt0089013/` (string) - IMDB URL
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
+        - `name`: `Demons` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score`: `56` (number) - Rotten Tomatoes score
+        - `runtime`: `1hr 20min` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `trailer`: `https://www.youtube.com/watch?v=_cNjTdFHL8E` (string, nullable) - Trailer URL
++ Response 200 (application/mill.example.movie+json)
+    + Attributes (Movie)
++ Response 400 (application/mill.example.movie+json)
+    There are two ways that this status code can be encountered:
+         * If there is a problem with the request.
+         * If the IMDB URL could not be validated.
+    + Attributes (Error)
+
+# Group Theaters
+## Theaters [/theaters/{id}]
+
+### Get a single movie theater. [GET]
+Return information on a specific movie theater.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 200 (application/mill.example.theater+json)
+    + Attributes (Theater)
++ Response 304 (application/mill.example.theater+json)
++ Response 404 (application/mill.example.theater+json)
+    + Attributes (Error)
+
+### Update a movie theater. [PATCH]
+Update a movie theaters' data.
+
+This action requires a bearer token with the `create` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Request
+    + Attributes
+        - `address`: `2548 Central Park Ave, Yonkers, NY 10710` (string, required) - Theater address
+        - `name`: `Alamo Drafthouse Cinema - Yonkers` (string, required) - Name of the theater.
+        - `phone_number`: `(914) 226-3082` (string, required) - Theater phone number
++ Response 200 (application/mill.example.theater+json)
+    + Attributes (Theater)
++ Response 400 (application/mill.example.theater+json)
+    + Attributes (Error)
++ Response 404 (application/mill.example.theater+json)
+    + Attributes (Error)
+
+## Theaters [/theaters]
+
+### Get movie theaters. [GET]
+Returns all movie theatres for a specific location.
+
++ Request
+    + Attributes
+        - `location` (string, required) - Location you want theaters in.
++ Response 200 (application/mill.example.theater+json)
+    + Attributes (array[Theater])
++ Response 400 (application/mill.example.theater+json)
+    + Attributes (Error)
+
+### Create a movie theater. [POST]
+Create a new movie theater.
+
+This action requires a bearer token with the `create` scope.
+
++ Request
+    + Attributes
+        - `address`: `2548 Central Park Ave, Yonkers, NY 10710` (string, required) - Theater address
+        - `name`: `Alamo Drafthouse Cinema - Yonkers` (string, required) - Name of the theater.
+        - `phone_number`: `(914) 226-3082` (string, required) - Theater phone number
++ Response 200 (application/mill.example.theater+json)
+    + Attributes (Theater)
++ Response 400 (application/mill.example.theater+json)
+    + Attributes (Error)
+
+# Data Structures
+## Error
+- `error` (string, required) - User-friendly error message
+
+## Movie
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
+    + Members
+        + `G`
+        + `NC-17`
+        + `NR`
+        + `PG`
+        + `PG-13`
+        + `R`
+        + `UR`
+        + `X`
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
+- `external_urls` (array) - External URLs. This data requires a bearer token with the `public` scope.
+     - (object)
+        - `imdb` (string, required) - IMDB URL. This data requires a bearer token with the `public` scope.
+        - `tickets` (string, required) - Tickets URL. This data requires a bearer token with the `public` scope.
+        - `trailer` (string, required) - Trailer URL. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
+- `purchase` (object)
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array[string], required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI
+
+## Person
+- `id` (number, required) - Unique ID
+- `imdb` (string, required) - IMDB URL
+- `name` (string, required) - Name
+- `uri` (string, required) - Person URI
+
+## Theater
+- `address` (string, required) - Address
+- `id` (number, required) - Unique ID
+- `movies` (array[Movie], required) - Movies currently playing
+- `name` (string, required) - Name
+- `phone_number` (string, required) - Phone number
+- `showtimes` (array[string], required) - Non-movie specific showtimes
+- `uri` (string, required) - Theater URI

--- a/resources/examples/Showtimes/compiled/public/1.1.2/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.1.2/api.yaml
@@ -1,0 +1,667 @@
+openapi: 3.0.0
+info:
+  title: 'Mill unit test API, Showtimes'
+  version: 1.1.2
+  contact:
+    name: 'Get help!'
+    email: support@example.com
+    url: 'https://developer.example.com/help'
+tags:
+  -
+    name: Movies
+  -
+    name: Theaters
+servers:
+  -
+    url: 'https://api.example.com'
+    description: Production
+  -
+    url: 'https://api.example.local'
+    description: Development
+paths:
+  /movies:
+    get:
+      summary: 'Get movies.'
+      description: 'Returns all movies for a specific location.'
+      operationId: getMovies
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Location you want movies for.'
+          in: query
+          name: location
+          required: true
+          schema:
+            type: string
+        -
+          description: 'Page of results to pull.'
+          in: query
+          name: page
+          required: false
+          schema:
+            type: number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/movie'
+        400:
+          description: 'If the location is invalid.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/error'
+    post:
+      summary: 'Create a movie.'
+      description: 'Create a new movie.'
+      operationId: createMovie
+      tags:
+        - Movies
+      requestBody:
+        required: true
+        content:
+          application/mill.example.movie+json:
+            schema:
+              type: object
+              properties:
+                cast:
+                  description: 'Array of cast members.'
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: 'Cast member name.'
+                        example: 'Natasha Hovey'
+                        type: string
+                      role:
+                        description: 'Cast member role.'
+                        example: Cheryl
+                        type: string
+                  type: array
+                content_rating:
+                  description: "MPAA rating\n\nOption descriptions:\n * `G` - Rated G\n * `NC-17` - Rated NC-17\n * `NR` - Not rated\n * `PG` - Rated PG\n * `PG-13` - Rated PG-13\n * `R` - Rated R\n * `UR` - Unrated\n * `X` - Rated X\n"
+                  enum:
+                    - G
+                    - NC-17
+                    - NR
+                    - PG
+                    - PG-13
+                    - R
+                    - UR
+                    - X
+                  example: NR
+                  type: string
+                description:
+                  description: 'Description, or tagline, for the movie.'
+                  type: string
+                director:
+                  description: 'Name of the director.'
+                  example: 'Lamberto Bava'
+                  type: string
+                genres:
+                  description: 'Array of movie genres.'
+                  items:
+                    type: string
+                  type: array
+                imdb:
+                  description: 'IMDB URL'
+                  example: 'https://www.imdb.com/title/tt0089013/'
+                  type: string
+                is_kid_friendly:
+                  description: 'Is this movie kid friendly?'
+                  type: boolean
+                name:
+                  description: 'Name of the movie.'
+                  example: Demons
+                  type: string
+                rotten_tomatoes_score:
+                  description: 'Rotten Tomatoes score'
+                  example: '56'
+                  type: number
+                runtime:
+                  description: 'Movie runtime, in `HHhr MMmin` format.'
+                  example: '1hr 20min'
+                  type: string
+                trailer:
+                  description: 'Trailer URL'
+                  example: 'https://www.youtube.com/watch?v=_cNjTdFHL8E'
+                  nullable: true
+                  type: string
+              required:
+                - description
+                - name
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        400:
+          description: "There are two ways that this status code can be encountered:\n * If there is a problem with the request.\n * If the IMDB URL could not be validated."
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - create
+  '/movies/{id}':
+    get:
+      summary: 'Get a single movie.'
+      description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
+      operationId: getMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        304:
+          description: 'If no content has been modified since the supplied Last-Modified header.'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/error'
+    patch:
+      summary: 'Update a movie.'
+      description: 'Update a movies data.'
+      operationId: updateMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      requestBody:
+        required: true
+        content:
+          application/mill.example.movie+json:
+            schema:
+              type: object
+              properties:
+                cast:
+                  description: 'Array of cast members.'
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: 'Cast member name.'
+                        example: 'Natasha Hovey'
+                        type: string
+                      role:
+                        description: 'Cast member role.'
+                        example: Cheryl
+                        type: string
+                  type: array
+                content_rating:
+                  description: "MPAA rating\n\nOption descriptions:\n * `G` - Rated G\n * `NC-17` - Rated NC-17\n * `NR` - Not rated\n * `PG` - Rated PG\n * `PG-13` - Rated PG-13\n * `R` - Rated R\n * `UR` - Unrated\n * `X` - Rated X\n"
+                  enum:
+                    - G
+                    - NC-17
+                    - NR
+                    - PG
+                    - PG-13
+                    - R
+                    - UR
+                    - X
+                  example: NR
+                  type: string
+                description:
+                  description: 'Description, or tagline, for the movie.'
+                  type: string
+                director:
+                  description: 'Name of the director.'
+                  example: 'Lamberto Bava'
+                  type: string
+                genres:
+                  description: 'Array of movie genres.'
+                  items:
+                    type: string
+                  type: array
+                imdb:
+                  description: 'IMDB URL'
+                  example: 'https://www.imdb.com/title/tt0089013/'
+                  type: string
+                is_kid_friendly:
+                  description: 'Is this movie kid friendly?'
+                  type: boolean
+                name:
+                  description: 'Name of the movie.'
+                  example: Demons
+                  type: string
+                rotten_tomatoes_score:
+                  description: 'Rotten Tomatoes score'
+                  example: '56'
+                  type: number
+                runtime:
+                  description: 'Movie runtime, in `HHhr MMmin` format.'
+                  example: '1hr 20min'
+                  type: string
+                trailer:
+                  description: 'Trailer URL'
+                  example: 'https://www.youtube.com/watch?v=_cNjTdFHL8E'
+                  nullable: true
+                  type: string
+              required:
+                - description
+                - name
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        400:
+          description: "There are two ways that this status code can be encountered:\n * If there is a problem with the request.\n * If the IMDB URL could not be validated."
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/error'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - edit
+  /theaters:
+    get:
+      summary: 'Get movie theaters.'
+      description: 'Returns all movie theatres for a specific location.'
+      operationId: getTheaters
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Location you want theaters in.'
+          in: query
+          name: location
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/theater'
+        400:
+          description: 'If the location is invalid.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/error'
+    post:
+      summary: 'Create a movie theater.'
+      description: 'Create a new movie theater.'
+      operationId: createTheater
+      tags:
+        - Theaters
+      requestBody:
+        required: true
+        content:
+          application/mill.example.theater+json:
+            schema:
+              type: object
+              properties:
+                address:
+                  description: 'Theater address'
+                  example: '2548 Central Park Ave, Yonkers, NY 10710'
+                  type: string
+                name:
+                  description: 'Name of the theater.'
+                  example: 'Alamo Drafthouse Cinema - Yonkers'
+                  type: string
+                phone_number:
+                  description: 'Theater phone number'
+                  example: '(914) 226-3082'
+                  type: string
+              required:
+                - address
+                - name
+                - phone_number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        400:
+          description: 'If there is a problem with the request.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - create
+  '/theaters/{id}':
+    get:
+      summary: 'Get a single movie theater.'
+      description: 'Return information on a specific movie theater.'
+      operationId: getTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        304:
+          description: 'If no content has been modified since the supplied Last-Modified header.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/error'
+    patch:
+      summary: 'Update a movie theater.'
+      description: 'Update a movie theaters'' data.'
+      operationId: updateTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      requestBody:
+        required: true
+        content:
+          application/mill.example.theater+json:
+            schema:
+              type: object
+              properties:
+                address:
+                  description: 'Theater address'
+                  example: '2548 Central Park Ave, Yonkers, NY 10710'
+                  type: string
+                name:
+                  description: 'Name of the theater.'
+                  example: 'Alamo Drafthouse Cinema - Yonkers'
+                  type: string
+                phone_number:
+                  description: 'Theater phone number'
+                  example: '(914) 226-3082'
+                  type: string
+              required:
+                - address
+                - name
+                - phone_number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        400:
+          description: 'If there is a problem with the request.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/error'
+        404:
+          description: 'If the movie movie could not be found.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - create
+components:
+  securitySchemes:
+    bearer:
+      type: http
+      scheme: bearer
+      bearerFormat: bearer
+    oauth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: /oauth/authorize
+          tokenUrl: /oauth/access_token
+          scopes:
+            create: Create
+            delete: Delete
+            edit: Edit
+            public: Public
+        clientCredentials:
+          tokenUrl: /oauth/authorize/client
+          scopes:
+            create: Create
+            delete: Delete
+            edit: Edit
+            public: Public
+  schemas:
+    error:
+      title: Error
+      properties:
+        error:
+          description: 'User-friendly error message'
+          type: string
+      required:
+        - error
+      type: object
+    movie:
+      title: Movie
+      properties:
+        cast:
+          description: 'Cast. This data requires a bearer token with the `public` scope.'
+          items:
+            $ref: '#/components/schemas/person'
+          type: array
+        content_rating:
+          description: 'MPAA rating'
+          enum:
+            - G
+            - NC-17
+            - NR
+            - PG
+            - PG-13
+            - R
+            - UR
+            - X
+          example: G
+          type: string
+        description:
+          description: Description
+          nullable: true
+          type: string
+        director:
+          allOf:
+            -
+              $ref: '#/components/schemas/person'
+          description: 'Director. This data requires a bearer token with the `public` scope.'
+        external_urls:
+          description: 'External URLs. This data requires a bearer token with the `public` scope.'
+          items:
+            type: object
+            properties:
+              imdb:
+                description: 'IMDB URL. This data requires a bearer token with the `public` scope.'
+                type: string
+              tickets:
+                description: 'Tickets URL. This data requires a bearer token with the `public` scope.'
+                type: string
+              trailer:
+                description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
+                type: string
+            required:
+              - imdb
+              - tickets
+              - trailer
+          type: array
+        genres:
+          description: Genres
+          items:
+            type: string
+          type: array
+        id:
+          description: 'Unique ID'
+          type: number
+        kid_friendly:
+          description: 'Kid friendly?'
+          example: 'false'
+          type: boolean
+        name:
+          description: Name
+          type: string
+        purchase:
+          properties:
+            url:
+              description: 'URL to purchase the film.'
+              nullable: true
+              type: string
+          type: object
+        rotten_tomatoes_score:
+          description: 'Rotten Tomatoes score'
+          type: number
+        runtime:
+          description: Runtime
+          type: string
+        showtimes:
+          description: 'Non-theater specific showtimes'
+          items:
+            type: string
+          type: array
+        theaters:
+          description: 'Theaters the movie is currently showing in'
+          items:
+            $ref: '#/components/schemas/theater'
+          type: array
+        uri:
+          description: 'Movie URI'
+          type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
+    person:
+      title: Person
+      properties:
+        id:
+          description: 'Unique ID'
+          type: number
+        imdb:
+          description: 'IMDB URL'
+          type: string
+        name:
+          description: Name
+          type: string
+        uri:
+          description: 'Person URI'
+          type: string
+      required:
+        - id
+        - imdb
+        - name
+        - uri
+      type: object
+    theater:
+      title: Theater
+      properties:
+        address:
+          description: Address
+          type: string
+        id:
+          description: 'Unique ID'
+          type: number
+        movies:
+          description: 'Movies currently playing'
+          items:
+            $ref: '#/components/schemas/movie'
+          type: array
+        name:
+          description: Name
+          type: string
+        phone_number:
+          description: 'Phone number'
+          type: string
+        showtimes:
+          description: 'Non-movie specific showtimes'
+          items:
+            type: string
+          type: array
+        uri:
+          description: 'Theater URI'
+          type: string
+      required:
+        - address
+        - id
+        - movies
+        - name
+        - phone_number
+        - showtimes
+        - uri
+      type: object
+security:
+  -
+    oauth2:
+      - create
+      - delete
+      - edit
+      - public

--- a/resources/examples/Showtimes/compiled/public/1.1.3/api.apib
+++ b/resources/examples/Showtimes/compiled/public/1.1.3/api.apib
@@ -1,0 +1,249 @@
+FORMAT: 1A
+
+# Mill unit test API, Showtimes
+This is the API Blueprint file for Mill unit test API, Showtimes.
+
+# Group Movies
+## Movies [/movies/{id}]
+
+### Get a single movie. [GET]
+Return information on a specific movie.
+
+Donec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem
+ipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis
+mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta
+sem malesuada magna mollis euismod.
+
+```
+[
+  {"id": "fizzbuzz"}
+]
+```
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Response 200 (application/mill.example.movie+json)
+    + Attributes (Movie)
++ Response 304 (application/mill.example.movie+json)
++ Response 404 (application/mill.example.movie+json)
+    There are three ways that this status code can be encountered:
+         * If the movie could not be found.
+         * For no reason.
+         * For some other reason.
+    + Attributes (Error)
+
+### Update a movie. [PATCH]
+Update a movies data.
+
+This action requires a bearer token with the `edit` scope.
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Request
+    + Attributes
+        - `cast` (array) - Array of cast members.
+             - (object)
+                - `name`: `Natasha Hovey` (string) - Cast member name.
+                - `role`: `Cheryl` (string) - Cast member role.
+        - `content_rating`: `NR` (enum[string]) - MPAA rating
+            + Members
+                + `G` - Rated G
+                + `NC-17` - Rated NC-17
+                + `NR` - Not rated
+                + `PG` - Rated PG
+                + `PG-13` - Rated PG-13
+                + `R` - Rated R
+                + `UR` - Unrated
+                + `X` - Rated X
+        - `description` (string, required) - Description, or tagline, for the movie.
+        - `director`: `Lamberto Bava` (string) - Name of the director.
+        - `genres` (array[string]) - Array of movie genres.
+        - `imdb`: `https://www.imdb.com/title/tt0089013/` (string) - IMDB URL
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
+        - `name`: `Demons` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score`: `56` (number) - Rotten Tomatoes score
+        - `runtime`: `1hr 20min` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `trailer`: `https://www.youtube.com/watch?v=_cNjTdFHL8E` (string, nullable) - Trailer URL
++ Response 200 (application/mill.example.movie+json)
+    + Attributes (Movie)
++ Response 202 (application/mill.example.movie+json)
+    + Attributes (Movie)
++ Response 400 (application/mill.example.movie+json)
+    There are two ways that this status code can be encountered:
+         * If there is a problem with the request.
+         * If the IMDB URL could not be validated.
+    + Attributes (Error)
++ Response 403 (application/mill.example.movie+json)
+    + Attributes (Coded error)
++ Response 404 (application/mill.example.movie+json)
+    There are two ways that this status code can be encountered:
+         * If the movie could not be found.
+         * If the trailer URL could not be validated.
+    + Attributes (Error)
+
+## Movies [/movies]
+
+### Get movies. [GET]
+Returns all movies for a specific location.
+
++ Request
+    + Attributes
+        - `location` (string, required) - Location you want movies for.
+        - `page` (number) - Page of results to pull.
++ Response 200 (application/mill.example.movie+json)
+    + Attributes (array[Movie])
++ Response 400 (application/mill.example.movie+json)
+    + Attributes (Error)
+
+### Create a movie. [POST]
+Create a new movie.
+
+This action requires a bearer token with the `create` scope.
+
++ Request
+    + Attributes
+        - `cast` (array) - Array of cast members.
+             - (object)
+                - `name`: `Natasha Hovey` (string) - Cast member name.
+                - `role`: `Cheryl` (string) - Cast member role.
+        - `content_rating`: `NR` (enum[string]) - MPAA rating
+            + Members
+                + `G` - Rated G
+                + `NC-17` - Rated NC-17
+                + `NR` - Not rated
+                + `PG` - Rated PG
+                + `PG-13` - Rated PG-13
+                + `R` - Rated R
+                + `UR` - Unrated
+                + `X` - Rated X
+        - `description` (string, required) - Description, or tagline, for the movie.
+        - `director`: `Lamberto Bava` (string) - Name of the director.
+        - `genres` (array[string]) - Array of movie genres.
+        - `imdb`: `https://www.imdb.com/title/tt0089013/` (string) - IMDB URL
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
+        - `name`: `Demons` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score`: `56` (number) - Rotten Tomatoes score
+        - `runtime`: `1hr 20min` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `trailer`: `https://www.youtube.com/watch?v=_cNjTdFHL8E` (string, nullable) - Trailer URL
++ Response 200 (application/mill.example.movie+json)
+    + Attributes (Movie)
++ Response 201 (application/mill.example.movie+json)
++ Response 400 (application/mill.example.movie+json)
+    There are two ways that this status code can be encountered:
+         * If there is a problem with the request.
+         * If the IMDB URL could not be validated.
+    + Attributes (Error)
+
+# Group Theaters
+## Theaters [/theaters/{id}]
+
+### Get a single movie theater. [GET]
+Return information on a specific movie theater.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 200 (application/mill.example.theater+json)
+    + Attributes (Theater)
++ Response 304 (application/mill.example.theater+json)
++ Response 404 (application/mill.example.theater+json)
+    + Attributes (Error)
+
+### Update a movie theater. [PATCH]
+Update a movie theaters' data.
+
+This action requires a bearer token with the `create` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Request
+    + Attributes
+        - `address`: `2548 Central Park Ave, Yonkers, NY 10710` (string, required) - Theater address
+        - `name`: `Alamo Drafthouse Cinema - Yonkers` (string, required) - Name of the theater.
+        - `phone_number`: `(914) 226-3082` (string, required) - Theater phone number
++ Response 200 (application/mill.example.theater+json)
+    + Attributes (Theater)
++ Response 400 (application/mill.example.theater+json)
+    + Attributes (Error)
++ Response 404 (application/mill.example.theater+json)
+    + Attributes (Error)
+
+## Theaters [/theaters]
+
+### Get movie theaters. [GET]
+Returns all movie theatres for a specific location.
+
++ Request
+    + Attributes
+        - `location` (string, required) - Location you want theaters in.
++ Response 200 (application/mill.example.theater+json)
+    + Attributes (array[Theater])
++ Response 400 (application/mill.example.theater+json)
+    + Attributes (Error)
+
+### Create a movie theater. [POST]
+Create a new movie theater.
+
+This action requires a bearer token with the `create` scope.
+
++ Request
+    + Attributes
+        - `address`: `2548 Central Park Ave, Yonkers, NY 10710` (string, required) - Theater address
+        - `name`: `Alamo Drafthouse Cinema - Yonkers` (string, required) - Name of the theater.
+        - `phone_number`: `(914) 226-3082` (string, required) - Theater phone number
++ Response 200 (application/mill.example.theater+json)
+    + Attributes (Theater)
++ Response 400 (application/mill.example.theater+json)
+    + Attributes (Error)
+
+# Data Structures
+## Coded error
+- `error` (string, required) - User-friendly error message
+- `error_code` (number, required) - Error code
+
+## Error
+- `error` (string, required) - User-friendly error message
+
+## Movie
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
+    + Members
+        + `G`
+        + `NC-17`
+        + `NR`
+        + `PG`
+        + `PG-13`
+        + `R`
+        + `UR`
+        + `X`
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
+- `external_urls` (array) - External URLs. This data requires a bearer token with the `public` scope.
+     - (object)
+        - `imdb` (string, required) - IMDB URL. This data requires a bearer token with the `public` scope.
+        - `trailer` (string, required) - Trailer URL. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
+- `purchase` (object)
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array[string], required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI
+
+## Person
+- `id` (number, required) - Unique ID
+- `imdb` (string, required) - IMDB URL
+- `name` (string, required) - Name
+- `uri` (string, required) - Person URI
+
+## Theater
+- `address` (string, required) - Address
+- `id` (number, required) - Unique ID
+- `movies` (array[Movie], required) - Movies currently playing
+- `name` (string, required) - Name
+- `phone_number` (string, required) - Phone number
+- `showtimes` (array[string], required) - Non-movie specific showtimes
+- `uri` (string, required) - Theater URI

--- a/resources/examples/Showtimes/compiled/public/1.1.3/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.1.3/api.yaml
@@ -1,0 +1,690 @@
+openapi: 3.0.0
+info:
+  title: 'Mill unit test API, Showtimes'
+  version: 1.1.3
+  contact:
+    name: 'Get help!'
+    email: support@example.com
+    url: 'https://developer.example.com/help'
+tags:
+  -
+    name: Movies
+  -
+    name: Theaters
+servers:
+  -
+    url: 'https://api.example.com'
+    description: Production
+  -
+    url: 'https://api.example.local'
+    description: Development
+paths:
+  /movies:
+    get:
+      summary: 'Get movies.'
+      description: 'Returns all movies for a specific location.'
+      operationId: getMovies
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Location you want movies for.'
+          in: query
+          name: location
+          required: true
+          schema:
+            type: string
+        -
+          description: 'Page of results to pull.'
+          in: query
+          name: page
+          required: false
+          schema:
+            type: number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/movie'
+        400:
+          description: 'If the location is invalid.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/error'
+    post:
+      summary: 'Create a movie.'
+      description: 'Create a new movie.'
+      operationId: createMovie
+      tags:
+        - Movies
+      requestBody:
+        required: true
+        content:
+          application/mill.example.movie+json:
+            schema:
+              type: object
+              properties:
+                cast:
+                  description: 'Array of cast members.'
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: 'Cast member name.'
+                        example: 'Natasha Hovey'
+                        type: string
+                      role:
+                        description: 'Cast member role.'
+                        example: Cheryl
+                        type: string
+                  type: array
+                content_rating:
+                  description: "MPAA rating\n\nOption descriptions:\n * `G` - Rated G\n * `NC-17` - Rated NC-17\n * `NR` - Not rated\n * `PG` - Rated PG\n * `PG-13` - Rated PG-13\n * `R` - Rated R\n * `UR` - Unrated\n * `X` - Rated X\n"
+                  enum:
+                    - G
+                    - NC-17
+                    - NR
+                    - PG
+                    - PG-13
+                    - R
+                    - UR
+                    - X
+                  example: NR
+                  type: string
+                description:
+                  description: 'Description, or tagline, for the movie.'
+                  type: string
+                director:
+                  description: 'Name of the director.'
+                  example: 'Lamberto Bava'
+                  type: string
+                genres:
+                  description: 'Array of movie genres.'
+                  items:
+                    type: string
+                  type: array
+                imdb:
+                  description: 'IMDB URL'
+                  example: 'https://www.imdb.com/title/tt0089013/'
+                  type: string
+                is_kid_friendly:
+                  description: 'Is this movie kid friendly?'
+                  type: boolean
+                name:
+                  description: 'Name of the movie.'
+                  example: Demons
+                  type: string
+                rotten_tomatoes_score:
+                  description: 'Rotten Tomatoes score'
+                  example: '56'
+                  type: number
+                runtime:
+                  description: 'Movie runtime, in `HHhr MMmin` format.'
+                  example: '1hr 20min'
+                  type: string
+                trailer:
+                  description: 'Trailer URL'
+                  example: 'https://www.youtube.com/watch?v=_cNjTdFHL8E'
+                  nullable: true
+                  type: string
+              required:
+                - description
+                - name
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        201:
+          description: 'Standard request.'
+        400:
+          description: "There are two ways that this status code can be encountered:\n * If there is a problem with the request.\n * If the IMDB URL could not be validated."
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - create
+  '/movies/{id}':
+    get:
+      summary: 'Get a single movie.'
+      description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
+      operationId: getMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        304:
+          description: 'If no content has been modified since the supplied Last-Modified header.'
+        404:
+          description: "There are three ways that this status code can be encountered:\n * If the movie could not be found.\n * For no reason.\n * For some other reason."
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/error'
+    patch:
+      summary: 'Update a movie.'
+      description: 'Update a movies data.'
+      operationId: updateMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      requestBody:
+        required: true
+        content:
+          application/mill.example.movie+json:
+            schema:
+              type: object
+              properties:
+                cast:
+                  description: 'Array of cast members.'
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: 'Cast member name.'
+                        example: 'Natasha Hovey'
+                        type: string
+                      role:
+                        description: 'Cast member role.'
+                        example: Cheryl
+                        type: string
+                  type: array
+                content_rating:
+                  description: "MPAA rating\n\nOption descriptions:\n * `G` - Rated G\n * `NC-17` - Rated NC-17\n * `NR` - Not rated\n * `PG` - Rated PG\n * `PG-13` - Rated PG-13\n * `R` - Rated R\n * `UR` - Unrated\n * `X` - Rated X\n"
+                  enum:
+                    - G
+                    - NC-17
+                    - NR
+                    - PG
+                    - PG-13
+                    - R
+                    - UR
+                    - X
+                  example: NR
+                  type: string
+                description:
+                  description: 'Description, or tagline, for the movie.'
+                  type: string
+                director:
+                  description: 'Name of the director.'
+                  example: 'Lamberto Bava'
+                  type: string
+                genres:
+                  description: 'Array of movie genres.'
+                  items:
+                    type: string
+                  type: array
+                imdb:
+                  description: 'IMDB URL'
+                  example: 'https://www.imdb.com/title/tt0089013/'
+                  type: string
+                is_kid_friendly:
+                  description: 'Is this movie kid friendly?'
+                  type: boolean
+                name:
+                  description: 'Name of the movie.'
+                  example: Demons
+                  type: string
+                rotten_tomatoes_score:
+                  description: 'Rotten Tomatoes score'
+                  example: '56'
+                  type: number
+                runtime:
+                  description: 'Movie runtime, in `HHhr MMmin` format.'
+                  example: '1hr 20min'
+                  type: string
+                trailer:
+                  description: 'Trailer URL'
+                  example: 'https://www.youtube.com/watch?v=_cNjTdFHL8E'
+                  nullable: true
+                  type: string
+              required:
+                - description
+                - name
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        202:
+          description: 'Standard request.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        400:
+          description: "There are two ways that this status code can be encountered:\n * If there is a problem with the request.\n * If the IMDB URL could not be validated."
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/error'
+        404:
+          description: "There are two ways that this status code can be encountered:\n * If the movie could not be found.\n * If the trailer URL could not be validated."
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/error'
+        403:
+          description: 'If the user is not allowed to edit that movie. Returns a unique error code of `666`.'
+          content:
+            application/mill.example.movie+json:
+              schema:
+                $ref: '#/components/schemas/coded-error'
+      security:
+        -
+          oauth2:
+            - edit
+  /theaters:
+    get:
+      summary: 'Get movie theaters.'
+      description: 'Returns all movie theatres for a specific location.'
+      operationId: getTheaters
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Location you want theaters in.'
+          in: query
+          name: location
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/theater'
+        400:
+          description: 'If the location is invalid.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/error'
+    post:
+      summary: 'Create a movie theater.'
+      description: 'Create a new movie theater.'
+      operationId: createTheater
+      tags:
+        - Theaters
+      requestBody:
+        required: true
+        content:
+          application/mill.example.theater+json:
+            schema:
+              type: object
+              properties:
+                address:
+                  description: 'Theater address'
+                  example: '2548 Central Park Ave, Yonkers, NY 10710'
+                  type: string
+                name:
+                  description: 'Name of the theater.'
+                  example: 'Alamo Drafthouse Cinema - Yonkers'
+                  type: string
+                phone_number:
+                  description: 'Theater phone number'
+                  example: '(914) 226-3082'
+                  type: string
+              required:
+                - address
+                - name
+                - phone_number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        400:
+          description: 'If there is a problem with the request.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - create
+  '/theaters/{id}':
+    get:
+      summary: 'Get a single movie theater.'
+      description: 'Return information on a specific movie theater.'
+      operationId: getTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        304:
+          description: 'If no content has been modified since the supplied Last-Modified header.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/error'
+    patch:
+      summary: 'Update a movie theater.'
+      description: 'Update a movie theaters'' data.'
+      operationId: updateTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      requestBody:
+        required: true
+        content:
+          application/mill.example.theater+json:
+            schema:
+              type: object
+              properties:
+                address:
+                  description: 'Theater address'
+                  example: '2548 Central Park Ave, Yonkers, NY 10710'
+                  type: string
+                name:
+                  description: 'Name of the theater.'
+                  example: 'Alamo Drafthouse Cinema - Yonkers'
+                  type: string
+                phone_number:
+                  description: 'Theater phone number'
+                  example: '(914) 226-3082'
+                  type: string
+              required:
+                - address
+                - name
+                - phone_number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        400:
+          description: 'If there is a problem with the request.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/error'
+        404:
+          description: 'If the movie movie could not be found.'
+          content:
+            application/mill.example.theater+json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - create
+components:
+  securitySchemes:
+    bearer:
+      type: http
+      scheme: bearer
+      bearerFormat: bearer
+    oauth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: /oauth/authorize
+          tokenUrl: /oauth/access_token
+          scopes:
+            create: Create
+            delete: Delete
+            edit: Edit
+            public: Public
+        clientCredentials:
+          tokenUrl: /oauth/authorize/client
+          scopes:
+            create: Create
+            delete: Delete
+            edit: Edit
+            public: Public
+  schemas:
+    coded-error:
+      title: 'Coded error'
+      properties:
+        error:
+          description: 'User-friendly error message'
+          type: string
+        error_code:
+          description: 'Error code'
+          type: number
+      required:
+        - error
+        - error_code
+      type: object
+    error:
+      title: Error
+      properties:
+        error:
+          description: 'User-friendly error message'
+          type: string
+      required:
+        - error
+      type: object
+    movie:
+      title: Movie
+      properties:
+        cast:
+          description: 'Cast. This data requires a bearer token with the `public` scope.'
+          items:
+            $ref: '#/components/schemas/person'
+          type: array
+        content_rating:
+          description: 'MPAA rating'
+          enum:
+            - G
+            - NC-17
+            - NR
+            - PG
+            - PG-13
+            - R
+            - UR
+            - X
+          example: G
+          type: string
+        description:
+          description: Description
+          nullable: true
+          type: string
+        director:
+          allOf:
+            -
+              $ref: '#/components/schemas/person'
+          description: 'Director. This data requires a bearer token with the `public` scope.'
+        external_urls:
+          description: 'External URLs. This data requires a bearer token with the `public` scope.'
+          items:
+            type: object
+            properties:
+              imdb:
+                description: 'IMDB URL. This data requires a bearer token with the `public` scope.'
+                type: string
+              trailer:
+                description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
+                type: string
+            required:
+              - imdb
+              - trailer
+          type: array
+        genres:
+          description: Genres
+          items:
+            type: string
+          type: array
+        id:
+          description: 'Unique ID'
+          type: number
+        kid_friendly:
+          description: 'Kid friendly?'
+          example: 'false'
+          type: boolean
+        name:
+          description: Name
+          type: string
+        purchase:
+          properties:
+            url:
+              description: 'URL to purchase the film.'
+              nullable: true
+              type: string
+          type: object
+        rotten_tomatoes_score:
+          description: 'Rotten Tomatoes score'
+          type: number
+        runtime:
+          description: Runtime
+          type: string
+        showtimes:
+          description: 'Non-theater specific showtimes'
+          items:
+            type: string
+          type: array
+        theaters:
+          description: 'Theaters the movie is currently showing in'
+          items:
+            $ref: '#/components/schemas/theater'
+          type: array
+        uri:
+          description: 'Movie URI'
+          type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
+    person:
+      title: Person
+      properties:
+        id:
+          description: 'Unique ID'
+          type: number
+        imdb:
+          description: 'IMDB URL'
+          type: string
+        name:
+          description: Name
+          type: string
+        uri:
+          description: 'Person URI'
+          type: string
+      required:
+        - id
+        - imdb
+        - name
+        - uri
+      type: object
+    theater:
+      title: Theater
+      properties:
+        address:
+          description: Address
+          type: string
+        id:
+          description: 'Unique ID'
+          type: number
+        movies:
+          description: 'Movies currently playing'
+          items:
+            $ref: '#/components/schemas/movie'
+          type: array
+        name:
+          description: Name
+          type: string
+        phone_number:
+          description: 'Phone number'
+          type: string
+        showtimes:
+          description: 'Non-movie specific showtimes'
+          items:
+            type: string
+          type: array
+        uri:
+          description: 'Theater URI'
+          type: string
+      required:
+        - address
+        - id
+        - movies
+        - name
+        - phone_number
+        - showtimes
+        - uri
+      type: object
+security:
+  -
+    oauth2:
+      - create
+      - delete
+      - edit
+      - public

--- a/resources/examples/Showtimes/compiled/public/1.1/api.apib
+++ b/resources/examples/Showtimes/compiled/public/1.1/api.apib
@@ -1,0 +1,239 @@
+FORMAT: 1A
+
+# Mill unit test API, Showtimes
+This is the API Blueprint file for Mill unit test API, Showtimes.
+
+# Group Movies
+## Movies [/movies/{id}]
+
+### Get a single movie. [GET]
+Return information on a specific movie.
+
+Donec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem
+ipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis
+mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta
+sem malesuada magna mollis euismod.
+
+```
+[
+  {"id": "fizzbuzz"}
+]
+```
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Response 200 (application/json)
+    + Attributes (Movie)
++ Response 304 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
+
+### Update a movie. [PATCH]
+Update a movies data.
+
+This action requires a bearer token with the `edit` scope.
+
++ Parameters
+    - `id` (number, required) - Movie ID
++ Request
+    + Attributes
+        - `cast` (array) - Array of cast members.
+             - (object)
+                - `name`: `Natasha Hovey` (string) - Cast member name.
+                - `role`: `Cheryl` (string) - Cast member role.
+        - `content_rating`: `NR` (enum[string]) - MPAA rating
+            + Members
+                + `G` - Rated G
+                + `NC-17` - Rated NC-17
+                + `NR` - Not rated
+                + `PG` - Rated PG
+                + `PG-13` - Rated PG-13
+                + `R` - Rated R
+                + `UR` - Unrated
+                + `X` - Rated X
+        - `description` (string, required) - Description, or tagline, for the movie.
+        - `director`: `Lamberto Bava` (string) - Name of the director.
+        - `genres` (array[string]) - Array of movie genres.
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
+        - `name`: `Demons` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score`: `56` (number) - Rotten Tomatoes score
+        - `runtime`: `1hr 20min` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `trailer`: `https://www.youtube.com/watch?v=_cNjTdFHL8E` (string, nullable) - Trailer URL
++ Response 200 (application/json)
+    + Attributes (Movie)
++ Response 400 (application/json)
+    There are two ways that this status code can be encountered:
+         * If there is a problem with the request.
+         * If the IMDB URL could not be validated.
+    + Attributes (Error)
++ Response 404 (application/json)
+    + Attributes (Error)
+
+## Movies [/movies]
+
+### Get movies. [GET]
+Returns all movies for a specific location.
+
++ Request
+    + Attributes
+        - `location` (string, required) - Location you want movies for.
+        - `page` (number) - Page of results to pull.
++ Response 200 (application/json)
+    + Attributes (array[Movie])
++ Response 400 (application/json)
+    + Attributes (Error)
+
+### Create a movie. [POST]
+Create a new movie.
+
+This action requires a bearer token with the `create` scope.
+
++ Request
+    + Attributes
+        - `cast` (array) - Array of cast members.
+             - (object)
+                - `name`: `Natasha Hovey` (string) - Cast member name.
+                - `role`: `Cheryl` (string) - Cast member role.
+        - `content_rating`: `NR` (enum[string]) - MPAA rating
+            + Members
+                + `G` - Rated G
+                + `NC-17` - Rated NC-17
+                + `NR` - Not rated
+                + `PG` - Rated PG
+                + `PG-13` - Rated PG-13
+                + `R` - Rated R
+                + `UR` - Unrated
+                + `X` - Rated X
+        - `description` (string, required) - Description, or tagline, for the movie.
+        - `director`: `Lamberto Bava` (string) - Name of the director.
+        - `genres` (array[string]) - Array of movie genres.
+        - `imdb`: `https://www.imdb.com/title/tt0089013/` (string) - IMDB URL
+        - `is_kid_friendly` (boolean) - Is this movie kid friendly?
+        - `name`: `Demons` (string, required) - Name of the movie.
+        - `rotten_tomatoes_score`: `56` (number) - Rotten Tomatoes score
+        - `runtime`: `1hr 20min` (string) - Movie runtime, in `HHhr MMmin` format.
+        - `trailer`: `https://www.youtube.com/watch?v=_cNjTdFHL8E` (string, nullable) - Trailer URL
++ Response 200 (application/json)
+    + Attributes (Movie)
++ Response 400 (application/json)
+    There are two ways that this status code can be encountered:
+         * If there is a problem with the request.
+         * If the IMDB URL could not be validated.
+    + Attributes (Error)
+
+# Group Theaters
+## Theaters [/theaters/{id}]
+
+### Get a single movie theater. [GET]
+Return information on a specific movie theater.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Response 200 (application/json)
+    + Attributes (Theater)
++ Response 304 (application/json)
++ Response 404 (application/json)
+    + Attributes (Error)
+
+### Update a movie theater. [PATCH]
+Update a movie theaters' data.
+
+This action requires a bearer token with the `create` scope.
+
++ Parameters
+    - `id` (number, required) - Theater ID
++ Request
+    + Attributes
+        - `address`: `2548 Central Park Ave, Yonkers, NY 10710` (string, required) - Theater address
+        - `name`: `Alamo Drafthouse Cinema - Yonkers` (string, required) - Name of the theater.
+        - `phone_number`: `(914) 226-3082` (string, required) - Theater phone number
++ Response 200 (application/json)
+    + Attributes (Theater)
++ Response 400 (application/json)
+    + Attributes (Error)
++ Response 403 (application/json)
+    + Attributes (Coded error)
++ Response 404 (application/json)
+    + Attributes (Error)
+
+## Theaters [/theaters]
+
+### Get movie theaters. [GET]
+Returns all movie theatres for a specific location.
+
++ Request
+    + Attributes
+        - `location` (string, required) - Location you want theaters in.
++ Response 200 (application/json)
+    + Attributes (array[Theater])
++ Response 400 (application/json)
+    + Attributes (Error)
+
+### Create a movie theater. [POST]
+Create a new movie theater.
+
+This action requires a bearer token with the `create` scope.
+
++ Request
+    + Attributes
+        - `address`: `2548 Central Park Ave, Yonkers, NY 10710` (string, required) - Theater address
+        - `name`: `Alamo Drafthouse Cinema - Yonkers` (string, required) - Name of the theater.
+        - `phone_number`: `(914) 226-3082` (string, required) - Theater phone number
++ Response 200 (application/json)
+    + Attributes (Theater)
++ Response 400 (application/json)
+    + Attributes (Error)
+
+# Data Structures
+## Coded error
+- `error` (string, required) - User-friendly error message
+- `error_code` (number, required) - Error code
+
+## Error
+- `error` (string, required) - User-friendly error message
+
+## Movie
+- `cast` (array[Person], required) - Cast. This data requires a bearer token with the `public` scope.
+- `content_rating`: `G` (enum[string], required) - MPAA rating
+    + Members
+        + `G`
+        + `NC-17`
+        + `NR`
+        + `PG`
+        + `PG-13`
+        + `R`
+        + `UR`
+        + `X`
+- `description` (string, nullable) - Description
+- `director` (Person, required) - Director. This data requires a bearer token with the `public` scope.
+- `external_urls` (array) - External URLs. This data requires a bearer token with the `public` scope.
+     - (object)
+        - `imdb` (string, required) - IMDB URL. This data requires a bearer token with the `public` scope.
+        - `tickets` (string, required) - Tickets URL. This data requires a bearer token with the `public` scope.
+        - `trailer` (string, required) - Trailer URL. This data requires a bearer token with the `public` scope.
+- `genres` (array[string], required) - Genres
+- `id` (number, required) - Unique ID
+- `kid_friendly`: `false` (boolean, required) - Kid friendly?
+- `name` (string, required) - Name
+- `purchase` (object)
+    - `url` (string, nullable) - URL to purchase the film.
+- `rotten_tomatoes_score` (number, required) - Rotten Tomatoes score
+- `runtime` (string, required) - Runtime
+- `showtimes` (array[string], required) - Non-theater specific showtimes
+- `theaters` (array[Theater], required) - Theaters the movie is currently showing in
+- `uri` (string, required) - Movie URI
+
+## Person
+- `id` (number, required) - Unique ID
+- `imdb` (string, required) - IMDB URL
+- `name` (string, required) - Name
+- `uri` (string, required) - Person URI
+
+## Theater
+- `address` (string, required) - Address
+- `id` (number, required) - Unique ID
+- `movies` (array[Movie], required) - Movies currently playing
+- `name` (string, required) - Name
+- `phone_number` (string, required) - Phone number
+- `showtimes` (array[string], required) - Non-movie specific showtimes
+- `uri` (string, required) - Theater URI

--- a/resources/examples/Showtimes/compiled/public/1.1/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.1/api.yaml
@@ -1,0 +1,682 @@
+openapi: 3.0.0
+info:
+  title: 'Mill unit test API, Showtimes'
+  version: '1.1'
+  contact:
+    name: 'Get help!'
+    email: support@example.com
+    url: 'https://developer.example.com/help'
+tags:
+  -
+    name: Movies
+  -
+    name: Theaters
+servers:
+  -
+    url: 'https://api.example.com'
+    description: Production
+  -
+    url: 'https://api.example.local'
+    description: Development
+paths:
+  /movies:
+    get:
+      summary: 'Get movies.'
+      description: 'Returns all movies for a specific location.'
+      operationId: getMovies
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Location you want movies for.'
+          in: query
+          name: location
+          required: true
+          schema:
+            type: string
+        -
+          description: 'Page of results to pull.'
+          in: query
+          name: page
+          required: false
+          schema:
+            type: number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/movie'
+        400:
+          description: 'If the location is invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    post:
+      summary: 'Create a movie.'
+      description: 'Create a new movie.'
+      operationId: createMovie
+      tags:
+        - Movies
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cast:
+                  description: 'Array of cast members.'
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: 'Cast member name.'
+                        example: 'Natasha Hovey'
+                        type: string
+                      role:
+                        description: 'Cast member role.'
+                        example: Cheryl
+                        type: string
+                  type: array
+                content_rating:
+                  description: "MPAA rating\n\nOption descriptions:\n * `G` - Rated G\n * `NC-17` - Rated NC-17\n * `NR` - Not rated\n * `PG` - Rated PG\n * `PG-13` - Rated PG-13\n * `R` - Rated R\n * `UR` - Unrated\n * `X` - Rated X\n"
+                  enum:
+                    - G
+                    - NC-17
+                    - NR
+                    - PG
+                    - PG-13
+                    - R
+                    - UR
+                    - X
+                  example: NR
+                  type: string
+                description:
+                  description: 'Description, or tagline, for the movie.'
+                  type: string
+                director:
+                  description: 'Name of the director.'
+                  example: 'Lamberto Bava'
+                  type: string
+                genres:
+                  description: 'Array of movie genres.'
+                  items:
+                    type: string
+                  type: array
+                imdb:
+                  description: 'IMDB URL'
+                  example: 'https://www.imdb.com/title/tt0089013/'
+                  type: string
+                is_kid_friendly:
+                  description: 'Is this movie kid friendly?'
+                  type: boolean
+                name:
+                  description: 'Name of the movie.'
+                  example: Demons
+                  type: string
+                rotten_tomatoes_score:
+                  description: 'Rotten Tomatoes score'
+                  example: '56'
+                  type: number
+                runtime:
+                  description: 'Movie runtime, in `HHhr MMmin` format.'
+                  example: '1hr 20min'
+                  type: string
+                trailer:
+                  description: 'Trailer URL'
+                  example: 'https://www.youtube.com/watch?v=_cNjTdFHL8E'
+                  nullable: true
+                  type: string
+              required:
+                - description
+                - name
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        400:
+          description: "There are two ways that this status code can be encountered:\n * If there is a problem with the request.\n * If the IMDB URL could not be validated."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - create
+  '/movies/{id}':
+    get:
+      summary: 'Get a single movie.'
+      description: "Return information on a specific movie.\n\nDonec id elit non mi porta gravida at eget metus. Cras mattis consectetur purus sit amet fermentum. Lorem\nipsum dolor sit amet, consectetur adipiscing elit. Etiam porta sem malesuada magna mollis euismod. Duis\nmollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Etiam porta\nsem malesuada magna mollis euismod.\n\n```\n[\n  {\"id\": \"fizzbuzz\"}\n]\n```"
+      operationId: getMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        304:
+          description: 'If no content has been modified since the supplied Last-Modified header.'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    patch:
+      summary: 'Update a movie.'
+      description: 'Update a movies data.'
+      operationId: updateMovie
+      tags:
+        - Movies
+      parameters:
+        -
+          description: 'Movie ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cast:
+                  description: 'Array of cast members.'
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        description: 'Cast member name.'
+                        example: 'Natasha Hovey'
+                        type: string
+                      role:
+                        description: 'Cast member role.'
+                        example: Cheryl
+                        type: string
+                  type: array
+                content_rating:
+                  description: "MPAA rating\n\nOption descriptions:\n * `G` - Rated G\n * `NC-17` - Rated NC-17\n * `NR` - Not rated\n * `PG` - Rated PG\n * `PG-13` - Rated PG-13\n * `R` - Rated R\n * `UR` - Unrated\n * `X` - Rated X\n"
+                  enum:
+                    - G
+                    - NC-17
+                    - NR
+                    - PG
+                    - PG-13
+                    - R
+                    - UR
+                    - X
+                  example: NR
+                  type: string
+                description:
+                  description: 'Description, or tagline, for the movie.'
+                  type: string
+                director:
+                  description: 'Name of the director.'
+                  example: 'Lamberto Bava'
+                  type: string
+                genres:
+                  description: 'Array of movie genres.'
+                  items:
+                    type: string
+                  type: array
+                is_kid_friendly:
+                  description: 'Is this movie kid friendly?'
+                  type: boolean
+                name:
+                  description: 'Name of the movie.'
+                  example: Demons
+                  type: string
+                rotten_tomatoes_score:
+                  description: 'Rotten Tomatoes score'
+                  example: '56'
+                  type: number
+                runtime:
+                  description: 'Movie runtime, in `HHhr MMmin` format.'
+                  example: '1hr 20min'
+                  type: string
+                trailer:
+                  description: 'Trailer URL'
+                  example: 'https://www.youtube.com/watch?v=_cNjTdFHL8E'
+                  nullable: true
+                  type: string
+              required:
+                - description
+                - name
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/movie'
+        400:
+          description: "There are two ways that this status code can be encountered:\n * If there is a problem with the request.\n * If the IMDB URL could not be validated."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        404:
+          description: 'If the movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - edit
+  /theaters:
+    get:
+      summary: 'Get movie theaters.'
+      description: 'Returns all movie theatres for a specific location.'
+      operationId: getTheaters
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Location you want theaters in.'
+          in: query
+          name: location
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/theater'
+        400:
+          description: 'If the location is invalid.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    post:
+      summary: 'Create a movie theater.'
+      description: 'Create a new movie theater.'
+      operationId: createTheater
+      tags:
+        - Theaters
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                address:
+                  description: 'Theater address'
+                  example: '2548 Central Park Ave, Yonkers, NY 10710'
+                  type: string
+                name:
+                  description: 'Name of the theater.'
+                  example: 'Alamo Drafthouse Cinema - Yonkers'
+                  type: string
+                phone_number:
+                  description: 'Theater phone number'
+                  example: '(914) 226-3082'
+                  type: string
+              required:
+                - address
+                - name
+                - phone_number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        400:
+          description: 'If there is a problem with the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+      security:
+        -
+          oauth2:
+            - create
+  '/theaters/{id}':
+    get:
+      summary: 'Get a single movie theater.'
+      description: 'Return information on a specific movie theater.'
+      operationId: getTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        304:
+          description: 'If no content has been modified since the supplied Last-Modified header.'
+        404:
+          description: 'If the movie theater could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+    patch:
+      summary: 'Update a movie theater.'
+      description: 'Update a movie theaters'' data.'
+      operationId: updateTheater
+      tags:
+        - Theaters
+      parameters:
+        -
+          description: 'Theater ID'
+          in: path
+          name: id
+          required: true
+          schema:
+            type: number
+            example: '1234'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                address:
+                  description: 'Theater address'
+                  example: '2548 Central Park Ave, Yonkers, NY 10710'
+                  type: string
+                name:
+                  description: 'Name of the theater.'
+                  example: 'Alamo Drafthouse Cinema - Yonkers'
+                  type: string
+                phone_number:
+                  description: 'Theater phone number'
+                  example: '(914) 226-3082'
+                  type: string
+              required:
+                - address
+                - name
+                - phone_number
+      responses:
+        200:
+          description: 'Standard request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/theater'
+        400:
+          description: 'If there is a problem with the request.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        404:
+          description: 'If the movie movie could not be found.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+        403:
+          description: 'If something cool happened. Returns a unique error code of `1337`.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/coded-error'
+      security:
+        -
+          oauth2:
+            - create
+components:
+  securitySchemes:
+    bearer:
+      type: http
+      scheme: bearer
+      bearerFormat: bearer
+    oauth2:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: /oauth/authorize
+          tokenUrl: /oauth/access_token
+          scopes:
+            create: Create
+            delete: Delete
+            edit: Edit
+            public: Public
+        clientCredentials:
+          tokenUrl: /oauth/authorize/client
+          scopes:
+            create: Create
+            delete: Delete
+            edit: Edit
+            public: Public
+  schemas:
+    coded-error:
+      title: 'Coded error'
+      properties:
+        error:
+          description: 'User-friendly error message'
+          type: string
+        error_code:
+          description: 'Error code'
+          type: number
+      required:
+        - error
+        - error_code
+      type: object
+    error:
+      title: Error
+      properties:
+        error:
+          description: 'User-friendly error message'
+          type: string
+      required:
+        - error
+      type: object
+    movie:
+      title: Movie
+      properties:
+        cast:
+          description: 'Cast. This data requires a bearer token with the `public` scope.'
+          items:
+            $ref: '#/components/schemas/person'
+          type: array
+        content_rating:
+          description: 'MPAA rating'
+          enum:
+            - G
+            - NC-17
+            - NR
+            - PG
+            - PG-13
+            - R
+            - UR
+            - X
+          example: G
+          type: string
+        description:
+          description: Description
+          nullable: true
+          type: string
+        director:
+          allOf:
+            -
+              $ref: '#/components/schemas/person'
+          description: 'Director. This data requires a bearer token with the `public` scope.'
+        external_urls:
+          description: 'External URLs. This data requires a bearer token with the `public` scope.'
+          items:
+            type: object
+            properties:
+              imdb:
+                description: 'IMDB URL. This data requires a bearer token with the `public` scope.'
+                type: string
+              tickets:
+                description: 'Tickets URL. This data requires a bearer token with the `public` scope.'
+                type: string
+              trailer:
+                description: 'Trailer URL. This data requires a bearer token with the `public` scope.'
+                type: string
+            required:
+              - imdb
+              - tickets
+              - trailer
+          type: array
+        genres:
+          description: Genres
+          items:
+            type: string
+          type: array
+        id:
+          description: 'Unique ID'
+          type: number
+        kid_friendly:
+          description: 'Kid friendly?'
+          example: 'false'
+          type: boolean
+        name:
+          description: Name
+          type: string
+        purchase:
+          properties:
+            url:
+              description: 'URL to purchase the film.'
+              nullable: true
+              type: string
+          type: object
+        rotten_tomatoes_score:
+          description: 'Rotten Tomatoes score'
+          type: number
+        runtime:
+          description: Runtime
+          type: string
+        showtimes:
+          description: 'Non-theater specific showtimes'
+          items:
+            type: string
+          type: array
+        theaters:
+          description: 'Theaters the movie is currently showing in'
+          items:
+            $ref: '#/components/schemas/theater'
+          type: array
+        uri:
+          description: 'Movie URI'
+          type: string
+      required:
+        - cast
+        - content_rating
+        - director
+        - genres
+        - id
+        - kid_friendly
+        - name
+        - rotten_tomatoes_score
+        - runtime
+        - showtimes
+        - theaters
+        - uri
+      type: object
+    person:
+      title: Person
+      properties:
+        id:
+          description: 'Unique ID'
+          type: number
+        imdb:
+          description: 'IMDB URL'
+          type: string
+        name:
+          description: Name
+          type: string
+        uri:
+          description: 'Person URI'
+          type: string
+      required:
+        - id
+        - imdb
+        - name
+        - uri
+      type: object
+    theater:
+      title: Theater
+      properties:
+        address:
+          description: Address
+          type: string
+        id:
+          description: 'Unique ID'
+          type: number
+        movies:
+          description: 'Movies currently playing'
+          items:
+            $ref: '#/components/schemas/movie'
+          type: array
+        name:
+          description: Name
+          type: string
+        phone_number:
+          description: 'Phone number'
+          type: string
+        showtimes:
+          description: 'Non-movie specific showtimes'
+          items:
+            type: string
+          type: array
+        uri:
+          description: 'Theater URI'
+          type: string
+      required:
+        - address
+        - id
+        - movies
+        - name
+        - phone_number
+        - showtimes
+        - uri
+      type: object
+security:
+  -
+    oauth2:
+      - create
+      - delete
+      - edit
+      - public

--- a/src/Command/Compile.php
+++ b/src/Command/Compile.php
@@ -7,7 +7,6 @@ use Mill\Config;
 use Mill\Compiler\Specification\ApiBlueprint;
 use Mill\Exceptions\Version\UnrecognizedSchemaException;
 use Mill\Parser\Version;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -24,6 +23,9 @@ class Compile extends BaseCompiler
 
     /** @var Filesystem */
     private $filesystem;
+
+    /** @var bool */
+    private $for_public_consumption = false;
 
     /**
      * @return void
@@ -65,6 +67,15 @@ class Compile extends BaseCompiler
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Compile documentation for a specific server environment. Only available for `openapi` compilations.'
+            )
+            ->addOption(
+                'for_public_consumption',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Flag designating if you want compiled documentation be ready for the public to consume. This will ' .
+                    'forgo compiling in `x-mill-*` extensions, bypass creating group-specific specifications, as ' .
+                    'as not create specification-specific directories.',
+                false
             );
     }
 
@@ -90,6 +101,22 @@ class Compile extends BaseCompiler
         if (!in_array($format, ['apiblueprint', 'openapi'])) {
             $output->writeLn('<error>`' . $format . '` is an unknown compilation format.</error>');
             return 1;
+        }
+
+        $for_public_consumption = $input->getOption('for_public_consumption');
+        if (is_bool($for_public_consumption) && $for_public_consumption === true) {
+            $this->for_public_consumption = true;
+        } elseif (is_string($for_public_consumption) && strtolower($for_public_consumption) == 'true') {
+            $this->for_public_consumption = true;
+        } else {
+            $this->for_public_consumption = false;
+        }
+
+        // If we're compiling for public consumption, then ignore the `vendor_tag` and `private` arguments that may
+        // have been supplied.
+        if ($this->for_public_consumption) {
+            $this->vendor_tags = null;
+            $this->private_docs = false;
         }
 
         if ($input->getOption('default')) {
@@ -134,6 +161,10 @@ class Compile extends BaseCompiler
         $compiler->setLoadPrivateDocs($this->private_docs);
         $compiler->setLoadVendorTagDocs($this->vendor_tags);
 
+        if ($this->for_public_consumption) {
+            $compiler->setCompileWithExtensions(false);
+        }
+
         $output->writeln(
             sprintf(
                 '<comment>Compiling %s files...</comment>',
@@ -170,35 +201,42 @@ class Compile extends BaseCompiler
      */
     private function saveApiBlueprint(OutputInterface $output, string $version_dir, array $spec): void
     {
-        $version_dir .= self::FORMAT_API_BLUEPRINT . DIRECTORY_SEPARATOR;
+        // If we aren't compiling specifications for public consumption, then go ahead and put these specs under a
+        // specification-specific subdirectory.
+        if (!$this->for_public_consumption) {
+            $version_dir .= self::FORMAT_API_BLUEPRINT . DIRECTORY_SEPARATOR;
+        }
 
         // Save a, single, combined API Blueprint file.
         $this->filesystem->put($version_dir . 'api.apib', $spec['combined']);
 
-        // Process resource groups.
-        if (isset($spec['groups'])) {
-            foreach ($spec['groups'] as $group => $markdown) {
-                // Convert any nested groups, like `Me\Videos`, into a proper directory structure: `Me/Videos`.
-                $group = str_replace('\\', DIRECTORY_SEPARATOR, $group);
+        if (!$this->for_public_consumption) {
+            // Process resource groups.
+            if (isset($spec['groups'])) {
+                foreach ($spec['groups'] as $group => $markdown) {
+                    // Convert any nested groups, like `Users\Videos`, into a proper directory structure:
+                    // `Users/Videos`.
+                    $group = str_replace('\\', DIRECTORY_SEPARATOR, $group);
 
-                $this->filesystem->put(
-                    $version_dir . 'resources' . DIRECTORY_SEPARATOR . $group . '.apib',
-                    trim($markdown)
-                );
+                    $this->filesystem->put(
+                        $version_dir . 'resources' . DIRECTORY_SEPARATOR . $group . '.apib',
+                        trim($markdown)
+                    );
+                }
             }
-        }
 
-        // Process data structures.
-        if (isset($spec['structures'])) {
-            foreach ($spec['structures'] as $structure => $markdown) {
-                // Sanitize any structure names with forward slashes to avoid them from being nested in directories
-                // by Flysystem.
-                $structure = str_replace('/', '-', $structure);
+            // Process data structures.
+            if (isset($spec['structures'])) {
+                foreach ($spec['structures'] as $structure => $markdown) {
+                    // Sanitize any structure names with forward slashes to avoid them from being nested in directories
+                    // by Flysystem.
+                    $structure = str_replace('/', '-', $structure);
 
-                $this->filesystem->put(
-                    $version_dir . 'representations' . DIRECTORY_SEPARATOR . $structure . '.apib',
-                    trim($markdown)
-                );
+                    $this->filesystem->put(
+                        $version_dir . 'representations' . DIRECTORY_SEPARATOR . $structure . '.apib',
+                        trim($markdown)
+                    );
+                }
             }
         }
     }
@@ -210,23 +248,29 @@ class Compile extends BaseCompiler
      */
     private function saveOpenApi(OutputInterface $output, string $version_dir, array $spec): void
     {
-        $version_dir .= self::FORMAT_OPENAPI . DIRECTORY_SEPARATOR;
+        // If we aren't compiling specifications for public consumption, then go ahead and put these specs under a
+        // specification-specific subdirectory.
+        if (!$this->for_public_consumption) {
+            $version_dir .= self::FORMAT_OPENAPI . DIRECTORY_SEPARATOR;
+        }
 
         // Save the full specification.
         $this->filesystem->put($version_dir . 'api.yaml', OpenApi::getYaml($spec));
 
-        // Save individual specs for each tag.
-        $reducer = new OpenApi\TagReducer($spec);
-        $reduced = $reducer->reduce();
-        foreach ($reduced as $tag => $tagged_spec) {
-            // Convert any nested tags, like `Me\Videos`, into a proper directory structure: `Me/Videos`.
-            $tag = str_replace('\\', DIRECTORY_SEPARATOR, $tag);
-            $tag = str_replace('/', DIRECTORY_SEPARATOR, $tag);
+        if (!$this->for_public_consumption) {
+            // Save individual specs for each tag.
+            $reducer = new OpenApi\TagReducer($spec);
+            $reduced = $reducer->reduce();
+            foreach ($reduced as $tag => $tagged_spec) {
+                // Convert any nested tags, like `Users\Videos`, into a proper directory structure: `Users/Videos`.
+                $tag = str_replace('\\', DIRECTORY_SEPARATOR, $tag);
+                $tag = str_replace('/', DIRECTORY_SEPARATOR, $tag);
 
-            $this->filesystem->put(
-                $version_dir . 'tags' . DIRECTORY_SEPARATOR . $tag . '.yaml',
-                OpenApi::getYaml($tagged_spec)
-            );
+                $this->filesystem->put(
+                    $version_dir . 'tags' . DIRECTORY_SEPARATOR . $tag . '.yaml',
+                    OpenApi::getYaml($tagged_spec)
+                );
+            }
         }
     }
 }

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -36,6 +36,9 @@ class Compiler
     /** @var array */
     protected $parsed_representations = [];
 
+    /** @var bool A setting to compile specifications with `x-mill-*` extensions. */
+    protected $compile_with_extensions = true;
+
     /**
      * A setting to compile documentation for documentation that's been marked, through a `:private` decorator, as
      * private.
@@ -264,6 +267,18 @@ class Compiler
         }
 
         return $this->compiled_resources[$version];
+    }
+
+    /**
+     * Set if we should compile a specification with `x-mill-*` extensions.
+     *
+     * @param bool $with_extensions
+     * @return Compiler
+     */
+    public function setCompileWithExtensions(bool $with_extensions): self
+    {
+        $this->compile_with_extensions = $with_extensions;
+        return $this;
     }
 
     /**

--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -456,6 +456,10 @@ class OpenApi extends Compiler\Specification
      */
     protected function processExtensions(Action\Documentation $action, PathAnnotation $path): array
     {
+        if (!$this->compile_with_extensions) {
+            return [];
+        }
+
         $schema = [
             'x-mill-path-aliased' => $path->isAliased(),
             'x-mill-path-aliases' => array_map(
@@ -581,7 +585,7 @@ class OpenApi extends Compiler\Specification
                     }
                 }
 
-                if (isset($data['vendor_tags']) && !empty($data['vendor_tags'])) {
+                if ($this->compile_with_extensions && (isset($data['vendor_tags']) && !empty($data['vendor_tags']))) {
                     $spec['x-mill-vendor-tags'] = $data['vendor_tags'];
                 }
             } else {


### PR DESCRIPTION
When `--for_public_consumption=true` is supplied to the `compile` command, three things will happen:

* Compiled specifications will not contain `x-mill-*` extensions/vendor tags.
* Private documentation will not be compiled.
* Smaller grouped specifications (`compiled/1.0/openapi/tags/` or `compiled/1.0/apiblueprint/{representations|resources}`) will not be compiled. You will have a single `api.yaml` or `api.apib` in your version directory depending on whatever format you're compiling for.