### PR TITLE
Refixing the syntax for `@api-return` to be more MSON-like.

### DIFF
--- a/docs/reference/annotations/return.md
+++ b/docs/reference/annotations/return.md
@@ -9,7 +9,7 @@ The return type should be indicative of the HTTP code that will be delivered (ex
 
 ## Syntax
 ```php
-@api-return:visibility {return type} \Representation description
+@api-return:visibility returnType (\Representation) - Description
 ```
 
 ## Requirements
@@ -21,9 +21,9 @@ The return type should be indicative of the HTTP code that will be delivered (ex
 | Tag | Optional | Description |
 | :--- | :--- | :--- |
 | :visibility | ✓ | [Visibility decorator](reference/visibility.md) |
-| {return type} | × | The type of response that will be returned. Example: `{ok}`, `{accepted}`, `{notmodified}`, etc. |
+| returnType | × | The type of response that will be returned. Example: `ok`, `accepted`, `notmodified`, etc. |
 | \Representation | ✓ | The fully qualified class name for a representation that will be returned. If your action is handling things like a `{delete}` or `{notmodified}` call, that normally don't return any data, you can exclude this. |
-| description | * | A short description describing why, or what, this response is. A description is only required when the returning HTTP code for this return is non-200. |
+| Description | * | A short description describing why, or what, this response is. A description is only required when the returning HTTP code for this return is non-200. |
 
 ## Available return types
 | HTTP Code | Designator |
@@ -47,7 +47,7 @@ The return type should be indicative of the HTTP code that will be delivered (ex
 /**
  * ...
  *
- * @api-return:private {accepted} \Some\Representation
+ * @api-return:private accepted (\Some\Representation)
  */
 public function PATCH()
 {
@@ -59,7 +59,7 @@ public function PATCH()
 /**
  * ...
  *
- * @api-return:public {notmodified} If no content has changed since the last modified date.
+ * @api-return:public notmodified - If no content has changed since the last modified date.
  */
 public function GET()
 {

--- a/docs/reference/deprecation.md
+++ b/docs/reference/deprecation.md
@@ -20,7 +20,7 @@ You might have instances where you need to deprecate a resource action request p
  * @api-contenttype application/json
  * @api-scope public
  *
- * @api-return:public {object} \MyApplication\Representations\Movie
+ * @api-return:public object (\MyApplication\Representations\Movie)
  *
  * @api-error:public 404 (\MyApplicationRepresentations\Error) - If the movie
  *     could not be found.

--- a/docs/writing-documentation.md
+++ b/docs/writing-documentation.md
@@ -31,9 +31,9 @@ class UsersController extends \MyApplication\Controller
      *     each page. Max 100.
      * @api-queryparam:public query (string, required) - Search query.
      *
-     * @api-return:public {collection} \MyApplication\Representation\User
+     * @api-return:public collection (\MyApplication\Representation\User)
      *
-     * @api-error:public {503} \MyApplication\Representation\Error If search
+     * @api-error:public 503 (\MyApplication\Representation\Error) - If search
      *     is disabled.
      */
     public function GET()

--- a/resources/examples/Showtimes/Controllers/Movie.php
+++ b/resources/examples/Showtimes/Controllers/Movie.php
@@ -25,8 +25,8 @@ class Movie
      * @api-path:public /movies/+movie_id
      * @api-pathparam movie_id `1234` (integer) - Movie ID
      *
-     * @api-return:public {object} \Mill\Examples\Showtimes\Representations\Movie
-     * @api-return:public {notmodified} If no content has been modified since the supplied Last-Modified header.
+     * @api-return:public object (\Mill\Examples\Showtimes\Representations\Movie)
+     * @api-return:public notmodified - If no content has been modified since the supplied Last-Modified header.
      *
      * @api-error:public 404 (\Mill\Examples\Showtimes\Representations\Error) - If the movie could not be found.
      *
@@ -81,7 +81,7 @@ class Movie
      * @api-param:public is_kid_friendly (boolean, optional) - Is this movie kid friendly?
      * @api-param:public rotten_tomatoes_score `56` (integer, optional) - Rotten Tomatoes score
      *
-     * @api-return:public {object} \Mill\Examples\Showtimes\Representations\Movie
+     * @api-return:public object (\Mill\Examples\Showtimes\Representations\Movie)
      *
      * @api-error:public 400 (\Mill\Examples\Showtimes\Representations\Error) - If there is a problem with the request.
      * @api-error:public 400 (\Mill\Examples\Showtimes\Representations\Error) - If the IMDB URL could not be validated.
@@ -97,7 +97,7 @@ class Movie
      * @api-param:public imdb `https://www.imdb.com/title/tt0089013/` (string, optional) - IMDB URL
      *
      * @api-version >=1.1.3
-     * @api-return:public {accepted} \Mill\Examples\Showtimes\Representations\Movie
+     * @api-return:public accepted (\Mill\Examples\Showtimes\Representations\Movie)
      * @api-error:public 404 (\Mill\Examples\Showtimes\Representations\Error) - If the trailer URL could not be
      *      validated.
      * @api-error:private 403 (\Mill\Examples\Showtimes\Representations\CodedError<1337>) - If something cool happened.
@@ -125,7 +125,7 @@ class Movie
      * @api-minVersion 1.1
      * @api-maxVersion 1.1.2
      *
-     * @api-return:private {deleted}
+     * @api-return:private deleted
      *
      * @api-error:private 404 (\Mill\Examples\Showtimes\Representations\Error) - If the movie could not be found.
      */

--- a/resources/examples/Showtimes/Controllers/Movies.php
+++ b/resources/examples/Showtimes/Controllers/Movies.php
@@ -14,7 +14,7 @@ class Movies
      *
      * @api-queryparam:public location (string, required) - Location you want movies for.
      *
-     * @api-return:public {collection} \Mill\Examples\Showtimes\Representations\Movie
+     * @api-return:public collection (\Mill\Examples\Showtimes\Representations\Movie)
      *
      * @api-error:public 400 (\Mill\Examples\Showtimes\Representations\Error) - If the location is invalid.
      *
@@ -64,7 +64,7 @@ class Movies
      * @api-param:public is_kid_friendly (boolean, optional) - Is this movie kid friendly?
      * @api-param:public rotten_tomatoes_score `56` (integer, optional) - Rotten Tomatoes score
      *
-     * @api-return:public {object} \Mill\Examples\Showtimes\Representations\Movie
+     * @api-return:public object (\Mill\Examples\Showtimes\Representations\Movie)
      *
      * @api-error:public 400 (\Mill\Examples\Showtimes\Representations\Error) - If there is a problem with the request.
      * @api-error:public 400 (\Mill\Examples\Showtimes\Representations\Error) - If the IMDB URL could not be validated.
@@ -81,7 +81,7 @@ class Movies
      *      URL
      *
      * @api-version >=1.1.3
-     * @api-return:public {created}
+     * @api-return:public created
      */
     public function POST()
     {

--- a/resources/examples/Showtimes/Controllers/Theater.php
+++ b/resources/examples/Showtimes/Controllers/Theater.php
@@ -13,8 +13,8 @@ class Theater
      * @api-path:public /theaters/+id
      * @api-pathparam id `1234` (integer) - Theater ID
      *
-     * @api-return:public {object} \Mill\Examples\Showtimes\Representations\Theater
-     * @api-return:public {notmodified} If no content has been modified since the supplied Last-Modified header.
+     * @api-return:public object (\Mill\Examples\Showtimes\Representations\Theater)
+     * @api-return:public notmodified - If no content has been modified since the supplied Last-Modified header.
      *
      * @api-error:public 404 (\Mill\Examples\Showtimes\Representations\Error) - If the movie theater could not be found.
      *
@@ -45,7 +45,7 @@ class Theater
      * @api-param:public address `2548 Central Park Ave, Yonkers, NY 10710` (string, required) - Theater address
      * @api-param:public phone_number `(914) 226-3082` (string, required) - Theater phone number
      *
-     * @api-return:public {object} \Mill\Examples\Showtimes\Representations\Theater
+     * @api-return:public object (\Mill\Examples\Showtimes\Representations\Theater)
      *
      * @api-error:public 400 (\Mill\Examples\Showtimes\Representations\Error) - If there is a problem with the request.
      * @api-error:public 404 (\Mill\Examples\Showtimes\Representations\Error) - If the movie movie could not be found.
@@ -75,7 +75,7 @@ class Theater
      * @api-contenttype application/json
      * @api-scope delete
      *
-     * @api-return:private {deleted}
+     * @api-return:private deleted
      *
      * @api-error:private 404 (\Mill\Examples\Showtimes\Representations\Error) - If the movie theater could not be
      *      found.

--- a/resources/examples/Showtimes/Controllers/Theaters.php
+++ b/resources/examples/Showtimes/Controllers/Theaters.php
@@ -14,7 +14,7 @@ class Theaters
      *
      * @api-queryparam:public location (string, required) - Location you want theaters in.
      *
-     * @api-return:public {collection} \Mill\Examples\Showtimes\Representations\Theater
+     * @api-return:public collection (\Mill\Examples\Showtimes\Representations\Theater)
      *
      * @api-error:public 400 (\Mill\Examples\Showtimes\Representations\Error) - If the location is invalid.
      *
@@ -44,7 +44,7 @@ class Theaters
      * @api-param:public address `2548 Central Park Ave, Yonkers, NY 10710` (string, required) - Theater address
      * @api-param:public phone_number `(914) 226-3082` (string, required) - Theater phone number
      *
-     * @api-return:public {object} \Mill\Examples\Showtimes\Representations\Theater
+     * @api-return:public object (\Mill\Examples\Showtimes\Representations\Theater)
      *
      * @api-error:public 400 (\Mill\Examples\Showtimes\Representations\Error) - If there is a problem with the request.
      *

--- a/src/Parser/Annotations/ReturnAnnotation.php
+++ b/src/Parser/Annotations/ReturnAnnotation.php
@@ -1,12 +1,12 @@
 <?php
 namespace Mill\Parser\Annotations;
 
-use Mill\Container;
 use Mill\Exceptions\Annotations\UnknownRepresentationException;
 use Mill\Exceptions\Annotations\UnknownReturnCodeException;
-use Mill\Exceptions\Config\UnconfiguredRepresentationException;
+use Mill\Exceptions\Annotations\UnsupportedTypeException;
 use Mill\Parser\Annotation;
 use Mill\Parser\Annotations\Traits\HasHttpCodeResponseTrait;
+use Mill\Parser\MSON;
 
 class ReturnAnnotation extends Annotation
 {
@@ -14,8 +14,6 @@ class ReturnAnnotation extends Annotation
 
     const REQUIRES_VISIBILITY_DECORATOR = true;
     const SUPPORTS_VERSIONING = true;
-
-    const REGEX_TYPE = '/^({[^}]*})/';
 
     const ARRAYABLE = [
         'description',
@@ -38,47 +36,29 @@ class ReturnAnnotation extends Annotation
      */
     protected function parser(): array
     {
-        $parsed = [];
+        $config = $this->application->getConfig();
         $content = trim($this->docblock);
 
-        // Parameter type is surrounded by `{curly braces}`.
-        if (preg_match(self::REGEX_TYPE, $content, $matches)) {
-            $parsed['type'] = substr($matches[1], 1, -1);
+        /** @var string $method */
+        $method = $this->method;
+        try {
+            $mson = new MSON($this->class, $method, $config);
+            $mson = $mson->parse($content);
+        } catch (UnsupportedTypeException $e) {
+            throw UnknownRepresentationException::create($content, $this->class, $method);
+        }
 
-            $code = $this->findReturnCodeForType($parsed['type']);
+        $field = $mson->getField();
+        $parsed = [
+            'type' => $field,
+            'description' => $mson->getDescription(),
+            'representation' => $mson->getType()
+        ];
+
+        if (!empty($field)) {
+            $code = $this->findReturnCodeForType($field);
             $parsed['http_code'] = $code . ' ' . $this->getHttpCodeMessage($code);
-
-            $content = trim(preg_replace(self::REGEX_TYPE, '', $content));
         }
-
-        $parts = explode(' ', $content);
-        $representation = array_shift($parts);
-        $description = trim(implode(' ', $parts));
-
-        if (!empty($representation)) {
-            // If the supplied representation /looks/ like a PHP FQN, then treat it as such, and verify that it's been
-            // either configured or ignored.
-            if (preg_match('/\\\([\\w]+)/', $representation)) {
-                // Verify that the supplied representation class exists. If it's being excluded, we can just go ahead
-                // and set it here anyways, as we'll be looking further up the stack to determine if we should actually
-                // parse it for documentation.
-                //
-                // If the class doesn't exist, this method call will throw an exception back out.
-                try {
-                    $this->application->getConfig()->doesRepresentationExist($representation);
-                } catch (UnconfiguredRepresentationException $e) {
-                    /** @var string $method */
-                    $method = $this->method;
-                    throw UnknownRepresentationException::create($representation, $this->class, $method);
-                }
-            } else {
-                $description = trim($representation . ' ' . $description);
-                $representation = false;
-            }
-        }
-
-        $parsed['representation'] = $representation;
-        $parsed['description'] = (!empty($description)) ? $description : null;
 
         return $parsed;
     }

--- a/tests/Parser/Annotations/ReturnAnnotationTest.php
+++ b/tests/Parser/Annotations/ReturnAnnotationTest.php
@@ -1,7 +1,6 @@
 <?php
 namespace Mill\Tests\Parser\Annotations;
 
-use Mill\Exceptions\Annotations\MissingRequiredFieldException;
 use Mill\Exceptions\Annotations\UnknownRepresentationException;
 use Mill\Exceptions\Annotations\UnknownReturnCodeException;
 use Mill\Parser\Annotations\ReturnAnnotation;
@@ -50,7 +49,7 @@ class ReturnAnnotationTest extends AnnotationTest
     {
         return [
             'with-no-representation' => [
-                'content' => '{deleted}',
+                'content' => 'deleted',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -63,7 +62,7 @@ class ReturnAnnotationTest extends AnnotationTest
                 ]
             ],
             'with-no-representation-and-a-description' => [
-                'content' => '{notmodified} If no data has been changed.',
+                'content' => 'notmodified - If no data has been changed.',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -76,7 +75,7 @@ class ReturnAnnotationTest extends AnnotationTest
                 ]
             ],
             'private' => [
-                'content' => '{notmodified} If no data has been changed.',
+                'content' => 'notmodified - If no data has been changed.',
                 'visible' => false,
                 'version' => null,
                 'expected' => [
@@ -89,7 +88,7 @@ class ReturnAnnotationTest extends AnnotationTest
                 ]
             ],
             'versioned' => [
-                'content' => '{collection} \Mill\Examples\Showtimes\Representations\Movie',
+                'content' => 'collection (\Mill\Examples\Showtimes\Representations\Movie)',
                 'visible' => true,
                 'version' => new Version('3.2', __CLASS__, __METHOD__),
                 'expected' => [
@@ -102,7 +101,7 @@ class ReturnAnnotationTest extends AnnotationTest
                 ]
             ],
             '_complete' => [
-                'content' => '{collection} \Mill\Examples\Showtimes\Representations\Movie A collection of movies.',
+                'content' => 'collection (\Mill\Examples\Showtimes\Representations\Movie) - A collection of movies.',
                 'visible' => true,
                 'version' => new Version('3.2', __CLASS__, __METHOD__),
                 'expected' => [
@@ -117,7 +116,7 @@ class ReturnAnnotationTest extends AnnotationTest
 
             // 200's
             'collection' => [
-                'content' => '{collection} \Mill\Examples\Showtimes\Representations\Movie',
+                'content' => 'collection (\Mill\Examples\Showtimes\Representations\Movie)',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -130,7 +129,7 @@ class ReturnAnnotationTest extends AnnotationTest
                 ]
             ],
             'directory' => [
-                'content' => '{directory} \Mill\Examples\Showtimes\Representations\Movie',
+                'content' => 'directory (\Mill\Examples\Showtimes\Representations\Movie)',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -143,7 +142,7 @@ class ReturnAnnotationTest extends AnnotationTest
                 ]
             ],
             'object' => [
-                'content' => '{object} \Mill\Examples\Showtimes\Representations\Movie',
+                'content' => 'object (\Mill\Examples\Showtimes\Representations\Movie)',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -156,7 +155,7 @@ class ReturnAnnotationTest extends AnnotationTest
                 ]
             ],
             'ok' => [
-                'content' => '{ok} \Mill\Examples\Showtimes\Representations\Movie',
+                'content' => 'ok (\Mill\Examples\Showtimes\Representations\Movie)',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -171,7 +170,7 @@ class ReturnAnnotationTest extends AnnotationTest
 
             // 201's
             'created' => [
-                'content' => '{created} \Mill\Examples\Showtimes\Representations\Movie',
+                'content' => 'created (\Mill\Examples\Showtimes\Representations\Movie)',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -186,7 +185,7 @@ class ReturnAnnotationTest extends AnnotationTest
 
             // 202's
             'accepted' => [
-                'content' => '{accepted} \Mill\Examples\Showtimes\Representations\Movie',
+                'content' => 'accepted (\Mill\Examples\Showtimes\Representations\Movie)',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -201,7 +200,7 @@ class ReturnAnnotationTest extends AnnotationTest
 
             // 204's
             'added' => [
-                'content' => '{added} \Mill\Examples\Showtimes\Representations\Movie',
+                'content' => 'added (\Mill\Examples\Showtimes\Representations\Movie)',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -214,7 +213,7 @@ class ReturnAnnotationTest extends AnnotationTest
                 ]
             ],
             'deleted' => [
-                'content' => '{deleted} \Mill\Examples\Showtimes\Representations\Representation',
+                'content' => 'deleted (\Mill\Examples\Showtimes\Representations\Representation)',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -227,7 +226,7 @@ class ReturnAnnotationTest extends AnnotationTest
                 ]
             ],
             'exists' => [
-                'content' => '{exists} \Mill\Examples\Showtimes\Representations\Movie',
+                'content' => 'exists (\Mill\Examples\Showtimes\Representations\Movie)',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -240,7 +239,7 @@ class ReturnAnnotationTest extends AnnotationTest
                 ]
             ],
             'updated' => [
-                'content' => '{updated} \Mill\Examples\Showtimes\Representations\Movie',
+                'content' => 'updated (\Mill\Examples\Showtimes\Representations\Movie)',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -255,7 +254,7 @@ class ReturnAnnotationTest extends AnnotationTest
 
             // 304's
             'notModified' => [
-                'content' => '{notmodified} \Mill\Examples\Showtimes\Representations\Movie If no data has changed.',
+                'content' => 'notmodified (\Mill\Examples\Showtimes\Representations\Movie) - If no data has changed.',
                 'visible' => true,
                 'version' => null,
                 'expected' => [
@@ -273,36 +272,25 @@ class ReturnAnnotationTest extends AnnotationTest
     public function providerAnnotationFailsOnInvalidContent(): array
     {
         return [
-            'code-could-not-be-found' => [
-                'annotation' => ReturnAnnotation::class,
-                'content' => '\Mill\Examples\Showtimes\Representations\Movie',
-                'expected.exception' => MissingRequiredFieldException::class,
-                'expected.exception.asserts' => [
-                    'getRequiredField' => 'http_code',
-                    'getAnnotation' => 'return',
-                    'getDocblock' => '\Mill\Examples\Showtimes\Representations\Movie',
-                    'getValues' => []
-                ]
-            ],
             'code-is-invalid' => [
                 'annotation' => ReturnAnnotation::class,
-                'content' => '{200 OK} \Mill\Examples\Showtimes\Representations\Movie',
+                'content' => '200 (\Mill\Examples\Showtimes\Representations\Movie)',
                 'expected.exception' => UnknownReturnCodeException::class,
                 'expected.exception.asserts' => [
                     'getRequiredField' => null,
                     'getAnnotation' => null,
-                    'getDocblock' => '{200 OK} \Mill\Examples\Showtimes\Representations\Movie',
+                    'getDocblock' => '200 (\Mill\Examples\Showtimes\Representations\Movie)',
                     'getValues' => []
                 ]
             ],
             'representation-is-unknown' => [
                 'annotation' => ReturnAnnotation::class,
-                'content' => '{object} \UnknownRepresentation',
+                'content' => 'object (\UnknownRepresentation)',
                 'expected.exception' => UnknownRepresentationException::class,
                 'expected.exception.asserts' => [
                     'getRequiredField' => null,
                     'getAnnotation' => null,
-                    'getDocblock' => '\UnknownRepresentation',
+                    'getDocblock' => 'object (\UnknownRepresentation)',
                     'getValues' => []
                 ]
             ]

--- a/tests/Parser/MSONTest.php
+++ b/tests/Parser/MSONTest.php
@@ -88,22 +88,6 @@ class MSONTest extends TestCase
                     ]
                 ]
             ],
-            'vendor-tag' => [
-                'content' => 'content_rating `G` (string, REQUIRED, tag:MOVIE_RATINGS) - MPAA rating',
-                'expected' => [
-                    'description' => 'MPAA rating',
-                    'field' => 'content_rating',
-                    'nullable' => false,
-                    'required' => true,
-                    'sample_data' => 'G',
-                    'subtype' => false,
-                    'type' => 'string',
-                    'values' => [],
-                    'vendor_tags' => [
-                        'tag:MOVIE_RATINGS'
-                    ]
-                ]
-            ],
             'description-long' => [
                 'content' => 'content_rating `G` (string, required) - Voluptate culpa ex, eiusmod rump sint id. Venison
                     non ribeye landjaeger laboris, enim jowl culpa meatloaf dolore mollit anim. Bacon shankle eiusmod
@@ -145,6 +129,48 @@ class MSONTest extends TestCase
                     'vendor_tags' => [
                         'tag:MOVIE_RATINGS'
                     ]
+                ]
+            ],
+            'description-only' => [
+                'content' => 'notmodified - If no data has been changed.',
+                'expected' => [
+                    'description' => 'If no data has been changed.',
+                    'field' => 'notmodified',
+                    'nullable' => false,
+                    'required' => false,
+                    'sample_data' => '', // @todo should be `false`, see `MSON::getRegex()`
+                    'subtype' => false,
+                    'type' => null,
+                    'values' => [],
+                    'vendor_tags' => []
+                ]
+            ],
+            'description-optional' => [
+                'content' => 'content_rating `G` (string, required)',
+                'expected' => [
+                    'description' => null,
+                    'field' => 'content_rating',
+                    'nullable' => false,
+                    'required' => true,
+                    'sample_data' => 'G',
+                    'subtype' => false,
+                    'type' => 'string',
+                    'values' => [],
+                    'vendor_tags' => []
+                ]
+            ],
+            'description-optional-variant' => [
+                'content' => 'collection (\Mill\Examples\Showtimes\Representations\Movie)',
+                'expected' => [
+                    'description' => null,
+                    'field' => 'collection',
+                    'nullable' => false,
+                    'required' => false,
+                    'sample_data' => '', // @todo should be `false`, see `MSON::getRegex()`
+                    'subtype' => false,
+                    'type' => '\Mill\Examples\Showtimes\Representations\Movie',
+                    'values' => [],
+                    'vendor_tags' => []
                 ]
             ],
             'description-starts-on-new-line' => [
@@ -271,6 +297,20 @@ class MSONTest extends TestCase
                     'vendor_tags' => []
                 ]
             ],
+            'field-only' => [
+                'content' => 'content.rating',
+                'expected' => [
+                    'description' => null,
+                    'field' => 'content.rating',
+                    'nullable' => false,
+                    'required' => false,
+                    'sample_data' => false,
+                    'subtype' => false,
+                    'type' => null,
+                    'values' => [],
+                    'vendor_tags' => []
+                ]
+            ],
             'type-array-with-subtype-object' => [
                 'content' => 'websites (array<object>) - The users\' list of websites.',
                 'expected' => [
@@ -311,6 +351,22 @@ class MSONTest extends TestCase
                     'type' => '\Mill\Examples\Showtimes\Representations\Person',
                     'values' => [],
                     'vendor_tags' => []
+                ]
+            ],
+            'vendor-tag' => [
+                'content' => 'content_rating `G` (string, REQUIRED, tag:MOVIE_RATINGS) - MPAA rating',
+                'expected' => [
+                    'description' => 'MPAA rating',
+                    'field' => 'content_rating',
+                    'nullable' => false,
+                    'required' => true,
+                    'sample_data' => 'G',
+                    'subtype' => false,
+                    'type' => 'string',
+                    'values' => [],
+                    'vendor_tags' => [
+                        'tag:MOVIE_RATINGS'
+                    ]
                 ]
             ],
             'without-defined-requirement-but-vendor-tags' => [

--- a/tests/Parser/Resource/Action/DocumentationTest.php
+++ b/tests/Parser/Resource/Action/DocumentationTest.php
@@ -965,7 +965,7 @@ DESCRIPTION;
                   * @api-contenttype application/json
                   * @api-scope public
                   *
-                  * @api-return:public {ok}
+                  * @api-return:public ok
                   */',
                 'asserts' => [
                     'getPaths' => [
@@ -1010,7 +1010,7 @@ DESCRIPTION;
                   * @api-contenttype application/json
                   * @api-scope public
                   *
-                  * @api-return:public {ok}
+                  * @api-return:public ok
                   */',
                 'asserts' => [
                     'getPaths' => [
@@ -1047,7 +1047,7 @@ DESCRIPTION;
                   * @api-scope delete
                   * @api-vendortag tag:DELETE_CONTENT
                   *
-                  * @api-return:private {deleted}
+                  * @api-return:private deleted
                   */',
                 'asserts' => [
                     'getVendorTags' => [
@@ -1143,7 +1143,7 @@ DESCRIPTION;
                   * @api-group Movies
                   * @api-path /
                   * @api-contenttype application/json
-                  * @api-return:public {collection} \Mill\Examples\Showtimes\Representations\Representation
+                  * @api-return:public collection (\Mill\Examples\Showtimes\Representations\Representation)
                   */',
                 'expected.exception' => MissingVisibilityDecoratorException::class,
                 'expected.exception.asserts' => [
@@ -1159,7 +1159,7 @@ DESCRIPTION;
                   * @api-group Movies
                   * @api-path:special /
                   * @api-contenttype application/json
-                  * @api-return {collection} \Mill\Examples\Showtimes\Representations\Representation
+                  * @api-return collection (\Mill\Examples\Showtimes\Representations\Representation)
                   */',
                 'expected.exception' => UnsupportedDecoratorException::class,
                 'expected.exception.asserts' => [
@@ -1192,7 +1192,7 @@ DESCRIPTION;
                   * @api-path:private /search
                   * @api-contenttype application/json
                   * @api-scope public
-                  * @api-return:private {collection} \Mill\Examples\Showtimes\Representations\Representation
+                  * @api-return:private collection (\Mill\Examples\Showtimes\Representations\Representation)
                   * @api-error:public 403 (\Mill\Examples\Showtimes\Representations\CodedError<666>) - If the user
                   *     isn\'t allowed to do something.
                   */',
@@ -1212,7 +1212,7 @@ DESCRIPTION;
                   * @api-path:private:alias /search2
                   * @api-contenttype application/json
                   * @api-scope public
-                  * @api-return:private {collection} \Mill\Examples\Showtimes\Representations\Representation
+                  * @api-return:private collection (\Mill\Examples\Showtimes\Representations\Representation)
                   * @api-error:public 403 (\Mill\Examples\Showtimes\Representations\CodedError<666>) - If the user
                   *     isn\'t allowed to do something.
                   */',

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -57,7 +57,7 @@ class ParserTest extends TestCase
           * @api-contenttype application/json
           * @api-scope public
           *
-          * @api-return:public {ok}
+          * @api-return:public ok
           */');
 
         $annotations = (new Parser(__CLASS__, $this->getApplication()))->getAnnotations(__METHOD__);


### PR DESCRIPTION
This introduces a new, refined, syntax for `@api-return` annotations to make it more MSON-like and similar to other annotations within Mill.

### Old
```
- @api-return:public {deleted}
- @api-return:public {notmodified} If no data has been changed.
- @api-return:public {collection} \Mill\Examples\Showtimes\Representations\Movie
- @api-return:public {collection} \Mill\Examples\Showtimes\Representations\Movie A collection of movies.
```

### New
```
- @api-return:public deleted
- @api-return:public notmodified - If no data has been changed.
- @api-return:public collection (\Mill\Examples\Showtimes\Representations\Movie)
- @api-return:public collection (\Mill\Examples\Showtimes\Representations\Movie) - A collection of movies.
```
