### PR TITLE
Asserting that string boolean examples are converted to real booleans.

### DIFF
--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -789,9 +789,9 @@ class OpenApi extends Compiler\Specification
     {
         // Booleans in OpenAPI specifications should be represented as booleans, not stringified versions of booleans.
         if ($type === 'boolean') {
-            if ($data === '0') {
+            if ($data === '0' || $data === 'false') {
                 return false;
-            } elseif ($data === '1') {
+            } elseif ($data === '1' || $data === 'true') {
                 return true;
             }
         }


### PR DESCRIPTION
```
@api-data active `true` (boolean) - Whether this video version is the currently active one.
```

This'll solve an issue where that `true` example is being compiled into a string `true` in the OpenAPI spec instead of a booleanified version. As since the example is being compiled as a string, it doesn't match its type, so OpenAPI validation fails on that piece of data.

Oops!