### PR TITLE
Improving the `@api-group` annotation with configurable tag data.

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -264,6 +264,22 @@
                 </xs:complexType>
             </xs:element>
 
+            <xs:element name="tags" minOccurs="1" maxOccurs="1">
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:element name="tag" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:simpleContent>
+                                    <xs:extension base="xs:string">
+                                        <xs:attribute name="name" type="xs:string" use="required" />
+                                    </xs:extension>
+                                </xs:simpleContent>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:choice>
+                </xs:complexType>
+            </xs:element>
+
             <xs:element name="vendorTags" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
                     <xs:choice>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,10 +238,21 @@ Here, `\ErrorRepresentation` would have `needsErrorCode="true"`.
 Configure your API servers with the `<servers>` element.
 
 ```xml
-    <servers>
-        <server environment="prod" url="https://api.example.com" description="Production" />
-        <server environment="dev" url="https://api.example.local" description="Development" />
-    </servers>
+<servers>
+    <server environment="prod" url="https://api.example.com" description="Production" />
+    <server environment="dev" url="https://api.example.local" description="Development" />
+</servers>
+```
+
+### Tags
+When building [resource actions](reference/resource-actions.md), you can use [`@api-group`](reference/annotations/group.md) to place your action within a specific group (or tag), that you can later use to reference. The `<tags>` config is here so you can configure your grouping tags, and potentially any additional metadata descriptions you'd like to attach to those in your compiled specifications.
+
+```xml
+<tags>
+    <tag name="Movies">These resources help you handle movies.</tag>
+    <tag name="Movies\Coming Soon" />
+    <tag name="Theaters" />
+</tags>
 ```
 
 ### Vendor tags

--- a/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
@@ -8,9 +8,10 @@ info:
     url: 'https://developer.example.com/help'
 tags:
   -
-    name: Movies
-  -
     name: Theaters
+  -
+    name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
@@ -9,6 +9,7 @@ info:
 tags:
   -
     name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
@@ -8,9 +8,10 @@ info:
     url: 'https://developer.example.com/help'
 tags:
   -
-    name: Movies
-  -
     name: Theaters
+  -
+    name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
@@ -9,6 +9,7 @@ info:
 tags:
   -
     name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
@@ -8,9 +8,10 @@ info:
     url: 'https://developer.example.com/help'
 tags:
   -
-    name: Movies
-  -
     name: Theaters
+  -
+    name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
@@ -9,6 +9,7 @@ info:
 tags:
   -
     name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
@@ -8,9 +8,10 @@ info:
     url: 'https://developer.example.com/help'
 tags:
   -
-    name: Movies
-  -
     name: Theaters
+  -
+    name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
@@ -9,6 +9,7 @@ info:
 tags:
   -
     name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
@@ -8,9 +8,10 @@ info:
     url: 'https://developer.example.com/help'
 tags:
   -
-    name: Movies
-  -
     name: Theaters
+  -
+    name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
@@ -9,6 +9,7 @@ info:
 tags:
   -
     name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/public/1.0/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.0/api.yaml
@@ -8,9 +8,10 @@ info:
     url: 'https://developer.example.com/help'
 tags:
   -
-    name: Movies
-  -
     name: Theaters
+  -
+    name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/public/1.1.1/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.1.1/api.yaml
@@ -8,9 +8,10 @@ info:
     url: 'https://developer.example.com/help'
 tags:
   -
-    name: Movies
-  -
     name: Theaters
+  -
+    name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/public/1.1.2/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.1.2/api.yaml
@@ -8,9 +8,10 @@ info:
     url: 'https://developer.example.com/help'
 tags:
   -
-    name: Movies
-  -
     name: Theaters
+  -
+    name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/public/1.1.3/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.1.3/api.yaml
@@ -8,9 +8,10 @@ info:
     url: 'https://developer.example.com/help'
 tags:
   -
-    name: Movies
-  -
     name: Theaters
+  -
+    name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/Showtimes/compiled/public/1.1/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.1/api.yaml
@@ -8,9 +8,10 @@ info:
     url: 'https://developer.example.com/help'
 tags:
   -
-    name: Movies
-  -
     name: Theaters
+  -
+    name: Movies
+    description: 'These resources help you handle movies.'
 servers:
   -
     url: 'https://api.example.com'

--- a/resources/examples/mill.xml
+++ b/resources/examples/mill.xml
@@ -79,6 +79,12 @@
         </translations>
     </pathParams>
 
+    <tags>
+        <tag name="Movies">These resources help you handle movies.</tag>
+        <tag name="Movies\Coming Soon" />
+        <tag name="Theaters" />
+    </tags>
+
     <vendorTags>
         <vendorTag name="tag:BUY_TICKETS" />
         <vendorTag name="tag:DELETE_CONTENT" />

--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -223,16 +223,24 @@ class OpenApi extends Compiler\Specification
      */
     protected function processTags(array $groups, array $group_excludes): array
     {
+        $configured_tags = $this->config->getTags();
+
         $tags = array_filter(
             array_map(
-                function (string $group) use ($group_excludes): ?array {
+                function (string $group) use ($group_excludes, $configured_tags): ?array {
                     if (in_array($group, $group_excludes)) {
                         return [];
                     }
 
-                    return [
+                    $tag = [
                         'name' => $group
                     ];
+
+                    if (!empty($configured_tags[$group])) {
+                        $tag['description'] = $configured_tags[$group];
+                    }
+
+                    return $tag;
                 },
                 array_keys($groups)
             )

--- a/src/Config.php
+++ b/src/Config.php
@@ -58,6 +58,9 @@ class Config
     /** @var array Array of API versions. */
     protected $api_versions = [];
 
+    /** @var array Allowable list of valid resource tags. */
+    protected $tags = [];
+
     /** @var array Allowable list of valid application vendor tags. */
     protected $vendor_tags = [];
 
@@ -152,10 +155,25 @@ class Config
         $config->loadPathParamTranslations($xml);
         $config->loadRepresentations($xml);
         $config->loadServers($xml);
+        $config->loadTags($xml);
         $config->loadVendorTags($xml);
         $config->loadVersions($xml);
 
         return $config;
+    }
+
+    /**
+     * @param SimpleXMLElement $xml
+     */
+    protected function loadTags(SimpleXMLElement $xml): void
+    {
+        /** @var SimpleXMLElement $tag */
+        foreach ($xml->tags->tag as $tag) {
+            $name = (string) $tag['name'];
+            $description = trim((string) $tag);
+
+            $this->tags[$name] = (!empty($description)) ? $description : null;
+        }
     }
 
     /**
@@ -657,6 +675,16 @@ class Config
         }
 
         throw new \Exception('The supplied version, `' . $version . '`` was not found to be configured.');
+    }
+
+    /**
+     * Get the array of configured resource tags.
+     *
+     * @return array
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
     }
 
     /**

--- a/src/Exceptions/Annotations/InvalidGroupSuppliedException.php
+++ b/src/Exceptions/Annotations/InvalidGroupSuppliedException.php
@@ -1,0 +1,48 @@
+<?php
+namespace Mill\Exceptions\Annotations;
+
+use Mill\Exceptions\BaseException;
+
+class InvalidGroupSuppliedException extends BaseException
+{
+    use AnnotationExceptionTrait;
+
+    /** @var string */
+    public $group;
+
+    /**
+     * @param string $group
+     * @param string $class
+     * @param string $method
+     * @return InvalidGroupSuppliedException
+     */
+    public static function create(
+        string $group,
+        string $class,
+        string $method
+    ): self {
+        $message = sprintf(
+            'The group on `@api-group %s` in %s::%s is not present in your config.',
+            $group,
+            $class,
+            $method
+        );
+
+        $exception = new self($message);
+        $exception->group = $group;
+        $exception->class = $class;
+        $exception->method = $method;
+
+        return $exception;
+    }
+
+    /**
+     * Get the vendor tag that this exception occurred with.
+     *
+     * @return string
+     */
+    public function getGroup(): string
+    {
+        return $this->group;
+    }
+}

--- a/src/Parser/Annotations/GroupAnnotation.php
+++ b/src/Parser/Annotations/GroupAnnotation.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mill\Parser\Annotations;
 
+use Mill\Exceptions\Annotations\InvalidGroupSuppliedException;
 use Mill\Parser\Annotation;
 
 class GroupAnnotation extends Annotation
@@ -17,8 +18,20 @@ class GroupAnnotation extends Annotation
      */
     protected function parser(): array
     {
+        $group = trim($this->docblock);
+
+        if (!empty($group)) {
+            // Validate the supplied vendor tag with what has been configured as allowable.
+            $tags = $this->application->getConfig()->getTags();
+            if (!array_key_exists($group, $tags)) {
+                /** @var string $method */
+                $method = $this->method;
+                throw InvalidGroupSuppliedException::create($group, $this->class, $method);
+            }
+        }
+
         return [
-            'group' => $this->docblock
+            'group' => $group
         ];
     }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -94,6 +94,12 @@ class ConfigTest extends TestCase
         ], $config->getVendorTags());
 
         $this->assertSame([
+            'Movies' => 'These resources help you handle movies.',
+            'Movies\Coming Soon' => null,
+            'Theaters' => null
+        ], $config->getTags());
+
+        $this->assertSame([
             'bearer' => [
                 'format' => 'bearer'
             ],
@@ -308,6 +314,11 @@ XML;
     $representations
     $authentication
     $xml
+
+    <tags>
+        <tag name="Movies">These resources help you handle movies.</tag>
+        <tag name="Theaters" />
+    </tags>
 </mill>
 XML;
 

--- a/tests/Parser/Annotations/GroupAnnotationTest.php
+++ b/tests/Parser/Annotations/GroupAnnotationTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Mill\Tests\Parser\Annotations;
 
+use Mill\Exceptions\Annotations\InvalidGroupSuppliedException;
 use Mill\Exceptions\Annotations\MissingRequiredFieldException;
 use Mill\Parser\Annotations\GroupAnnotation;
 
@@ -55,6 +56,14 @@ class GroupAnnotationTest extends AnnotationTest
                     'getAnnotation' => 'group',
                     'getDocblock' => '',
                     'getValues' => []
+                ]
+            ],
+            'tag-was-not-configured' => [
+                'annotation' => GroupAnnotation::class,
+                'content' => 'Moviesss',
+                'expected.exception' => InvalidGroupSuppliedException::class,
+                'expected.exception.asserts' => [
+                    'getGroup' => 'Moviesss'
                 ]
             ]
         ];

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -948,7 +948,7 @@ DESCRIPTION;
                 'docblock' => '/**
                   * @api-label Update a piece of content.
                   * @api-operationid updateFoo
-                  * @api-group Foo\Bar
+                  * @api-group Movies
                   *
                   * @api-path:public /foo
                   * @api-path:private:alias /bar
@@ -993,7 +993,7 @@ DESCRIPTION;
                 'docblock' => '/**
                   * @api-label Update a piece of content.
                   * @api-operationid updateFoo
-                  * @api-group Foo\Bar
+                  * @api-group Movies
                   *
                   * @api-path:public /foo
                   * @api-path:private /bar
@@ -1030,7 +1030,7 @@ DESCRIPTION;
                 'docblock' => '/**
                   * @api-label Delete a piece of content.
                   * @api-operationid deleteFoo
-                  * @api-group Foo\Bar
+                  * @api-group Movies
                   *
                   * @api-path:private /foo
                   *
@@ -1117,7 +1117,7 @@ DESCRIPTION;
                   *
                   * @api-label Test Method
                   * @api-operationid testFoo
-                  * @api-group Something
+                  * @api-group Movies
                   * @api-path /some/page
                   */',
                 'expected.exception' => '\Mill\Exceptions\Annotations\RequiredAnnotationException',
@@ -1131,7 +1131,7 @@ DESCRIPTION;
                   *
                   * @api-label Test method
                   * @api-operationid testFoo
-                  * @api-group Root
+                  * @api-group Movies
                   * @api-path /
                   * @api-contenttype application/json
                   * @api-return:public {collection} \Mill\Examples\Showtimes\Representations\Representation
@@ -1147,7 +1147,7 @@ DESCRIPTION;
                   *
                   * @api-label Test method
                   * @api-operationid testFoo
-                  * @api-group Root
+                  * @api-group Movies
                   * @api-path:special /
                   * @api-contenttype application/json
                   * @api-return {collection} \Mill\Examples\Showtimes\Representations\Representation
@@ -1164,7 +1164,7 @@ DESCRIPTION;
                   *
                   * @api-label Test method
                   * @api-operationid testFoo
-                  * @api-group Something
+                  * @api-group Movies
                   * @api-contenttype application/json
                   * @api-param:public {page}
                   */',
@@ -1179,7 +1179,7 @@ DESCRIPTION;
                   *
                   * @api-label Test method
                   * @api-operationid testFoo
-                  * @api-group Search
+                  * @api-group Movies
                   * @api-path:private /search
                   * @api-contenttype application/json
                   * @api-scope public
@@ -1198,7 +1198,7 @@ DESCRIPTION;
                   *
                   * @api-label Test method
                   * @api-operationid testFoo
-                  * @api-group Search
+                  * @api-group Movies
                   * @api-path:private:alias /search
                   * @api-path:private:alias /search2
                   * @api-contenttype application/json

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -46,7 +46,7 @@ class ParserTest extends TestCase
     {
         $this->overrideReadersWithFakeDocblockReturn('/**
           * @api-label Update a piece of content.
-          * @api-group Foo\Bar
+          * @api-group Movies
           *
           * @api-path:public /foo
           * @api-path:private:deprecated /bar

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -100,6 +100,12 @@
         </translations>
     </pathParams>
 
+    <tags>
+        <tag name="Movies">These resources help you handle movies.</tag>
+        <tag name="Movies\Coming Soon" />
+        <tag name="Theaters" />
+    </tags>
+
     <vendorTags>
         <vendorTag name="tag:BUY_TICKETS" />
         <vendorTag name="tag:DELETE_CONTENT" />


### PR DESCRIPTION
`@api-group` data must now be configured within `mill.xml` under `<tags>`. In addition to being more strict about group names (and avoiding any accidental typos), you can now also add a description to your group that's then compiled into your OpenAPI spec for further use.

Resolves https://github.com/vimeo/mill/issues/212