### PR TITLE
Adding support for OpenAPI API info descriptions

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -17,6 +17,8 @@
             <xs:element name="info" minOccurs="1" maxOccurs="1">
                 <xs:complexType>
                     <xs:sequence>
+                        <xs:element name="description" minOccurs="1" maxOccurs="unbounded" />
+
                         <xs:element name="terms" minOccurs="0" maxOccurs="1">
                             <xs:complexType>
                                 <xs:attribute name="url" type="xs:string" use="required" />

--- a/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/api.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: '1.0'
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Movies.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: '1.0'
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.0/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.0/openapi/tags/Theaters.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: '1.0'
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/api.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: 1.1.1
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Movies.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: 1.1.1
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.1/openapi/tags/Theaters.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: 1.1.1
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/api.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: 1.1.2
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Movies.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: 1.1.2
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.2/openapi/tags/Theaters.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: 1.1.2
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/api.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: 1.1.3
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Movies.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: 1.1.3
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1.3/openapi/tags/Theaters.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: 1.1.3
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/api.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: '1.1'
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Movies.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: '1.1'
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/1.1/openapi/tags/Theaters.yaml
+++ b/resources/examples/Showtimes/compiled/1.1/openapi/tags/Theaters.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: '1.1'
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/public/1.0/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.0/api.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: '1.0'
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/public/1.1.1/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.1.1/api.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: 1.1.1
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/public/1.1.2/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.1.2/api.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: 1.1.2
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/public/1.1.3/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.1.3/api.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: 1.1.3
   contact:
     name: 'Get help!'

--- a/resources/examples/Showtimes/compiled/public/1.1/api.yaml
+++ b/resources/examples/Showtimes/compiled/public/1.1/api.yaml
@@ -1,6 +1,7 @@
 openapi: 3.0.2
 info:
   title: 'Mill unit test API, Showtimes'
+  description: 'This is an example API for the purposes of showing how Mill works.'
   version: '1.1'
   contact:
     name: 'Get help!'

--- a/resources/examples/mill.xml
+++ b/resources/examples/mill.xml
@@ -4,6 +4,8 @@
     bootstrap="../../vendor/autoload.php"
 >
     <info>
+        <description>This is an example API for the purposes of showing how Mill works.</description>
+
         <terms url="https://example.com/terms" />
 
         <contact

--- a/src/Compiler/Specification/OpenApi.php
+++ b/src/Compiler/Specification/OpenApi.php
@@ -56,6 +56,7 @@ class OpenApi extends Compiler\Specification
                 'openapi' => '3.0.2',
                 'info' => [
                     'title' => $this->config->getName(),
+                    'description' => $this->config->getDescription(),
                     'version' => $version,
                     'contact' => $this->processContact()
                 ],

--- a/src/Config.php
+++ b/src/Config.php
@@ -29,10 +29,10 @@ class Config
     protected $base_dir;
 
     /** @var string The name of your API. */
-    protected $name = null;
+    protected $name;
 
     /** @var string The description of your API. */
-    protected $description = null;
+    protected $description;
 
     /** @var null|string The terms of service URL for your API. */
     protected $terms = null;

--- a/src/Config.php
+++ b/src/Config.php
@@ -28,8 +28,11 @@ class Config
     /** @var string The base directory for this configuration file. */
     protected $base_dir;
 
-    /** @var null|string The name of your API. */
+    /** @var string The name of your API. */
     protected $name = null;
+
+    /** @var string The description of your API. */
+    protected $description = null;
 
     /** @var null|string The terms of service URL for your API. */
     protected $terms = null;
@@ -306,6 +309,10 @@ class Config
      */
     protected function loadInfo(SimpleXMLElement $xml): void
     {
+        if (isset($xml->info->description)) {
+            $this->description = (string) $xml->info->description;
+        }
+
         if (isset($xml->info->terms)) {
             $this->terms = (string) $xml->info->terms['url'];
         }
@@ -543,11 +550,21 @@ class Config
     /**
      * Get the name of your API.
      *
-     * @return null|string
+     * @return string
      */
-    public function getName(): ?string
+    public function getName(): string
     {
         return $this->name;
+    }
+
+    /**
+     * Get the description of your API.
+     *
+     * @return string
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
     }
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -12,7 +12,11 @@ class ConfigTest extends TestCase
         $config = $this->getConfig();
 
         $this->assertSame('Mill unit test API, Showtimes', $config->getName());
-        $this->assertSame('This is an example API for the purposes of showing how Mill works.', $config->getDescription());
+        $this->assertSame(
+            'This is an example API for the purposes of showing how Mill works.',
+            $config->getDescription()
+        );
+
         $this->assertSame('https://example.com/terms', $config->getTerms());
 
         $this->assertSame([

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -12,6 +12,7 @@ class ConfigTest extends TestCase
         $config = $this->getConfig();
 
         $this->assertSame('Mill unit test API, Showtimes', $config->getName());
+        $this->assertSame('This is an example API for the purposes of showing how Mill works.', $config->getDescription());
         $this->assertSame('https://example.com/terms', $config->getTerms());
 
         $this->assertSame([
@@ -230,6 +231,8 @@ XML;
         if (strpos($provider, 'info.') === false) {
             $info = <<<XML
 <info>
+    <description>This is an example API for the purposes of showing how Mill works.</description>
+
     <terms url="https://example.com/terms" />
 
     <contact

--- a/tests/_fixtures/mill.test.xml
+++ b/tests/_fixtures/mill.test.xml
@@ -4,6 +4,8 @@
     bootstrap="vendor/autoload.php"
 >
     <info>
+        <description>This is an example API for the purposes of showing how Mill works.</description>
+
         <terms url="https://example.com/terms" />
 
         <contact


### PR DESCRIPTION
Adding a new `description` config that translates to `info.description` data within compiled OpenAPI specs.