### PR TITLE
OpenAPI generated examples for `array<enum>` were in the wrong place.

### DIFF
--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -636,6 +636,12 @@ class OpenApi extends Compiler\Specification
                         'type' => 'string'
                     ];
                 }
+
+                // Array examples should be at the level of `items`, not `schema`.
+                if (isset($spec['example'])) {
+                    $spec['items']['example'] = $spec['example'];
+                    unset($spec['example']);
+                }
             }
 
             // Request body and response schema requirement definitions need to be separate from the item schema.


### PR DESCRIPTION
```
@api-data content_filter (array<enum>, optional) - The user's content filters:
    + Members
        - `language` - Profanity or sexually suggestive content.
        - `drugs` - Drugs or alcohol use.
        - `violence` - Violent or graphic content.
        - `nudity` - Nudity.
        - `safe` - Suitable for all audiences.
        - `unrated` - No rating.
```

Annotations like this were being generated with the following, improper, JSON schema:

```
content_filter:
    description: "The user's content filters:\n\nOption descriptions:\n * `drugs` - Drugs or alcohol use.\n * `language` - Profanity or sexually suggestive content.\n * `nudity` - Nudity.\n * `safe` - Suitable for all audiences.\n * `unrated` - No rating.\n * `violence` - Violent or graphic content.\n"
    enum:
        - drugs
        - language
        - nudity
        - safe
        - unrated
        - violence
    example: drugs
    items:
        type: string
    type: array
```

`example` should be within the `items` object, not at the root level of the schema entry.