### PR TITLE
Slimming down the error annotation and removing type/subtype support.

### DIFF
--- a/docs/reference/annotations/error.md
+++ b/docs/reference/annotations/error.md
@@ -22,23 +22,6 @@ This represents an exception that may be returned on a resource action.
 | vendor:tagName | ✓ | Defined vendor tag. See the [`@api-vendortag`](reference/annotations/vendortag.md) documentation for more information. There is no limit to the amount of vendor tags you can specify on a parameter. |
 | description | ✓ | A short description describing why, or what, this error is. |
 
-## Types and subtypes
-In addition to supporting straight descriptions, the [`@api-error`](reference/annotations/error.md) annotation also supports the concept of "types" and "subtypes". For example:
-
-```php
-@api-error:public 404 (\ErrorRepresentation) - {user}
-```
-
-In this case, this exception will be thrown when the `{user}` passed into the route (usually via the URI) is not found. The generated error message for this becomes: "If the user cannot be found."
-
-There also exist the concept of a subtype, represented as:
-
-```php
-@api-error:public 404 (\ErrorRepresentation) - {user,group}
-```
-
-This means that if the supplied group could not be found for the supplied user, an exception will be thrown. The generated error message for this is: "If the user cannot be found in the group."
-
 ## Examples
 Usage with a vendor tag and description type:
 

--- a/src/Parser/Annotations/ErrorAnnotation.php
+++ b/src/Parser/Annotations/ErrorAnnotation.php
@@ -17,11 +17,6 @@ class ErrorAnnotation extends Annotation
     const SUPPORTS_VENDOR_TAGS = true;
     const SUPPORTS_VERSIONING = true;
 
-    const REGEX_ERROR_CODE = '/^(\(.*\))/';
-    const REGEX_ERROR_HTTP_CODE = '/{([\d]+)}/';
-    const REGEX_ERROR_TYPE = '/{([\w\s]+)}/';
-    const REGEX_ERROR_SUB_TYPE = '/{([\w\s]+),([\w\s]+)}/';
-
     const ARRAYABLE = [
         'description',
         'error_code',
@@ -82,14 +77,6 @@ class ErrorAnnotation extends Annotation
                 },
                 $parsed['vendor_tags']
             );
-        }
-
-        if (!empty($parsed['description'])) {
-            if (preg_match(self::REGEX_ERROR_SUB_TYPE, $parsed['description'], $matches)) {
-                $parsed['description'] = sprintf('If %s was not found in the %s.', $matches[1], $matches[2]);
-            } elseif (preg_match(self::REGEX_ERROR_TYPE, $parsed['description'], $matches)) {
-                $parsed['description'] = sprintf('If %s was not found.', $matches[1]);
-            }
         }
 
         // Now that we've parsed out both the representation and error code, make sure that a representation that

--- a/tests/Parser/Annotations/ErrorAnnotationTest.php
+++ b/tests/Parser/Annotations/ErrorAnnotationTest.php
@@ -1,9 +1,7 @@
 <?php
 namespace Mill\Tests\Parser\Annotations;
 
-use Mill\Exceptions\Annotations\InvalidMSONSyntaxException;
 use Mill\Exceptions\Annotations\MissingRepresentationErrorCodeException;
-//use Mill\Exceptions\Annotations\MissingRequiredFieldException;
 use Mill\Exceptions\Annotations\UnknownErrorRepresentationException;
 use Mill\Exceptions\Annotations\UnknownReturnCodeException;
 use Mill\Parser\Annotations\ErrorAnnotation;
@@ -104,34 +102,6 @@ class ErrorAnnotationTest extends AnnotationTest
                     'visible' => true
                 ]
             ],
-            'description.error_type' => [
-                'content' => '404 (\Mill\Examples\Showtimes\Representations\Error) - {movie}',
-                'version' => null,
-                'visible' => true,
-                'expected' => [
-                    'description' => 'If movie was not found.',
-                    'error_code' => false,
-                    'http_code' => '404 Not Found',
-                    'representation' => '\Mill\Examples\Showtimes\Representations\Error',
-                    'vendor_tags' => [],
-                    'version' => false,
-                    'visible' => true
-                ]
-            ],
-            'description.error_type.suberror_type' => [
-                'content' => '404 (\Mill\Examples\Showtimes\Representations\Error) - {movie,theater}',
-                'version' => null,
-                'visible' => true,
-                'expected' => [
-                    'description' => 'If movie was not found in the theater.',
-                    'error_code' => false,
-                    'http_code' => '404 Not Found',
-                    'representation' => '\Mill\Examples\Showtimes\Representations\Error',
-                    'vendor_tags' => [],
-                    'version' => false,
-                    'visible' => true
-                ]
-            ],
             'error_code' => [
                 'content' => '403 (\Mill\Examples\Showtimes\Representations\CodedError<666>) - If the user is not ' .
                     'allowed to edit that movie.',
@@ -163,11 +133,11 @@ class ErrorAnnotationTest extends AnnotationTest
                 ]
             ],
             'private' => [
-                'content' => '404 (\Mill\Examples\Showtimes\Representations\Error) - {movie}',
+                'content' => '404 (\Mill\Examples\Showtimes\Representations\Error) - No such movie exists.',
                 'version' => null,
                 'visible' => false,
                 'expected' => [
-                    'description' => 'If movie was not found.',
+                    'description' => 'No such movie exists.',
                     'error_code' => false,
                     'http_code' => '404 Not Found',
                     'representation' => '\Mill\Examples\Showtimes\Representations\Error',
@@ -194,11 +164,11 @@ class ErrorAnnotationTest extends AnnotationTest
                 ]
             ],
             'versioned' => [
-                'content' => '404 (\Mill\Examples\Showtimes\Representations\Error) - {movie}',
+                'content' => '404 (\Mill\Examples\Showtimes\Representations\Error) - No such movie exists.',
                 'version' => new Version('1.1 - 1.2', __CLASS__, __METHOD__),
                 'visible' => false,
                 'expected' => [
-                    'description' => 'If movie was not found.',
+                    'description' => 'No such movie exists.',
                     'error_code' => false,
                     'http_code' => '404 Not Found',
                     'representation' => '\Mill\Examples\Showtimes\Representations\Error',
@@ -214,39 +184,6 @@ class ErrorAnnotationTest extends AnnotationTest
                 'visible' => true,
                 'expected' => [
                     'description' => 'If the tickets URL does not exist.',
-                    'error_code' => false,
-                    'http_code' => '404 Not Found',
-                    'representation' => '\Mill\Examples\Showtimes\Representations\Error',
-                    'vendor_tags' => [
-                        'tag:BUY_TICKETS'
-                    ],
-                    'version' => false,
-                    'visible' => true
-                ]
-            ],
-            '_complete.error_code' => [
-                'content' => '404 (\Mill\Examples\Showtimes\Representations\CodedError<666>, tag:BUY_TICKETS) - ' .
-                    '{movie,theater}',
-                'version' => null,
-                'visible' => true,
-                'expected' => [
-                    'description' => 'If movie was not found in the theater.',
-                    'error_code' => '666',
-                    'http_code' => '404 Not Found',
-                    'representation' => '\Mill\Examples\Showtimes\Representations\CodedError',
-                    'vendor_tags' => [
-                        'tag:BUY_TICKETS'
-                    ],
-                    'version' => false,
-                    'visible' => true
-                ]
-            ],
-            '_complete.type_subtype' => [
-                'content' => '404 (\Mill\Examples\Showtimes\Representations\Error, tag:BUY_TICKETS) - {movie,theater}',
-                'version' => null,
-                'visible' => true,
-                'expected' => [
-                    'description' => 'If movie was not found in the theater.',
                     'error_code' => false,
                     'http_code' => '404 Not Found',
                     'representation' => '\Mill\Examples\Showtimes\Representations\Error',


### PR DESCRIPTION
The existing type/subtype system on `@api-error` for swapping in error strings doesn't always work out that great in real world usage, and in the Vimeo API we end up eschewing it completely for a fully custom error message.

This feature is super niche and it's not worth making this a configurable message because we'll still run into the cases of most instances not fitting properly within it.

So because of all that, we're removing this feature from `@api-error` annotations.